### PR TITLE
feat: add sort and order query params to all list endpoints (T40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **T40 / #55:** `access-types` list default sort changed from `bit` to `title` for consistency with other entities. Clients relying on bit-order should add `?sort=bit` (once added) or sort client-side.
 - **T34 / #45 (breaking):** List endpoint responses changed from bare JSON arrays to paginated `{"data": [...], "meta": {...}}` envelope. Clients must update to read `data` for items and `meta` for pagination info.
 - Migrated `cmd/server` from `log.Printf` / `log.Fatal` to structured `internal/logger` calls
 - Pinned toolchain to **go1.25.8** via `toolchain` in `go/go.mod` (language `go 1.25.0`) for stdlib security patches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **T40 / #55:** `access-types` list default sort changed from `bit` to `title` for consistency with other entities. Clients relying on bit-order should add `?sort=bit` (once added) or sort client-side.
+- **T40 / #55:** `access-types` list default sort changed from `bit` to `title` for consistency with other entities. Clients relying on bit-order should sort client-side.
 - **T34 / #45 (breaking):** List endpoint responses changed from bare JSON arrays to paginated `{"data": [...], "meta": {...}}` envelope. Clients must update to read `data` for items and `meta` for pagination info.
 - Migrated `cmd/server` from `log.Printf` / `log.Fatal` to structured `internal/logger` calls
 - Pinned toolchain to **go1.25.8** via `toolchain` in `go/go.mod` (language `go 1.25.0`) for stdlib security patches

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -120,11 +120,27 @@ components:
         enum: [contains, starts_with, ends_with]
         default: contains
       description: How to match the search term against title. Only applies when `search` is non-empty.
+    sortParam:
+      name: sort
+      in: query
+      required: false
+      schema:
+        type: string
+      description: Field to sort by (entity-specific; see endpoint description for allowed values). Defaults to `title`.
+    orderParam:
+      name: order
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [asc, desc]
+        default: asc
+      description: Sort direction.
 
   schemas:
     ListMeta:
       type: object
-      required: [total, offset, limit]
+      required: [total, offset, limit, sort, order]
       properties:
         total:
           type: integer
@@ -134,6 +150,13 @@ components:
           type: integer
         limit:
           type: integer
+        sort:
+          type: string
+          description: The sort field applied (entity-specific).
+        order:
+          type: string
+          enum: [asc, desc]
+          description: The sort direction applied.
 
     ErrorBody:
       type: object
@@ -393,11 +416,14 @@ paths:
     get:
       tags: [Domains]
       summary: List domains
+      description: "Allowed sort fields: `title` (default)."
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/searchParam"
         - $ref: "#/components/parameters/searchTypeParam"
+        - $ref: "#/components/parameters/sortParam"
+        - $ref: "#/components/parameters/orderParam"
       responses:
         "200":
           description: OK
@@ -534,11 +560,14 @@ paths:
     get:
       tags: [Users]
       summary: List users in domain
+      description: "Allowed sort fields: `title` (default)."
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/searchParam"
         - $ref: "#/components/parameters/searchTypeParam"
+        - $ref: "#/components/parameters/sortParam"
+        - $ref: "#/components/parameters/orderParam"
       responses:
         "200":
           description: OK
@@ -675,11 +704,14 @@ paths:
     get:
       tags: [Groups]
       summary: List groups
+      description: "Allowed sort fields: `title` (default)."
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/searchParam"
         - $ref: "#/components/parameters/searchTypeParam"
+        - $ref: "#/components/parameters/sortParam"
+        - $ref: "#/components/parameters/orderParam"
         - name: parent_group_id
           in: query
           required: false
@@ -852,11 +884,14 @@ paths:
     get:
       tags: [Resources]
       summary: List resources
+      description: "Allowed sort fields: `title` (default)."
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/searchParam"
         - $ref: "#/components/parameters/searchTypeParam"
+        - $ref: "#/components/parameters/sortParam"
+        - $ref: "#/components/parameters/orderParam"
       responses:
         "200":
           description: OK
@@ -993,11 +1028,14 @@ paths:
     get:
       tags: [AccessTypes]
       summary: List access types
+      description: "Allowed sort fields: `title` (default)."
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/searchParam"
         - $ref: "#/components/parameters/searchTypeParam"
+        - $ref: "#/components/parameters/sortParam"
+        - $ref: "#/components/parameters/orderParam"
       responses:
         "200":
           description: OK
@@ -1133,11 +1171,14 @@ paths:
     get:
       tags: [Permissions]
       summary: List permissions
+      description: "Allowed sort fields: `title` (default), `resource_id`."
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"
         - $ref: "#/components/parameters/searchParam"
         - $ref: "#/components/parameters/searchTypeParam"
+        - $ref: "#/components/parameters/sortParam"
+        - $ref: "#/components/parameters/orderParam"
         - name: resource_id
           in: query
           required: false

--- a/api/postman/access-manager.postman_collection.json
+++ b/api/postman/access-manager.postman_collection.json
@@ -34,7 +34,7 @@
       },
       "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["var json = pm.response.json();", "if (json.ID) pm.collectionVariables.set('domainId', json.ID);"]}}]
     },
-    {"name": "List domains", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}]}}},
+    {"name": "List domains", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "sort", "value": "title", "description": "Sort field: title (default)", "disabled": true}, {"key": "order", "value": "asc", "description": "asc (default) | desc", "disabled": true}]}}},
     {"name": "Get domain", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}"}},
     {
       "name": "Patch domain",
@@ -55,7 +55,7 @@
       },
       "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["var json = pm.response.json();", "if (json.ID) pm.collectionVariables.set('userId', json.ID);"]}}]
     },
-    {"name": "List users", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/users?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}]}}},
+    {"name": "List users", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/users?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "sort", "value": "title", "description": "Sort field: title (default)", "disabled": true}, {"key": "order", "value": "asc", "description": "asc (default) | desc", "disabled": true}]}}},
     {"name": "Get user", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}"}},
     {
       "name": "Patch user",
@@ -76,7 +76,7 @@
       },
       "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["var json = pm.response.json();", "if (json.ID) pm.collectionVariables.set('groupId', json.ID);"]}}]
     },
-    {"name": "List groups", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups?offset=0&limit=20&search=&parent_group_id=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "parent_group_id", "value": "", "description": "Filter by parent group UUID"}]}}},
+    {"name": "List groups", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups?offset=0&limit=20&search=&parent_group_id=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "sort", "value": "title", "description": "Sort field: title (default)", "disabled": true}, {"key": "order", "value": "asc", "description": "asc (default) | desc", "disabled": true}, {"key": "parent_group_id", "value": "", "description": "Filter by parent group UUID"}]}}},
     {"name": "Get group", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups/{{groupId}}"}},
     {
       "name": "Patch group",
@@ -106,7 +106,7 @@
       },
       "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["var json = pm.response.json();", "if (json.ID) pm.collectionVariables.set('resourceId', json.ID);"]}}]
     },
-    {"name": "List resources", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/resources?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}]}}},
+    {"name": "List resources", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/resources?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "sort", "value": "title", "description": "Sort field: title (default)", "disabled": true}, {"key": "order", "value": "asc", "description": "asc (default) | desc", "disabled": true}]}}},
     {"name": "Get resource", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/resources/{{resourceId}}"}},
     {
       "name": "Patch resource",
@@ -127,7 +127,7 @@
       },
       "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["var json = pm.response.json();", "if (json.ID) pm.collectionVariables.set('accessTypeId', json.ID);"]}}]
     },
