### PR TITLE
T15: CHANGELOG and release notes process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-27
+
+### Added
+
+- Go HTTP service under `go/` with domain-scoped access control (users, groups, resources, access-type bits, permissions, authorization checks) and SQLite persistence
+- Configuration via optional `CONFIG_PATH` YAML and environment variable overrides
+- Optional static Bearer token for `/api/v1/*`; `/health` remains public
+- Dockerfile, compose file, and Make targets for local container runs
+- GitHub Actions workflow: Go test, vet, lint; Docker build and compose health smoke; container image publish to GHCR on pushes to `main`
+
+### Security
+
+- Logged startup warning when the listen address is not loopback and no API bearer token is configured
+
+[Unreleased]: https://github.com/DanyalTorabi/access-manager/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/DanyalTorabi/access-manager/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for local setup, PR expectations, **`
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contributor guide and GitHub hygiene (**T6**)  
 - [AGENTS.md](AGENTS.md) — contributor rules for humans and AI  
 - [`.github/workflows/ci.yml`](.github/workflows/ci.yml) — CI + GHCR (**T13**)  
+- [CHANGELOG.md](CHANGELOG.md) — release notes (**T15**); see below  
+
+### Changelog (**T15**)
+
+User-facing or notable changes belong under **`## [Unreleased]`** in [CHANGELOG.md](CHANGELOG.md), using [Keep a Changelog](https://keepachangelog.com/) sections (**Added**, **Changed**, **Fixed**, **Removed**, **Security**). Merge each PR that needs a note before release; when you cut a release, move the bullets into a new `## [x.y.z] - YYYY-MM-DD` section and create a matching Git tag (`v0.1.0`, etc.).
 
 ## License
 

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -43,7 +43,7 @@ Engineering practices follow the org **Backend Engineering** curriculum where th
 
 | id | title | status | notes |
 |----|-------|--------|-------|
-| T15 | CHANGELOG | open | Keep a Changelog, semver, tags/releases |
+| T15 | CHANGELOG | done | [CHANGELOG.md](CHANGELOG.md) + README process; semver tags on release (**T6**) |
 | T16 | E2E / smoke tests | open | Full API journeys; optional Newman in CI |
 | T17 | API docs & contract testing | open | OpenAPI/Swagger + Postman collection |
 | T18 | Developer AI / editor tooling | done | `.cursor/rules`, `AGENTS.md`, tech stack doc |

--- a/plan/phase-5/T15-changelog.md
+++ b/plan/phase-5/T15-changelog.md
@@ -14,8 +14,8 @@ Adopt **[Keep a Changelog](https://keepachangelog.com/)** format and a **semver*
 
 ## Deliverables
 
-- **`CHANGELOG.md`** at repo root.
-- Process note in README: when to add `## [Unreleased]` entries.
+- [x] **`CHANGELOG.md`** at repo root.
+- [x] Process note in README: when to add `## [Unreleased]` entries.
 
 ## Steps
 


### PR DESCRIPTION
## Summary

Adds root `CHANGELOG.md` (Keep a Changelog + SemVer), seeds `## [Unreleased]` and an initial `0.1.0` section summarizing the current Go service, config, optional Bearer auth, Docker, and CI. Documents in the README when contributors should append to Unreleased and how releases map to `v*` tags.

## Ticket

T15 — CHANGELOG

## Checklist

- [x] `make test` / `make lint` — not required (docs-only); optional: run from repo root
- [x] Docs updated (`README.md`, `CHANGELOG.md`, `TICKETS.md`, plan)
- [x] No secrets committed