-    {"name": "List access types", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/access-types?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}]}}},
+    {"name": "List access types", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/access-types?offset=0&limit=20&search=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "sort", "value": "title", "description": "Sort field: title (default)", "disabled": true}, {"key": "order", "value": "asc", "description": "asc (default) | desc", "disabled": true}]}}},
     {"name": "Get access type", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/access-types/{{accessTypeId}}"}},
     {
       "name": "Patch access type",
@@ -148,7 +148,7 @@
       },
       "event": [{"listen": "test", "script": {"type": "text/javascript", "exec": ["var json = pm.response.json();", "if (json.ID) pm.collectionVariables.set('permissionId', json.ID);"]}}]
     },
-    {"name": "List permissions", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/permissions?offset=0&limit=20&search=&resource_id=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "resource_id", "value": "", "description": "Filter by resource UUID"}]}}},
+    {"name": "List permissions", "request": {"method": "GET", "url": {"raw": "{{baseUrl}}/api/v1/domains/{{domainId}}/permissions?offset=0&limit=20&search=&resource_id=", "query": [{"key": "offset", "value": "0"}, {"key": "limit", "value": "20"}, {"key": "search", "value": "", "description": "Case-insensitive title match"}, {"key": "search_type", "value": "contains", "description": "contains | starts_with | ends_with (only with search)", "disabled": true}, {"key": "sort", "value": "title", "description": "Sort field: title (default), resource_id", "disabled": true}, {"key": "order", "value": "asc", "description": "asc (default) | desc", "disabled": true}, {"key": "resource_id", "value": "", "description": "Filter by resource UUID"}]}}},
     {"name": "Get permission", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/permissions/{{permissionId}}"}},
     {
       "name": "Patch permission",

--- a/go/README.md
+++ b/go/README.md
@@ -89,6 +89,28 @@ REST routes live under **`/api/v1`** with domain-scoped segments, for example:
 - Domain-scoped CRUD includes `PATCH` / `DELETE` for users, groups, resources, permissions, and access types (plus `GET` for a single access type). Deletes fail with **400** when SQLite foreign keys block removal.
 - `GET /api/v1/domains/{domainID}/authz/check?user_id=&resource_id=&access_bit=`
 
+### Pagination, filtering, and sorting
+
+All list endpoints support `offset`, `limit`, `search`, and `search_type` query parameters for pagination and title filtering. They also support **`sort`** and **`order`** for client-controlled ordering:
+
+| Param | Default | Description |
+|-------|---------|-------------|
+| `sort` | `title` | Field to sort by. Allowed values are entity-specific (see below). |
+| `order` | `asc` | `asc` or `desc`. |
+
+**Allowed sort fields per entity:**
+
+| Endpoint | Sortable fields |
+|----------|----------------|
+| /domains | `title` |
+| /users | `title` |
+| /groups | `title` |
+| /resources | `title` |
+| /access-types | `title` |
+| /permissions | `title`, `resource_id` |
+
+Invalid `sort` or `order` values return **400**. The applied sort and order are echoed in the response `meta` alongside `total`, `offset`, and `limit`.
+
 ### Authentication
 
 When **`API_BEARER_TOKEN`** (or YAML **`api_bearer_token`**) is non-empty, clients must send:

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -181,7 +182,7 @@ func (s *Server) domainList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	opts.Sort, opts.Order, err = parseSortOrder(r, store.DomainSortFields)
+	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.DomainSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -257,7 +258,7 @@ func (s *Server) userList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	opts.Sort, opts.Order, err = parseSortOrder(r, store.UserSortFields)
+	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.UserSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -342,7 +343,7 @@ func (s *Server) groupList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	opts.Sort, opts.Order, err = parseSortOrder(r, store.GroupSortFields)
+	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.GroupSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -462,7 +463,7 @@ func (s *Server) resourceList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	opts.Sort, opts.Order, err = parseSortOrder(r, store.ResourceSortFields)
+	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.ResourceSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -551,7 +552,7 @@ func (s *Server) accessTypeList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	opts.Sort, opts.Order, err = parseSortOrder(r, store.AccessTypeSortFields)
+	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.AccessTypeSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -657,7 +658,7 @@ func (s *Server) permissionList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
-	opts.Sort, opts.Order, err = parseSortOrder(r, store.PermissionSortFields)
+	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.PermissionSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -1019,8 +1020,7 @@ func parsePermissionListOpts(r *http.Request) (store.PermissionListOpts, error) 
 
 // parseSortOrder reads sort and order query params, validates them against
 // the allowed sort fields, and returns the validated values.
-func parseSortOrder(r *http.Request, allowed []string) (string, store.SortOrder, error) {
-	q := r.URL.Query()
+func parseSortOrder(q url.Values, allowed []string) (string, store.SortOrder, error) {
 	sortField, err := store.ValidateSort(strings.TrimSpace(q.Get("sort")), allowed)
 	if err != nil {
 		return "", "", err

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -1021,7 +1021,7 @@ func parsePermissionListOpts(r *http.Request) (store.PermissionListOpts, error) 
 // the allowed sort fields, and returns the validated values.
 func parseSortOrder(r *http.Request, allowed []string) (string, store.SortOrder, error) {
 	q := r.URL.Query()
-	sort, err := store.ValidateSort(strings.TrimSpace(q.Get("sort")), allowed)
+	sortField, err := store.ValidateSort(strings.TrimSpace(q.Get("sort")), allowed)
 	if err != nil {
 		return "", "", err
 	}
@@ -1035,7 +1035,7 @@ func parseSortOrder(r *http.Request, allowed []string) (string, store.SortOrder,
 			return "", "", errors.New("order must be asc or desc")
 		}
 	}
-	return sort, order, nil
+	return sortField, order, nil
 }
 
 func writeList(w http.ResponseWriter, data any, total int64, opts store.ListOpts) {

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -181,6 +181,11 @@ func (s *Server) domainList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
+	opts.Sort, opts.Order, err = parseSortOrder(r, store.DomainSortFields)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
 	list, total, err := s.Store.DomainList(r.Context(), opts)
 	if err != nil {
 		writeInternalErr(w, r, err)
@@ -248,6 +253,11 @@ func (s *Server) userCreate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) userList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	opts.Sort, opts.Order, err = parseSortOrder(r, store.UserSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -328,6 +338,11 @@ func (s *Server) groupCreate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) groupList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseGroupListOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	opts.Sort, opts.Order, err = parseSortOrder(r, store.GroupSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -447,6 +462,11 @@ func (s *Server) resourceList(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
+	opts.Sort, opts.Order, err = parseSortOrder(r, store.ResourceSortFields)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
 	domainID := chi.URLParam(r, "domainID")
 	list, total, err := s.Store.ResourceList(r.Context(), domainID, opts)
 	if err != nil {
@@ -527,6 +547,11 @@ func (s *Server) accessTypeCreate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) accessTypeList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	opts.Sort, opts.Order, err = parseSortOrder(r, store.AccessTypeSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -628,6 +653,11 @@ func (s *Server) permissionCreate(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) permissionList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parsePermissionListOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	opts.Sort, opts.Order, err = parseSortOrder(r, store.PermissionSortFields)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -906,9 +936,11 @@ func publicInvalidInputMsg(err error) string {
 const maxRequestBodySize = 1 << 20 // 1 MiB
 
 type listMeta struct {
-	Total  int64 `json:"total"`
-	Offset int   `json:"offset"`
-	Limit  int   `json:"limit"`
+	Total  int64  `json:"total"`
+	Offset int    `json:"offset"`
+	Limit  int    `json:"limit"`
+	Sort   string `json:"sort"`
+	Order  string `json:"order"`
 }
 
 type listEnvelope struct {
@@ -985,10 +1017,37 @@ func parsePermissionListOpts(r *http.Request) (store.PermissionListOpts, error) 
 	return out, nil
 }
 
+// parseSortOrder reads sort and order query params, validates them against
+// the allowed sort fields, and returns the validated values.
+func parseSortOrder(r *http.Request, allowed []string) (string, store.SortOrder, error) {
+	q := r.URL.Query()
+	sort, err := store.ValidateSort(strings.TrimSpace(q.Get("sort")), allowed)
+	if err != nil {
+		return "", "", err
+	}
+	order := store.OrderAsc
+	if v := strings.TrimSpace(q.Get("order")); v != "" {
+		o := store.SortOrder(v)
+		switch o {
+		case store.OrderAsc, store.OrderDesc:
+			order = o
+		default:
+			return "", "", errors.New("order must be asc or desc")
+		}
+	}
+	return sort, order, nil
+}
+
 func writeList(w http.ResponseWriter, data any, total int64, opts store.ListOpts) {
 	writeJSON(w, http.StatusOK, listEnvelope{
 		Data: data,
-		Meta: listMeta{Total: total, Offset: opts.Offset, Limit: opts.Limit},
+		Meta: listMeta{
+			Total:  total,
+			Offset: opts.Offset,
+			Limit:  opts.Limit,
+			Sort:   opts.Sort,
+			Order:  string(opts.Order),
+		},
 	})
 }
 

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -3518,3 +3518,107 @@ func TestAPI_accessTypeList_sortDesc(t *testing.T) {
 		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
 	}
 }
+
+func TestAPI_userList_invalidSort(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/users?sort=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_userList_invalidOrder(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/users?order=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_groupList_invalidSort(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/groups?sort=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_groupList_invalidOrder(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/groups?order=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_resourceList_invalidSort(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/resources?sort=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_resourceList_invalidOrder(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/resources?order=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_accessTypeList_invalidSort(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/access-types?sort=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_accessTypeList_invalidOrder(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/access-types?order=bad")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -1687,9 +1687,11 @@ func TestAPI_accessTypeList_empty(t *testing.T) {
 type listResponse[T any] struct {
 	Data []T `json:"data"`
 	Meta struct {
-		Total  int64 `json:"total"`
-		Offset int   `json:"offset"`
-		Limit  int   `json:"limit"`
+		Total  int64  `json:"total"`
+		Offset int    `json:"offset"`
+		Limit  int    `json:"limit"`
+		Sort   string `json:"sort"`
+		Order  string `json:"order"`
 	} `json:"meta"`
 }
 
@@ -1697,6 +1699,16 @@ type listResponse[T any] struct {
 func mustCreateDomain(t *testing.T, ts *httptest.Server) string {
 	t.Helper()
 	b := mustPostJSON201(t, ts.URL+"/api/v1/domains", `{"title":"test-domain"}`)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func mustCreateResource(t *testing.T, ts *httptest.Server, domainID, title string) string {
+	t.Helper()
+	b := mustPostJSON201(t, ts.URL+"/api/v1/domains/"+domainID+"/resources", fmt.Sprintf(`{"title":%q}`, title))
 	var out struct{ ID string }
 	if err := json.Unmarshal(b, &out); err != nil {
 		t.Fatal(err)
@@ -3165,5 +3177,178 @@ func TestAPI_domainList_searchType(t *testing.T) {
 	defer func() { _ = res3.Body.Close() }()
 	if res3.StatusCode != http.StatusBadRequest {
 		t.Fatalf("invalid search_type: want 400, got %d", res3.StatusCode)
+	}
+}
+
+func TestAPI_parseSortOrder(t *testing.T) {
+	tests := []struct {
+		name      string
+		qs        string
+		allowed   []string
+		wantSort  string
+		wantOrder store.SortOrder
+		wantErr   bool
+	}{
+		{"defaults", "", store.DomainSortFields, "title", store.OrderAsc, false},
+		{"explicit asc", "sort=title&order=asc", store.DomainSortFields, "title", store.OrderAsc, false},
+		{"explicit desc", "sort=title&order=desc", store.DomainSortFields, "title", store.OrderDesc, false},
+		{"order only", "order=desc", store.DomainSortFields, "title", store.OrderDesc, false},
+		{"sort only", "sort=title", store.DomainSortFields, "title", store.OrderAsc, false},
+		{"permission resource_id", "sort=resource_id", store.PermissionSortFields, "resource_id", store.OrderAsc, false},
+		{"invalid sort", "sort=unknown", store.DomainSortFields, "", "", true},
+		{"invalid order", "order=random", store.DomainSortFields, "", "", true},
+		{"sort trimmed", "sort=%20title%20", store.DomainSortFields, "title", store.OrderAsc, false},
+		{"order trimmed", "order=%20desc%20", store.DomainSortFields, "title", store.OrderDesc, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/test?"+tt.qs, nil)
+			sort, order, err := parseSortOrder(req, tt.allowed)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if sort != tt.wantSort {
+				t.Fatalf("sort=%q, want %q", sort, tt.wantSort)
+			}
+			if order != tt.wantOrder {
+				t.Fatalf("order=%q, want %q", order, tt.wantOrder)
+			}
+		})
+	}
+}
+
+func TestAPI_domainList_sortMeta(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	mustPostJSON201(t, ts.URL+"/api/v1/domains", `{"title":"one"}`)
+
+	res, err := http.Get(ts.URL + "/api/v1/domains")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", res.StatusCode)
+	}
+	var env listResponse[store.Domain]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Meta.Sort != "title" {
+		t.Fatalf("meta.sort: want title, got %q", env.Meta.Sort)
+	}
+	if env.Meta.Order != "asc" {
+		t.Fatalf("meta.order: want asc, got %q", env.Meta.Order)
+	}
+}
+
+func TestAPI_domainList_sortDesc(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	for _, title := range []string{"Alpha", "Beta", "Charlie"} {
+		mustPostJSON201(t, ts.URL+"/api/v1/domains", fmt.Sprintf(`{"title":%q}`, title))
+	}
+
+	res, err := http.Get(ts.URL + "/api/v1/domains?sort=title&order=desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.Domain]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("want 3 items, got %d", len(env.Data))
+	}
+	if env.Data[0].Title != "Charlie" || env.Data[2].Title != "Alpha" {
+		t.Fatalf("order: got %q, %q, %q", env.Data[0].Title, env.Data[1].Title, env.Data[2].Title)
+	}
+	if env.Meta.Sort != "title" || env.Meta.Order != "desc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}
+
+func TestAPI_domainList_invalidSort(t *testing.T) {
+	ts, _ := newTestAPI(t)
+
+	res, err := http.Get(ts.URL + "/api/v1/domains?sort=unknown_field")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_domainList_invalidOrder(t *testing.T) {
+	ts, _ := newTestAPI(t)
+
+	res, err := http.Get(ts.URL + "/api/v1/domains?order=random")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
+	}
+}
+
+func TestAPI_permissionList_sortByResourceID(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+
+	resA := mustCreateResource(t, ts, domainID, "Resource A")
+	resB := mustCreateResource(t, ts, domainID, "Resource B")
+
+	mustPostJSON201(t, ts.URL+"/api/v1/domains/"+domainID+"/permissions",
+		fmt.Sprintf(`{"title":"perm-b","resource_id":%q,"access_mask":"1"}`, resB))
+	mustPostJSON201(t, ts.URL+"/api/v1/domains/"+domainID+"/permissions",
+		fmt.Sprintf(`{"title":"perm-a","resource_id":%q,"access_mask":"2"}`, resA))
+
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/permissions?sort=resource_id&order=asc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.Permission]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 2 {
+		t.Fatalf("want 2, got %d", len(env.Data))
+	}
+	if env.Data[0].ResourceID > env.Data[1].ResourceID {
+		t.Fatalf("expected ascending resource_id order: %s > %s", env.Data[0].ResourceID, env.Data[1].ResourceID)
+	}
+	if env.Meta.Sort != "resource_id" || env.Meta.Order != "asc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}
+
+func TestAPI_permissionList_invalidSort(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/permissions?sort=access_mask")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", res.StatusCode)
 	}
 }

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -3352,3 +3352,37 @@ func TestAPI_permissionList_invalidSort(t *testing.T) {
 		t.Fatalf("want 400, got %d", res.StatusCode)
 	}
 }
+
+func TestAPI_accessTypeList_defaultSortByTitle(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	base := ts.URL + "/api/v1/domains/" + domainID
+
+	mustPostJSON201(t, base+"/access-types", `{"title":"Zebra","bit":"0x1"}`)
+	mustPostJSON201(t, base+"/access-types", `{"title":"Alpha","bit":"0x2"}`)
+	mustPostJSON201(t, base+"/access-types", `{"title":"Middle","bit":"0x4"}`)
+
+	res, err := http.Get(base + "/access-types")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.AccessType]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("want 3 items, got %d", len(env.Data))
+	}
+	if env.Data[0].Title != "Alpha" || env.Data[1].Title != "Middle" || env.Data[2].Title != "Zebra" {
+		t.Fatalf("expected title-asc order, got %q %q %q",
+			env.Data[0].Title, env.Data[1].Title, env.Data[2].Title)
+	}
+	if env.Meta.Sort != "title" || env.Meta.Order != "asc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -3203,7 +3203,7 @@ func TestAPI_parseSortOrder(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req := httptest.NewRequest(http.MethodGet, "/test?"+tt.qs, nil)
-			sort, order, err := parseSortOrder(req, tt.allowed)
+			sort, order, err := parseSortOrder(req.URL.Query(), tt.allowed)
 			if tt.wantErr {
 				if err == nil {
 					t.Fatal("want error")

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -3386,3 +3386,135 @@ func TestAPI_accessTypeList_defaultSortByTitle(t *testing.T) {
 		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
 	}
 }
+
+func TestAPI_userList_sortDesc(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	base := ts.URL + "/api/v1/domains/" + domainID
+
+	for _, title := range []string{"Alice", "Bob", "Charlie"} {
+		mustPostJSON201(t, base+"/users", fmt.Sprintf(`{"title":%q}`, title))
+	}
+
+	res, err := http.Get(base + "/users?sort=title&order=desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.User]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("want 3, got %d", len(env.Data))
+	}
+	if env.Data[0].Title != "Charlie" || env.Data[2].Title != "Alice" {
+		t.Fatalf("order: got %q %q %q", env.Data[0].Title, env.Data[1].Title, env.Data[2].Title)
+	}
+	if env.Meta.Sort != "title" || env.Meta.Order != "desc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}
+
+func TestAPI_groupList_sortDesc(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	base := ts.URL + "/api/v1/domains/" + domainID
+
+	for _, title := range []string{"Admins", "Editors", "Viewers"} {
+		mustPostJSON201(t, base+"/groups", fmt.Sprintf(`{"title":%q}`, title))
+	}
+
+	res, err := http.Get(base + "/groups?sort=title&order=desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.Group]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("want 3, got %d", len(env.Data))
+	}
+	if env.Data[0].Title != "Viewers" || env.Data[2].Title != "Admins" {
+		t.Fatalf("order: got %q %q %q", env.Data[0].Title, env.Data[1].Title, env.Data[2].Title)
+	}
+	if env.Meta.Sort != "title" || env.Meta.Order != "desc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}
+
+func TestAPI_resourceList_sortDesc(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	base := ts.URL + "/api/v1/domains/" + domainID
+
+	for _, title := range []string{"Docs", "Files", "Settings"} {
+		mustPostJSON201(t, base+"/resources", fmt.Sprintf(`{"title":%q}`, title))
+	}
+
+	res, err := http.Get(base + "/resources?sort=title&order=desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.Resource]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("want 3, got %d", len(env.Data))
+	}
+	if env.Data[0].Title != "Settings" || env.Data[2].Title != "Docs" {
+		t.Fatalf("order: got %q %q %q", env.Data[0].Title, env.Data[1].Title, env.Data[2].Title)
+	}
+	if env.Meta.Sort != "title" || env.Meta.Order != "desc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}
+
+func TestAPI_accessTypeList_sortDesc(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domainID := mustCreateDomain(t, ts)
+	base := ts.URL + "/api/v1/domains/" + domainID
+
+	mustPostJSON201(t, base+"/access-types", `{"title":"Alpha","bit":"0x1"}`)
+	mustPostJSON201(t, base+"/access-types", `{"title":"Beta","bit":"0x2"}`)
+	mustPostJSON201(t, base+"/access-types", `{"title":"Gamma","bit":"0x4"}`)
+
+	res, err := http.Get(base + "/access-types?sort=title&order=desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[store.AccessType]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("want 3, got %d", len(env.Data))
+	}
+	if env.Data[0].Title != "Gamma" || env.Data[2].Title != "Alpha" {
+		t.Fatalf("order: got %q %q %q", env.Data[0].Title, env.Data[1].Title, env.Data[2].Title)
+	}
+	if env.Meta.Sort != "title" || env.Meta.Order != "desc" {
+		t.Fatalf("meta: sort=%q order=%q", env.Meta.Sort, env.Meta.Order)
+	}
+}

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -60,13 +60,26 @@ var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 
 func escapeLikePattern(s string) string { return likeEscaper.Replace(s) }
 
+// sortColumns builds a field→column map from the store's allowed sort fields.
+// By default field name == column name; pass overrides for any that differ.
+func sortColumns(fields []string, overrides map[string]string) map[string]string {
+	cols := make(map[string]string, len(fields))
+	for _, f := range fields {
+		cols[f] = f
+	}
+	for f, col := range overrides {
+		cols[f] = col
+	}
+	return cols
+}
+
 var (
-	domainSortColumns     = map[string]string{"title": "title"}
-	userSortColumns       = map[string]string{"title": "title"}
-	groupSortColumns      = map[string]string{"title": "title"}
-	resourceSortColumns   = map[string]string{"title": "title"}
-	accessTypeSortColumns = map[string]string{"title": "title"}
-	permissionSortColumns = map[string]string{"title": "title", "resource_id": "resource_id"}
+	domainSortColumns     = sortColumns(store.DomainSortFields, nil)
+	userSortColumns       = sortColumns(store.UserSortFields, nil)
+	groupSortColumns      = sortColumns(store.GroupSortFields, nil)
+	resourceSortColumns   = sortColumns(store.ResourceSortFields, nil)
+	accessTypeSortColumns = sortColumns(store.AccessTypeSortFields, nil)
+	permissionSortColumns = sortColumns(store.PermissionSortFields, nil)
 )
 
 // orderByClause returns a safe " ORDER BY <col> <dir>" clause.

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -85,11 +85,13 @@ var (
 	permissionSortColumns = sortColumns(store.PermissionSortFields, nil)
 )
 
-// orderByClause returns a safe " ORDER BY <col> <dir>" clause.
+// orderByClause returns a safe " ORDER BY <col> <dir>, id <dir>" clause.
 // sort should already be validated against the allow-list by the caller.
 // An empty sort falls back to fallbackCol. An unknown non-empty sort also
 // falls back to fallbackCol for compatibility, but emits a warning so
 // call-site bugs are not silently masked.
+// A secondary ", id" tiebreaker is always appended to guarantee
+// deterministic pagination when the primary column has duplicates.
 func orderByClause(sort string, order store.SortOrder, allowed map[string]string, fallbackCol string) string {
 	col := fallbackCol
 	if sort != "" {
@@ -103,7 +105,11 @@ func orderByClause(sort string, order store.SortOrder, allowed map[string]string
 	if order == store.OrderDesc {
 		dir = "DESC"
 	}
-	return " ORDER BY " + col + " " + dir
+	clause := " ORDER BY " + col + " " + dir
+	if col != "id" {
+		clause += ", id " + dir
+	}
+	return clause
 }
 
 func likePattern(search string, st store.SearchType) string {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -61,14 +61,17 @@ var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 func escapeLikePattern(s string) string { return likeEscaper.Replace(s) }
 
 // sortColumns builds a field→column map from the store's allowed sort fields.
-// By default field name == column name; pass overrides for any that differ.
+// By default field name == column name; pass overrides for any allowed fields
+// whose column names differ. Override keys not present in fields are ignored.
 func sortColumns(fields []string, overrides map[string]string) map[string]string {
 	cols := make(map[string]string, len(fields))
 	for _, f := range fields {
 		cols[f] = f
 	}
 	for f, col := range overrides {
-		cols[f] = col
+		if _, ok := cols[f]; ok {
+			cols[f] = col
+		}
 	}
 	return cols
 }

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -60,6 +60,31 @@ var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 
 func escapeLikePattern(s string) string { return likeEscaper.Replace(s) }
 
+var (
+	domainSortColumns     = map[string]string{"title": "title"}
+	userSortColumns       = map[string]string{"title": "title"}
+	groupSortColumns      = map[string]string{"title": "title"}
+	resourceSortColumns   = map[string]string{"title": "title"}
+	accessTypeSortColumns = map[string]string{"title": "title"}
+	permissionSortColumns = map[string]string{"title": "title", "resource_id": "resource_id"}
+)
+
+// orderByClause returns a safe " ORDER BY <col> <dir>" clause.
+// sort must already be validated against the allow-list. If the field is
+// missing from allowed (defensive, or empty from direct store calls),
+// it falls back to fallbackCol.
+func orderByClause(sort string, order store.SortOrder, allowed map[string]string, fallbackCol string) string {
+	col, ok := allowed[sort]
+	if !ok {
+		col = fallbackCol
+	}
+	dir := "ASC"
+	if order == store.OrderDesc {
+		dir = "DESC"
+	}
+	return " ORDER BY " + col + " " + dir
+}
+
 func likePattern(search string, st store.SearchType) string {
 	escaped := escapeLikePattern(search)
 	switch st {
@@ -108,7 +133,7 @@ func (s *Store) DomainList(ctx context.Context, opts store.ListOpts) ([]store.Do
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, title FROM domains`+where+` ORDER BY title LIMIT ? OFFSET ?`,
+		`SELECT id, title FROM domains`+where+orderByClause(opts.Sort, opts.Order, domainSortColumns, "title")+` LIMIT ? OFFSET ?`,
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -186,7 +211,7 @@ func (s *Store) UserList(ctx context.Context, domainID string, opts store.ListOp
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title FROM users `+where+` ORDER BY title LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title FROM users `+where+orderByClause(opts.Sort, opts.Order, userSortColumns, "title")+` LIMIT ? OFFSET ?`,
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -278,7 +303,7 @@ func (s *Store) GroupList(ctx context.Context, domainID string, opts store.Group
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, parent_group_id FROM groups `+where+` ORDER BY title LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title, parent_group_id FROM groups `+where+orderByClause(opts.Sort, opts.Order, groupSortColumns, "title")+` LIMIT ? OFFSET ?`,
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -442,7 +467,7 @@ func (s *Store) ResourceList(ctx context.Context, domainID string, opts store.Li
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title FROM resources `+where+` ORDER BY title LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title FROM resources `+where+orderByClause(opts.Sort, opts.Order, resourceSortColumns, "title")+` LIMIT ? OFFSET ?`,
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -508,7 +533,7 @@ func (s *Store) AccessTypeList(ctx context.Context, domainID string, opts store.
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, bit FROM access_types `+where+` ORDER BY bit LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title, bit FROM access_types `+where+orderByClause(opts.Sort, opts.Order, accessTypeSortColumns, "title")+` LIMIT ? OFFSET ?`,
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -631,7 +656,7 @@ func (s *Store) PermissionList(ctx context.Context, domainID string, opts store.
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, resource_id, access_mask FROM permissions `+where+` ORDER BY title LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title, resource_id, access_mask FROM permissions `+where+orderByClause(opts.Sort, opts.Order, permissionSortColumns, "title")+` LIMIT ? OFFSET ?`,
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -86,13 +86,18 @@ var (
 )
 
 // orderByClause returns a safe " ORDER BY <col> <dir>" clause.
-// sort must already be validated against the allow-list. If the field is
-// missing from allowed (defensive, or empty from direct store calls),
-// it falls back to fallbackCol.
+// sort should already be validated against the allow-list by the caller.
+// An empty sort falls back to fallbackCol. An unknown non-empty sort also
+// falls back to fallbackCol for compatibility, but emits a warning so
+// call-site bugs are not silently masked.
 func orderByClause(sort string, order store.SortOrder, allowed map[string]string, fallbackCol string) string {
-	col, ok := allowed[sort]
-	if !ok {
-		col = fallbackCol
+	col := fallbackCol
+	if sort != "" {
+		if mapped, ok := allowed[sort]; ok {
+			col = mapped
+		} else {
+			slog.Warn("unknown sort field, falling back to default", "sort", sort, "fallback", fallbackCol)
+		}
 	}
 	dir := "ASC"
 	if order == store.OrderDesc {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -133,7 +133,7 @@ func (s *Store) DomainList(ctx context.Context, opts store.ListOpts) ([]store.Do
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, title FROM domains`+where+orderByClause(opts.Sort, opts.Order, domainSortColumns, "title")+` LIMIT ? OFFSET ?`,
+		`SELECT id, title FROM domains`+where+orderByClause(opts.Sort, opts.Order, domainSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -211,7 +211,7 @@ func (s *Store) UserList(ctx context.Context, domainID string, opts store.ListOp
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title FROM users `+where+orderByClause(opts.Sort, opts.Order, userSortColumns, "title")+` LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title FROM users `+where+orderByClause(opts.Sort, opts.Order, userSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -303,7 +303,7 @@ func (s *Store) GroupList(ctx context.Context, domainID string, opts store.Group
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, parent_group_id FROM groups `+where+orderByClause(opts.Sort, opts.Order, groupSortColumns, "title")+` LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title, parent_group_id FROM groups `+where+orderByClause(opts.Sort, opts.Order, groupSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -467,7 +467,7 @@ func (s *Store) ResourceList(ctx context.Context, domainID string, opts store.Li
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title FROM resources `+where+orderByClause(opts.Sort, opts.Order, resourceSortColumns, "title")+` LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title FROM resources `+where+orderByClause(opts.Sort, opts.Order, resourceSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -533,7 +533,7 @@ func (s *Store) AccessTypeList(ctx context.Context, domainID string, opts store.
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, bit FROM access_types `+where+orderByClause(opts.Sort, opts.Order, accessTypeSortColumns, "title")+` LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title, bit FROM access_types `+where+orderByClause(opts.Sort, opts.Order, accessTypeSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -656,7 +656,7 @@ func (s *Store) PermissionList(ctx context.Context, domainID string, opts store.
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, resource_id, access_mask FROM permissions `+where+orderByClause(opts.Sort, opts.Order, permissionSortColumns, "title")+` LIMIT ? OFFSET ?`,
+		`SELECT id, domain_id, title, resource_id, access_mask FROM permissions `+where+orderByClause(opts.Sort, opts.Order, permissionSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -2865,3 +2865,92 @@ func TestOrderByClause(t *testing.T) {
 		}
 	})
 }
+
+func TestList_queryContextError(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	db, err := Open("file:" + filepath.Join(dir, "qctx.db") + "?_pragma=foreign_keys(1)")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := MigrateUp(db, testutil.SQLiteMigrationsDir(t)); err != nil {
+		_ = db.Close()
+		t.Fatal(err)
+	}
+	s := New(db)
+
+	domID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := store.ListOpts{Limit: 10, Sort: "title", Order: store.OrderAsc}
+
+	dropAndReplace := func(table, viewSQL string) {
+		t.Helper()
+		if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+			t.Fatalf("disable FK: %v", err)
+		}
+		if _, err := db.ExecContext(ctx, "DROP TABLE IF EXISTS "+table); err != nil {
+			t.Fatalf("drop %s: %v", table, err)
+		}
+		if _, err := db.ExecContext(ctx, viewSQL); err != nil {
+			t.Fatalf("create view %s: %v", table, err)
+		}
+		if _, err := db.ExecContext(ctx, "PRAGMA foreign_keys = ON"); err != nil {
+			t.Fatalf("enable FK: %v", err)
+		}
+	}
+
+	t.Run("UserList", func(t *testing.T) {
+		dropAndReplace("users", "CREATE VIEW users AS SELECT 'x' AS domain_id")
+		_, _, err := s.UserList(ctx, domID, opts)
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+
+	t.Run("GroupList", func(t *testing.T) {
+		dropAndReplace("groups", "CREATE VIEW groups AS SELECT 'x' AS domain_id")
+		_, _, err := s.GroupList(ctx, domID, store.GroupListOpts{ListOpts: opts})
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+
+	t.Run("ResourceList", func(t *testing.T) {
+		dropAndReplace("resources", "CREATE VIEW resources AS SELECT 'x' AS domain_id")
+		_, _, err := s.ResourceList(ctx, domID, opts)
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+
+	t.Run("AccessTypeList", func(t *testing.T) {
+		dropAndReplace("access_types", "CREATE VIEW access_types AS SELECT 'x' AS domain_id")
+		_, _, err := s.AccessTypeList(ctx, domID, opts)
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+
+	t.Run("PermissionList", func(t *testing.T) {
+		dropAndReplace("permissions", "CREATE VIEW permissions AS SELECT 'x' AS domain_id")
+		_, _, err := s.PermissionList(ctx, domID, store.PermissionListOpts{ListOpts: opts})
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+
+	t.Run("DomainList", func(t *testing.T) {
+		dropAndReplace("domains", "CREATE VIEW domains AS SELECT 1 AS x")
+		_, _, err := s.DomainList(ctx, opts)
+		if err == nil {
+			t.Fatal("want error")
+		}
+	})
+}

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -2602,5 +2603,199 @@ func TestDomainList_searchType(t *testing.T) {
 	}
 	if total != 0 {
 		t.Fatalf("starts_with eta: want 0, got total=%d", total)
+	}
+}
+
+func TestDomainList_sortDesc(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	for _, title := range []string{"Alpha", "Beta", "Charlie"} {
+		if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: title}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.DomainList(ctx, store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderDesc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 3 {
+		t.Fatalf("want 3, got %d", len(list))
+	}
+	if list[0].Title != "Charlie" || list[2].Title != "Alpha" {
+		t.Fatalf("desc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestDomainList_sortAscExplicit(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	for _, title := range []string{"Charlie", "Alpha", "Beta"} {
+		if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: title}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.DomainList(ctx, store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderAsc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].Title != "Alpha" || list[2].Title != "Charlie" {
+		t.Fatalf("asc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestUserList_sortDesc(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, title := range []string{"Alice", "Bob", "Charlie"} {
+		if err := s.UserCreate(ctx, &store.User{ID: uuid.NewString(), DomainID: domainID, Title: title}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.UserList(ctx, domainID, store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderDesc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].Title != "Charlie" || list[2].Title != "Alice" {
+		t.Fatalf("desc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestGroupList_sortDesc(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, title := range []string{"Admins", "Editors", "Viewers"} {
+		if err := s.GroupCreate(ctx, &store.Group{ID: uuid.NewString(), DomainID: domainID, Title: title}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.GroupList(ctx, domainID, store.GroupListOpts{ListOpts: store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderDesc}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].Title != "Viewers" || list[2].Title != "Admins" {
+		t.Fatalf("desc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestResourceList_sortDesc(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, title := range []string{"Doc", "File", "Repo"} {
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: uuid.NewString(), DomainID: domainID, Title: title}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.ResourceList(ctx, domainID, store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderDesc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].Title != "Repo" || list[2].Title != "Doc" {
+		t.Fatalf("desc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestAccessTypeList_sortDesc(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	for i, title := range []string{"Read", "Write", "Execute"} {
+		if err := s.AccessTypeCreate(ctx, &store.AccessType{ID: uuid.NewString(), DomainID: domainID, Title: title, Bit: uint64(1 << i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.AccessTypeList(ctx, domainID, store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderDesc})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].Title != "Write" || list[2].Title != "Execute" {
+		t.Fatalf("desc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestPermissionList_sortDesc(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, title := range []string{"perm-a", "perm-b", "perm-c"} {
+		if err := s.PermissionCreate(ctx, &store.Permission{ID: uuid.NewString(), DomainID: domainID, Title: title, ResourceID: rid, AccessMask: 1}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	list, _, err := s.PermissionList(ctx, domainID, store.PermissionListOpts{ListOpts: store.ListOpts{Limit: 100, Sort: "title", Order: store.OrderDesc}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].Title != "perm-c" || list[2].Title != "perm-a" {
+		t.Fatalf("desc order: got %q, %q, %q", list[0].Title, list[1].Title, list[2].Title)
+	}
+}
+
+func TestPermissionList_sortByResourceID(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rids := []string{uuid.NewString(), uuid.NewString()}
+	for i, rid := range rids {
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: fmt.Sprintf("r%d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: uuid.NewString(), DomainID: domainID, Title: "p1", ResourceID: rids[1], AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: uuid.NewString(), DomainID: domainID, Title: "p2", ResourceID: rids[0], AccessMask: 2}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, _, err := s.PermissionList(ctx, domainID, store.PermissionListOpts{ListOpts: store.ListOpts{Limit: 100, Sort: "resource_id", Order: store.OrderAsc}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("want 2, got %d", len(list))
+	}
+	if list[0].ResourceID > list[1].ResourceID {
+		t.Fatalf("asc resource_id: %s should come before %s", list[0].ResourceID, list[1].ResourceID)
+	}
+
+	list, _, err = s.PermissionList(ctx, domainID, store.PermissionListOpts{ListOpts: store.ListOpts{Limit: 100, Sort: "resource_id", Order: store.OrderDesc}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if list[0].ResourceID < list[1].ResourceID {
+		t.Fatalf("desc resource_id: %s should come after %s", list[0].ResourceID, list[1].ResourceID)
 	}
 }

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -2799,3 +2799,69 @@ func TestPermissionList_sortByResourceID(t *testing.T) {
 		t.Fatalf("desc resource_id: %s should come after %s", list[0].ResourceID, list[1].ResourceID)
 	}
 }
+
+func TestSortColumns(t *testing.T) {
+	t.Run("no overrides", func(t *testing.T) {
+		cols := sortColumns([]string{"title", "resource_id"}, nil)
+		if len(cols) != 2 {
+			t.Fatalf("want 2 entries, got %d", len(cols))
+		}
+		if cols["title"] != "title" || cols["resource_id"] != "resource_id" {
+			t.Fatalf("unexpected mapping: %v", cols)
+		}
+	})
+
+	t.Run("valid override", func(t *testing.T) {
+		cols := sortColumns([]string{"title"}, map[string]string{"title": "name"})
+		if cols["title"] != "name" {
+			t.Fatalf("want title→name, got title→%s", cols["title"])
+		}
+	})
+
+	t.Run("invalid override key ignored", func(t *testing.T) {
+		cols := sortColumns([]string{"title"}, map[string]string{"unknown": "col"})
+		if _, ok := cols["unknown"]; ok {
+			t.Fatal("override key not in fields should be ignored")
+		}
+		if len(cols) != 1 {
+			t.Fatalf("want 1 entry, got %d", len(cols))
+		}
+	})
+}
+
+func TestOrderByClause(t *testing.T) {
+	allowed := map[string]string{"title": "title", "resource_id": "resource_id"}
+
+	t.Run("known field", func(t *testing.T) {
+		got := orderByClause("title", store.OrderAsc, allowed, "title")
+		want := " ORDER BY title ASC, id ASC"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("empty defaults to fallback", func(t *testing.T) {
+		got := orderByClause("", store.OrderDesc, allowed, "title")
+		want := " ORDER BY title DESC, id DESC"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("unknown non-empty falls back with warning", func(t *testing.T) {
+		got := orderByClause("bogus", store.OrderAsc, allowed, "title")
+		want := " ORDER BY title ASC, id ASC"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("sort by id skips tiebreaker", func(t *testing.T) {
+		a := map[string]string{"id": "id"}
+		got := orderByClause("id", store.OrderAsc, a, "id")
+		want := " ORDER BY id ASC"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -2125,11 +2125,12 @@ func TestSanitizeListOpts(t *testing.T) {
 		in   store.ListOpts
 		want store.ListOpts
 	}{
-		{"zero limit defaults", store.ListOpts{Offset: 0, Limit: 0}, store.ListOpts{Offset: 0, Limit: store.DefaultLimit}},
-		{"negative limit defaults", store.ListOpts{Offset: 0, Limit: -5}, store.ListOpts{Offset: 0, Limit: store.DefaultLimit}},
-		{"over max capped", store.ListOpts{Offset: 0, Limit: 500}, store.ListOpts{Offset: 0, Limit: store.MaxLimit}},
-		{"negative offset zeroed", store.ListOpts{Offset: -3, Limit: 10}, store.ListOpts{Offset: 0, Limit: 10}},
-		{"valid unchanged", store.ListOpts{Offset: 5, Limit: 25}, store.ListOpts{Offset: 5, Limit: 25}},
+		{"zero limit defaults", store.ListOpts{Offset: 0, Limit: 0}, store.ListOpts{Offset: 0, Limit: store.DefaultLimit, Order: store.OrderAsc}},
+		{"negative limit defaults", store.ListOpts{Offset: 0, Limit: -5}, store.ListOpts{Offset: 0, Limit: store.DefaultLimit, Order: store.OrderAsc}},
+		{"over max capped", store.ListOpts{Offset: 0, Limit: 500}, store.ListOpts{Offset: 0, Limit: store.MaxLimit, Order: store.OrderAsc}},
+		{"negative offset zeroed", store.ListOpts{Offset: -3, Limit: 10}, store.ListOpts{Offset: 0, Limit: 10, Order: store.OrderAsc}},
+		{"valid unchanged", store.ListOpts{Offset: 5, Limit: 25}, store.ListOpts{Offset: 5, Limit: 25, Order: store.OrderAsc}},
+		{"order preserved when set", store.ListOpts{Offset: 0, Limit: 10, Order: store.OrderDesc}, store.ListOpts{Offset: 0, Limit: 10, Order: store.OrderDesc}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -89,6 +89,9 @@ var (
 // allowed[0]. An unrecognised field produces a descriptive error listing
 // the accepted values.
 func ValidateSort(sort string, allowed []string) (string, error) {
+	if len(allowed) == 0 {
+		return "", fmt.Errorf("no sortable fields defined")
+	}
 	if sort == "" {
 		return allowed[0], nil
 	}

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -3,6 +3,8 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 )
 
 var (
@@ -65,12 +67,47 @@ const (
 	SearchEndsWith   SearchType = "ends_with"
 )
 
-// ListOpts controls pagination and optional title search for list queries.
+// SortOrder controls ascending vs descending sort direction.
+type SortOrder string
+
+const (
+	OrderAsc  SortOrder = "asc"
+	OrderDesc SortOrder = "desc"
+)
+
+// Per-entity allowed sort fields. The first element is the default.
+var (
+	DomainSortFields     = []string{"title"}
+	UserSortFields       = []string{"title"}
+	GroupSortFields      = []string{"title"}
+	ResourceSortFields   = []string{"title"}
+	AccessTypeSortFields = []string{"title"}
+	PermissionSortFields = []string{"title", "resource_id"}
+)
+
+// ValidateSort returns a validated sort field. An empty input defaults to
+// allowed[0]. An unrecognised field produces a descriptive error listing
+// the accepted values.
+func ValidateSort(sort string, allowed []string) (string, error) {
+	if sort == "" {
+		return allowed[0], nil
+	}
+	for _, f := range allowed {
+		if sort == f {
+			return sort, nil
+		}
+	}
+	return "", fmt.Errorf("sort must be one of: %s", strings.Join(allowed, ", "))
+}
+
+// ListOpts controls pagination, optional title search, and sorting for list queries.
 type ListOpts struct {
 	Offset     int
 	Limit      int
 	Search     string     // case-insensitive match on title; empty = no filter
 	SearchType SearchType // defaults to SearchContains when empty
+	Sort       string     // validated per entity before reaching store
+	Order      SortOrder  // defaults to OrderAsc
 }
 
 // GroupListOpts extends ListOpts with group-specific filters.
@@ -86,7 +123,7 @@ type PermissionListOpts struct {
 }
 
 // SanitizeListOpts defaults Limit to DefaultLimit when <= 0, caps it at
-// MaxLimit, and floors Offset at 0.
+// MaxLimit, floors Offset at 0, and defaults Order to OrderAsc.
 func SanitizeListOpts(opts ListOpts) ListOpts {
 	if opts.Limit <= 0 {
 		opts.Limit = DefaultLimit
@@ -96,6 +133,9 @@ func SanitizeListOpts(opts ListOpts) ListOpts {
 	}
 	if opts.Offset < 0 {
 		opts.Offset = 0
+	}
+	if opts.Order == "" {
+		opts.Order = OrderAsc
 	}
 	return opts
 }

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -76,11 +76,14 @@ const (
 )
 
 // Per-entity allowed sort fields. The first element is the default.
+// These slices are treated as read-only; do not append or modify at runtime.
 var (
-	DomainSortFields     = []string{"title"}
-	UserSortFields       = []string{"title"}
-	GroupSortFields      = []string{"title"}
-	ResourceSortFields   = []string{"title"}
+	DomainSortFields   = []string{"title"}
+	UserSortFields     = []string{"title"}
+	GroupSortFields    = []string{"title"}
+	ResourceSortFields = []string{"title"}
+	// AccessTypeSortFields intentionally excludes "bit": bit is an internal
+	// mask position, not a meaningful user-facing ordering criterion.
 	AccessTypeSortFields = []string{"title"}
 	PermissionSortFields = []string{"title", "resource_id"}
 )

--- a/go/internal/store/store_test.go
+++ b/go/internal/store/store_test.go
@@ -10,19 +10,22 @@ func TestValidateSort(t *testing.T) {
 	single := []string{"title"}
 
 	tests := []struct {
-		name    string
-		sort    string
-		allowed []string
-		want    string
-		wantErr bool
+		name       string
+		sort       string
+		allowed    []string
+		want       string
+		wantErr    bool
+		errContain string
 	}{
-		{"empty defaults to first", "", multi, "title", false},
-		{"valid first field", "title", multi, "title", false},
-		{"valid second field", "resource_id", multi, "resource_id", false},
-		{"unknown field", "unknown", multi, "", true},
-		{"single allowed empty", "", single, "title", false},
-		{"single allowed valid", "title", single, "title", false},
-		{"single allowed invalid", "other", single, "", true},
+		{"empty defaults to first", "", multi, "title", false, ""},
+		{"valid first field", "title", multi, "title", false, ""},
+		{"valid second field", "resource_id", multi, "resource_id", false, ""},
+		{"unknown field", "unknown", multi, "", true, "sort must be one of"},
+		{"single allowed empty", "", single, "title", false, ""},
+		{"single allowed valid", "title", single, "title", false, ""},
+		{"single allowed invalid", "other", single, "", true, "sort must be one of"},
+		{"nil allowed", "", nil, "", true, "no sortable fields defined"},
+		{"empty allowed slice", "title", []string{}, "", true, "no sortable fields defined"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -31,8 +34,8 @@ func TestValidateSort(t *testing.T) {
 				if err == nil {
 					t.Fatal("want error")
 				}
-				if !strings.Contains(err.Error(), "sort must be one of") {
-					t.Fatalf("error message: %v", err)
+				if !strings.Contains(err.Error(), tt.errContain) {
+					t.Fatalf("error should contain %q, got: %v", tt.errContain, err)
 				}
 				return
 			}

--- a/go/internal/store/store_test.go
+++ b/go/internal/store/store_test.go
@@ -49,14 +49,53 @@ func TestValidateSort(t *testing.T) {
 	}
 }
 
-func TestSanitizeListOpts_orderDefault(t *testing.T) {
-	opts := SanitizeListOpts(ListOpts{Limit: 10})
-	if opts.Order != OrderAsc {
-		t.Fatalf("Order: got %q, want %q", opts.Order, OrderAsc)
-	}
+func TestSanitizeListOpts(t *testing.T) {
+	t.Run("order defaults to asc", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{Limit: 10})
+		if opts.Order != OrderAsc {
+			t.Fatalf("Order: got %q, want %q", opts.Order, OrderAsc)
+		}
+	})
 
-	opts = SanitizeListOpts(ListOpts{Limit: 10, Order: OrderDesc})
-	if opts.Order != OrderDesc {
-		t.Fatalf("Order preserved: got %q, want %q", opts.Order, OrderDesc)
-	}
+	t.Run("order preserved when set", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{Limit: 10, Order: OrderDesc})
+		if opts.Order != OrderDesc {
+			t.Fatalf("Order: got %q, want %q", opts.Order, OrderDesc)
+		}
+	})
+
+	t.Run("limit defaults when zero", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{})
+		if opts.Limit != DefaultLimit {
+			t.Fatalf("Limit: got %d, want %d", opts.Limit, DefaultLimit)
+		}
+	})
+
+	t.Run("limit defaults when negative", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{Limit: -5})
+		if opts.Limit != DefaultLimit {
+			t.Fatalf("Limit: got %d, want %d", opts.Limit, DefaultLimit)
+		}
+	})
+
+	t.Run("limit capped at max", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{Limit: MaxLimit + 50})
+		if opts.Limit != MaxLimit {
+			t.Fatalf("Limit: got %d, want %d", opts.Limit, MaxLimit)
+		}
+	})
+
+	t.Run("negative offset floored to zero", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{Limit: 10, Offset: -3})
+		if opts.Offset != 0 {
+			t.Fatalf("Offset: got %d, want 0", opts.Offset)
+		}
+	})
+
+	t.Run("valid values unchanged", func(t *testing.T) {
+		opts := SanitizeListOpts(ListOpts{Limit: 50, Offset: 10, Order: OrderDesc})
+		if opts.Limit != 50 || opts.Offset != 10 || opts.Order != OrderDesc {
+			t.Fatalf("got Limit=%d Offset=%d Order=%q", opts.Limit, opts.Offset, opts.Order)
+		}
+	})
 }

--- a/go/internal/store/store_test.go
+++ b/go/internal/store/store_test.go
@@ -1,0 +1,59 @@
+package store
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateSort(t *testing.T) {
+	multi := []string{"title", "resource_id"}
+	single := []string{"title"}
+
+	tests := []struct {
+		name    string
+		sort    string
+		allowed []string
+		want    string
+		wantErr bool
+	}{
+		{"empty defaults to first", "", multi, "title", false},
+		{"valid first field", "title", multi, "title", false},
+		{"valid second field", "resource_id", multi, "resource_id", false},
+		{"unknown field", "unknown", multi, "", true},
+		{"single allowed empty", "", single, "title", false},
+		{"single allowed valid", "title", single, "title", false},
+		{"single allowed invalid", "other", single, "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidateSort(tt.sort, tt.allowed)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("want error")
+				}
+				if !strings.Contains(err.Error(), "sort must be one of") {
+					t.Fatalf("error message: %v", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSanitizeListOpts_orderDefault(t *testing.T) {
+	opts := SanitizeListOpts(ListOpts{Limit: 10})
+	if opts.Order != OrderAsc {
+		t.Fatalf("Order: got %q, want %q", opts.Order, OrderAsc)
+	}
+
+	opts = SanitizeListOpts(ListOpts{Limit: 10, Order: OrderDesc})
+	if opts.Order != OrderDesc {
+		t.Fatalf("Order preserved: got %q, want %q", opts.Order, OrderDesc)
+	}
+}


### PR DESCRIPTION
## Summary

Add optional `sort` and `order` query parameters to all six list endpoints so clients can control result ordering. Sort fields are validated against per-entity allow-lists (e.g. permissions accept `title` and `resource_id`). Invalid values return 400. The applied sort/order are echoed in the response `meta`. SQL injection is prevented by mapping user input through hard-coded column allow-lists — no raw interpolation into ORDER BY.

**Behavior change:** `GET .../access-types` default sort changes from `bit` to `title` (consistent with all other entities).

## Ticket

Fixes #55

## Checklist

- [x] `make test` and `make lint` pass (from repo root)
- [x] Docs updated if behavior or setup changed (`README.md`, `go/README.md`, or `docs/` as needed)
- [x] No secrets or real `.env` values committed