### PR TITLE
feat(T39): add integration tests — isolation, concurrency, integrity, authz masks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Delegate to the Go implementation under go/ (T29). Override: `make -C go test`.
 # Docker (T19): run from repo root (compose files live here).
-.PHONY: build test cover cover-func run tidy lint vuln e2e e2e-bash docker-build docker-up docker-down docker-logs
+.PHONY: build test integration cover cover-func run tidy lint vuln e2e e2e-bash docker-build docker-up docker-down docker-logs
 
-build test cover cover-func run tidy lint vuln:
+build test integration cover cover-func run tidy lint vuln:
 	$(MAKE) -C go $@
 
 # T16 — same as go/Makefile e2e: go test -race -count=1 -tags=e2e ./e2e/... (BASE_URL default http://127.0.0.1:8080).

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test cover cover-func run tidy lint vuln e2e
+.PHONY: build test integration cover cover-func run tidy lint vuln e2e
 
 # golang/go#75031: GOTOOLCHAIN=auto can make `go test -cover` fail with "no such tool covdata".
 # Pin the minimum toolchain to the `go` version in go.mod (override: `make test GOTOOLCHAIN=local`).
@@ -37,6 +37,9 @@ lint:
 
 vuln:
 	go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
+
+integration:
+	go test -race -count=1 -run '^TestIntegration' ./internal/api/...
 
 # T16 — requires a running API (default BASE_URL http://127.0.0.1:8080). Bash twin: ../../test/e2e/bash/run.sh
 e2e:

--- a/go/internal/api/helpers_test.go
+++ b/go/internal/api/helpers_test.go
@@ -1,0 +1,164 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// mustGet performs a GET and asserts the expected status code.
+func mustGet(t *testing.T, url string, wantStatus int) []byte {
+	t.Helper()
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != wantStatus {
+		t.Fatalf("GET %s: want %d, got %d: %s", url, wantStatus, res.StatusCode, b)
+	}
+	return b
+}
+
+// mustDoRequest performs an HTTP request with optional JSON body and asserts status.
+func mustDoRequest(t *testing.T, method, url, body string, wantStatus int) []byte {
+	t.Helper()
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != wantStatus {
+		t.Fatalf("%s %s: want %d, got %d: %s", method, url, wantStatus, res.StatusCode, b)
+	}
+	return b
+}
+
+func mustPatchJSON(t *testing.T, url, jsonBody string, wantStatus int) []byte {
+	t.Helper()
+	return mustDoRequest(t, http.MethodPatch, url, jsonBody, wantStatus)
+}
+
+func mustDeleteReq(t *testing.T, url string, wantStatus int) []byte {
+	t.Helper()
+	return mustDoRequest(t, http.MethodDelete, url, "", wantStatus)
+}
+
+func mustPostJSON(t *testing.T, url, jsonBody string, wantStatus int) []byte {
+	t.Helper()
+	return mustDoRequest(t, http.MethodPost, url, jsonBody, wantStatus)
+}
+
+func mustPostEmpty(t *testing.T, url string, wantStatus int) []byte {
+	t.Helper()
+	return mustDoRequest(t, http.MethodPost, url, "", wantStatus)
+}
+
+func domainBase(ts *httptest.Server, domainID string) string {
+	return ts.URL + "/api/v1/domains/" + domainID
+}
+
+func seedDomain(t *testing.T, ts *httptest.Server, title string) string {
+	t.Helper()
+	b := mustPostJSON(t, ts.URL+"/api/v1/domains", fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func seedUser(t *testing.T, ts *httptest.Server, domainID, title string) string {
+	t.Helper()
+	b := mustPostJSON(t, domainBase(ts, domainID)+"/users", fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func seedGroup(t *testing.T, ts *httptest.Server, domainID, title string) string {
+	t.Helper()
+	b := mustPostJSON(t, domainBase(ts, domainID)+"/groups", fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func seedResource(t *testing.T, ts *httptest.Server, domainID, title string) string {
+	t.Helper()
+	b := mustPostJSON(t, domainBase(ts, domainID)+"/resources", fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func seedAccessType(t *testing.T, ts *httptest.Server, domainID, title, bit string) string {
+	t.Helper()
+	b := mustPostJSON(t, domainBase(ts, domainID)+"/access-types",
+		fmt.Sprintf(`{"title":%q,"bit":%q}`, title, bit), http.StatusCreated)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func seedPermission(t *testing.T, ts *httptest.Server, domainID, title, resourceID, mask string) string {
+	t.Helper()
+	b := mustPostJSON(t, domainBase(ts, domainID)+"/permissions",
+		fmt.Sprintf(`{"title":%q,"resource_id":%q,"access_mask":%q}`, title, resourceID, mask), http.StatusCreated)
+	var out struct{ ID string }
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	return out.ID
+}
+
+func addMembership(t *testing.T, ts *httptest.Server, domainID, userID, groupID string) {
+	t.Helper()
+	mustPostEmpty(t, domainBase(ts, domainID)+"/users/"+userID+"/groups/"+groupID, http.StatusNoContent)
+}
+
+func grantUserPerm(t *testing.T, ts *httptest.Server, domainID, userID, permID string) {
+	t.Helper()
+	mustPostEmpty(t, domainBase(ts, domainID)+"/users/"+userID+"/permissions/"+permID, http.StatusNoContent)
+}
+
+func grantGroupPerm(t *testing.T, ts *httptest.Server, domainID, groupID, permID string) {
+	t.Helper()
+	mustPostEmpty(t, domainBase(ts, domainID)+"/groups/"+groupID+"/permissions/"+permID, http.StatusNoContent)
+}
+
+func revokeUserPerm(t *testing.T, ts *httptest.Server, domainID, userID, permID string) {
+	t.Helper()
+	mustDeleteReq(t, domainBase(ts, domainID)+"/users/"+userID+"/permissions/"+permID, http.StatusNoContent)
+}

--- a/go/internal/api/helpers_test.go
+++ b/go/internal/api/helpers_test.go
@@ -8,12 +8,15 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
+
+var testClient = &http.Client{Timeout: 10 * time.Second}
 
 // mustGet performs a GET and asserts the expected status code.
 func mustGet(t *testing.T, url string, wantStatus int) []byte {
 	t.Helper()
-	res, err := http.Get(url)
+	res, err := testClient.Get(url)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -42,7 +45,7 @@ func mustDoRequest(t *testing.T, method, url, body string, wantStatus int) []byt
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := testClient.Do(req)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +176,7 @@ func doRequestErr(method, url, body string, wantStatus int) ([]byte, error) {
 	if body != "" {
 		req.Header.Set("Content-Type", "application/json")
 	}
-	res, err := http.DefaultClient.Do(req)
+	res, err := testClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("%s %s: %w", method, url, err)
 	}

--- a/go/internal/api/helpers_test.go
+++ b/go/internal/api/helpers_test.go
@@ -162,3 +162,33 @@ func revokeUserPerm(t *testing.T, ts *httptest.Server, domainID, userID, permID 
 	t.Helper()
 	mustDeleteReq(t, domainBase(ts, domainID)+"/users/"+userID+"/permissions/"+permID, http.StatusNoContent)
 }
+
+// doRequestErr is a goroutine-safe variant of mustDoRequest that returns the
+// response body and an error instead of calling t.Fatal (which is unsafe from
+// non-test goroutines).
+func doRequestErr(method, url, body string, wantStatus int) ([]byte, error) {
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: build request: %w", method, url, err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: %w", method, url, err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	b, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: read body: %w", method, url, err)
+	}
+	if res.StatusCode != wantStatus {
+		return nil, fmt.Errorf("%s %s: want %d, got %d: %s", method, url, wantStatus, res.StatusCode, b)
+	}
+	return b, nil
+}

--- a/go/internal/api/helpers_test.go
+++ b/go/internal/api/helpers_test.go
@@ -57,11 +57,6 @@ func mustDoRequest(t *testing.T, method, url, body string, wantStatus int) []byt
 	return b
 }
 
-func mustPatchJSON(t *testing.T, url, jsonBody string, wantStatus int) []byte {
-	t.Helper()
-	return mustDoRequest(t, http.MethodPatch, url, jsonBody, wantStatus)
-}
-
 func mustDeleteReq(t *testing.T, url string, wantStatus int) []byte {
 	t.Helper()
 	return mustDoRequest(t, http.MethodDelete, url, "", wantStatus)

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -390,6 +390,7 @@ func TestIntegration_permissionMaskArithmetic(t *testing.T) {
 		assertAuthzCheck(t, base, uid, r2, "0x1", false)
 	})
 
+	// Must run last: revokes p1, which invalidates earlier check_direct_bit* assertions.
 	t.Run("revoke_and_recheck", func(t *testing.T) {
 		revokeUserPerm(t, ts, did, uid, p1)
 

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -161,25 +161,43 @@ func TestIntegration_concurrentMembership(t *testing.T) {
 		uids[i] = seedUser(t, ts, domID, fmt.Sprintf("u-%d", i))
 	}
 
+	addErrs := make(chan error, n)
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {
 		wg.Add(1)
 		go func(uid string) {
 			defer wg.Done()
-			addMembership(t, ts, domID, uid, gid)
+			_, err := doRequestErr(http.MethodPost,
+				base+"/users/"+uid+"/groups/"+gid, "", http.StatusNoContent)
+			if err != nil {
+				addErrs <- err
+			}
 		}(uids[i])
 	}
 	wg.Wait()
+	close(addErrs)
+	for err := range addErrs {
+		t.Error(err)
+	}
 
+	delErrs := make(chan error, n)
 	var wg2 sync.WaitGroup
 	for i := 0; i < n; i++ {
 		wg2.Add(1)
 		go func(uid string) {
 			defer wg2.Done()
-			mustDeleteReq(t, base+"/users/"+uid+"/groups/"+gid, http.StatusNoContent)
+			_, err := doRequestErr(http.MethodDelete,
+				base+"/users/"+uid+"/groups/"+gid, "", http.StatusNoContent)
+			if err != nil {
+				delErrs <- err
+			}
 		}(uids[i])
 	}
 	wg2.Wait()
+	close(delErrs)
+	for err := range delErrs {
+		t.Error(err)
+	}
 
 	var env listResponse[store.User]
 	if err := json.Unmarshal(mustGet(t, base+"/users", http.StatusOK), &env); err != nil {

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -1,0 +1,392 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/dtorabi/access-manager/internal/store"
+)
+
+// ---------------------------------------------------------------------------
+// 1. Multi-domain isolation
+// ---------------------------------------------------------------------------
+
+func TestIntegration_multiDomainIsolation(t *testing.T) {
+	ts, _ := newTestAPI(t)
+
+	domA := seedDomain(t, ts, "DomainA")
+	domB := seedDomain(t, ts, "DomainB")
+	baseA := domainBase(ts, domA)
+	baseB := domainBase(ts, domB)
+
+	userA := seedUser(t, ts, domA, "SharedName")
+	userB := seedUser(t, ts, domB, "SharedName")
+	groupA := seedGroup(t, ts, domA, "SharedGroup")
+	_ = seedGroup(t, ts, domB, "SharedGroup")
+	resA := seedResource(t, ts, domA, "SharedRes")
+	_ = seedResource(t, ts, domB, "SharedRes")
+	_ = seedAccessType(t, ts, domA, "read", "0x1")
+	_ = seedAccessType(t, ts, domB, "read", "0x1")
+	permA := seedPermission(t, ts, domA, "can-read", resA, "0x1")
+
+	t.Run("list_isolation_users", func(t *testing.T) {
+		var envA listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, baseA+"/users", http.StatusOK), &envA); err != nil {
+			t.Fatal(err)
+		}
+		if envA.Meta.Total != 1 {
+			t.Fatalf("domain A users total: want 1, got %d", envA.Meta.Total)
+		}
+		if len(envA.Data) != 1 || envA.Data[0].ID != userA {
+			t.Fatalf("domain A users: %+v", envA.Data)
+		}
+
+		var envB listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, baseB+"/users", http.StatusOK), &envB); err != nil {
+			t.Fatal(err)
+		}
+		if envB.Meta.Total != 1 {
+			t.Fatalf("domain B users total: want 1, got %d", envB.Meta.Total)
+		}
+		if len(envB.Data) != 1 || envB.Data[0].ID != userB {
+			t.Fatalf("domain B users: %+v", envB.Data)
+		}
+	})
+
+	t.Run("get_isolation", func(t *testing.T) {
+		mustGet(t, baseA+"/users/"+userA, http.StatusOK)
+		mustGet(t, baseB+"/users/"+userA, http.StatusNotFound)
+		mustGet(t, baseA+"/users/"+userB, http.StatusNotFound)
+		mustGet(t, baseB+"/users/"+userB, http.StatusOK)
+	})
+
+	t.Run("authz_isolation", func(t *testing.T) {
+		addMembership(t, ts, domA, userA, groupA)
+		grantGroupPerm(t, ts, domA, groupA, permA)
+
+		checkURL := func(domID, uID, rID string) string {
+			return domainBase(ts, domID) + fmt.Sprintf("/authz/check?user_id=%s&resource_id=%s&access_bit=0x1", uID, rID)
+		}
+
+		var outA struct{ Allowed bool `json:"allowed"` }
+		if err := json.Unmarshal(mustGet(t, checkURL(domA, userA, resA), http.StatusOK), &outA); err != nil {
+			t.Fatal(err)
+		}
+		if !outA.Allowed {
+			t.Fatal("domain A user should be allowed in domain A")
+		}
+
+		var outB struct{ Allowed bool `json:"allowed"` }
+		if err := json.Unmarshal(mustGet(t, checkURL(domB, userA, resA), http.StatusOK), &outB); err != nil {
+			t.Fatal(err)
+		}
+		if outB.Allowed {
+			t.Fatal("domain A user should NOT be allowed in domain B")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 2. Concurrent write safety
+// ---------------------------------------------------------------------------
+
+func TestIntegration_concurrentWrites(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domID := seedDomain(t, ts, "concurrent")
+	base := domainBase(ts, domID)
+
+	const n = 20
+	errs := make(chan error, n*3)
+	var wg sync.WaitGroup
+
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			title := fmt.Sprintf("user-%d", i)
+
+			b := mustPostJSON(t, base+"/users", fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+			var created struct{ ID string }
+			if err := json.Unmarshal(b, &created); err != nil {
+				errs <- fmt.Errorf("create user %d: %w", i, err)
+				return
+			}
+
+			mustPatchJSON(t, base+"/users/"+created.ID,
+				fmt.Sprintf(`{"title":%q}`, title+"-patched"), http.StatusOK)
+			mustDeleteReq(t, base+"/users/"+created.ID, http.StatusNoContent)
+		}(i)
+	}
+
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	var env listResponse[store.User]
+	if err := json.Unmarshal(mustGet(t, base+"/users", http.StatusOK), &env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Meta.Total != 0 {
+		t.Fatalf("want 0 users after concurrent delete-all, got %d", env.Meta.Total)
+	}
+}
+
+func TestIntegration_concurrentMembership(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	domID := seedDomain(t, ts, "membership")
+	base := domainBase(ts, domID)
+	gid := seedGroup(t, ts, domID, "group")
+
+	const n = 15
+	uids := make([]string, n)
+	for i := 0; i < n; i++ {
+		uids[i] = seedUser(t, ts, domID, fmt.Sprintf("u-%d", i))
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(uid string) {
+			defer wg.Done()
+			addMembership(t, ts, domID, uid, gid)
+		}(uids[i])
+	}
+	wg.Wait()
+
+	var wg2 sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg2.Add(1)
+		go func(uid string) {
+			defer wg2.Done()
+			mustDeleteReq(t, base+"/users/"+uid+"/groups/"+gid, http.StatusNoContent)
+		}(uids[i])
+	}
+	wg2.Wait()
+
+	var env listResponse[store.User]
+	if err := json.Unmarshal(mustGet(t, base+"/users", http.StatusOK), &env); err != nil {
+		t.Fatal(err)
+	}
+	if int(env.Meta.Total) != n {
+		t.Fatalf("users should still exist (%d), got total=%d", n, env.Meta.Total)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Referential integrity challenges
+// ---------------------------------------------------------------------------
+
+func TestIntegration_referentialIntegrity(t *testing.T) {
+	ts, _ := newTestAPI(t)
+
+	t.Run("domain_with_users", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-dom")
+		_ = seedUser(t, ts, did, "u")
+		mustDeleteReq(t, domainBase(ts, did), http.StatusBadRequest)
+		mustGet(t, ts.URL+"/api/v1/domains/"+did, http.StatusOK)
+	})
+
+	t.Run("group_with_child_group", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-group-parent")
+		parent := seedGroup(t, ts, did, "parent")
+		mustPostJSON(t, domainBase(ts, did)+"/groups",
+			fmt.Sprintf(`{"title":"child","parent_group_id":%q}`, parent), http.StatusCreated)
+
+		mustDeleteReq(t, domainBase(ts, did)+"/groups/"+parent, http.StatusBadRequest)
+		mustGet(t, domainBase(ts, did)+"/groups/"+parent, http.StatusOK)
+	})
+
+	t.Run("group_with_members", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-group-members")
+		gid := seedGroup(t, ts, did, "g")
+		uid := seedUser(t, ts, did, "u")
+		addMembership(t, ts, did, uid, gid)
+
+		mustDeleteReq(t, domainBase(ts, did)+"/groups/"+gid, http.StatusBadRequest)
+		mustGet(t, domainBase(ts, did)+"/groups/"+gid, http.StatusOK)
+	})
+
+	t.Run("user_with_membership", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-user-member")
+		gid := seedGroup(t, ts, did, "g")
+		uid := seedUser(t, ts, did, "u")
+		addMembership(t, ts, did, uid, gid)
+
+		mustDeleteReq(t, domainBase(ts, did)+"/users/"+uid, http.StatusBadRequest)
+		mustGet(t, domainBase(ts, did)+"/users/"+uid, http.StatusOK)
+	})
+
+	t.Run("resource_with_permissions", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-res-perm")
+		rid := seedResource(t, ts, did, "r")
+		_ = seedPermission(t, ts, did, "p", rid, "0x1")
+
+		mustDeleteReq(t, domainBase(ts, did)+"/resources/"+rid, http.StatusBadRequest)
+		mustGet(t, domainBase(ts, did)+"/resources/"+rid, http.StatusOK)
+	})
+
+	t.Run("permission_with_user_grants", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-perm-user")
+		rid := seedResource(t, ts, did, "r")
+		pid := seedPermission(t, ts, did, "p", rid, "0x1")
+		uid := seedUser(t, ts, did, "u")
+		grantUserPerm(t, ts, did, uid, pid)
+
+		mustDeleteReq(t, domainBase(ts, did)+"/permissions/"+pid, http.StatusBadRequest)
+		mustGet(t, domainBase(ts, did)+"/permissions/"+pid, http.StatusOK)
+	})
+
+	t.Run("permission_with_group_grants", func(t *testing.T) {
+		did := seedDomain(t, ts, "ref-perm-group")
+		rid := seedResource(t, ts, did, "r")
+		pid := seedPermission(t, ts, did, "p", rid, "0x1")
+		gid := seedGroup(t, ts, did, "g")
+		grantGroupPerm(t, ts, did, gid, pid)
+
+		mustDeleteReq(t, domainBase(ts, did)+"/permissions/"+pid, http.StatusBadRequest)
+		mustGet(t, domainBase(ts, did)+"/permissions/"+pid, http.StatusOK)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 4. Idempotency / conflict checks
+// ---------------------------------------------------------------------------
+
+func TestIntegration_idempotencyConflicts(t *testing.T) {
+	ts, _ := newTestAPI(t)
+
+	t.Run("double_membership", func(t *testing.T) {
+		did := seedDomain(t, ts, "idem-mem")
+		uid := seedUser(t, ts, did, "u")
+		gid := seedGroup(t, ts, did, "g")
+		addMembership(t, ts, did, uid, gid)
+
+		mustPostEmpty(t, domainBase(ts, did)+"/users/"+uid+"/groups/"+gid, http.StatusConflict)
+	})
+
+	t.Run("double_user_grant", func(t *testing.T) {
+		did := seedDomain(t, ts, "idem-ugrant")
+		uid := seedUser(t, ts, did, "u")
+		rid := seedResource(t, ts, did, "r")
+		pid := seedPermission(t, ts, did, "p", rid, "0x1")
+		grantUserPerm(t, ts, did, uid, pid)
+
+		mustPostEmpty(t, domainBase(ts, did)+"/users/"+uid+"/permissions/"+pid, http.StatusConflict)
+	})
+
+	t.Run("double_group_grant", func(t *testing.T) {
+		did := seedDomain(t, ts, "idem-ggrant")
+		gid := seedGroup(t, ts, did, "g")
+		rid := seedResource(t, ts, did, "r")
+		pid := seedPermission(t, ts, did, "p", rid, "0x1")
+		grantGroupPerm(t, ts, did, gid, pid)
+
+		mustPostEmpty(t, domainBase(ts, did)+"/groups/"+gid+"/permissions/"+pid, http.StatusConflict)
+	})
+
+	t.Run("duplicate_access_type_bit", func(t *testing.T) {
+		did := seedDomain(t, ts, "idem-at")
+		_ = seedAccessType(t, ts, did, "read", "0x1")
+
+		mustPostJSON(t, domainBase(ts, did)+"/access-types",
+			`{"title":"write","bit":"0x1"}`, http.StatusConflict)
+	})
+}
+
+// ---------------------------------------------------------------------------
+// 5. Permission mask arithmetic
+// ---------------------------------------------------------------------------
+
+func TestIntegration_permissionMaskArithmetic(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	did := seedDomain(t, ts, "masks")
+	base := domainBase(ts, did)
+
+	_ = seedAccessType(t, ts, did, "bit0", "0x1")
+	_ = seedAccessType(t, ts, did, "bit1", "0x2")
+	_ = seedAccessType(t, ts, did, "bit2", "0x4")
+	_ = seedAccessType(t, ts, did, "bit3", "0x8")
+
+	r1 := seedResource(t, ts, did, "R1")
+	r2 := seedResource(t, ts, did, "R2")
+
+	p1 := seedPermission(t, ts, did, "P1", r1, "0x3")
+	p2 := seedPermission(t, ts, did, "P2", r1, "0xC")
+	_ = seedPermission(t, ts, did, "P3", r2, "0x5")
+
+	uid := seedUser(t, ts, did, "U")
+	gid := seedGroup(t, ts, did, "G")
+	addMembership(t, ts, did, uid, gid)
+
+	grantUserPerm(t, ts, did, uid, p1)
+	grantGroupPerm(t, ts, did, gid, p2)
+
+	t.Run("masks_endpoint", func(t *testing.T) {
+		url := fmt.Sprintf("%s/authz/masks?user_id=%s&resource_id=%s", base, uid, r1)
+		var out struct{ Masks []uint64 `json:"masks"` }
+		if err := json.Unmarshal(mustGet(t, url, http.StatusOK), &out); err != nil {
+			t.Fatal(err)
+		}
+		if len(out.Masks) != 2 {
+			t.Fatalf("want 2 masks, got %d: %v", len(out.Masks), out.Masks)
+		}
+		got := make([]uint64, len(out.Masks))
+		copy(got, out.Masks)
+		sort.Slice(got, func(i, j int) bool { return got[i] < got[j] })
+		if got[0] != 3 || got[1] != 12 {
+			t.Fatalf("want masks [3, 12], got %v", got)
+		}
+	})
+
+	t.Run("check_direct_bit1", func(t *testing.T) {
+		assertAuthzCheck(t, base, uid, r1, "0x1", true)
+	})
+	t.Run("check_direct_bit2", func(t *testing.T) {
+		assertAuthzCheck(t, base, uid, r1, "0x2", true)
+	})
+	t.Run("check_group_bit4", func(t *testing.T) {
+		assertAuthzCheck(t, base, uid, r1, "0x4", true)
+	})
+	t.Run("check_group_bit8", func(t *testing.T) {
+		assertAuthzCheck(t, base, uid, r1, "0x8", true)
+	})
+	t.Run("check_no_grant_on_r2", func(t *testing.T) {
+		assertAuthzCheck(t, base, uid, r2, "0x1", false)
+	})
+
+	t.Run("revoke_and_recheck", func(t *testing.T) {
+		revokeUserPerm(t, ts, did, uid, p1)
+
+		assertAuthzCheck(t, base, uid, r1, "0x1", false)
+		assertAuthzCheck(t, base, uid, r1, "0x2", false)
+		assertAuthzCheck(t, base, uid, r1, "0x4", true)
+		assertAuthzCheck(t, base, uid, r1, "0x8", true)
+	})
+}
+
+func assertAuthzCheck(t *testing.T, base, userID, resourceID, bit string, wantAllowed bool) {
+	t.Helper()
+	url := fmt.Sprintf("%s/authz/check?user_id=%s&resource_id=%s&access_bit=%s",
+		base, userID, resourceID, bit)
+	var out struct {
+		Allowed bool `json:"allowed"`
+	}
+	if err := json.Unmarshal(mustGet(t, url, http.StatusOK), &out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Allowed != wantAllowed {
+		t.Fatalf("authz/check(user=%s, res=%s, bit=%s): want allowed=%v, got %v",
+			userID, resourceID, bit, wantAllowed, out.Allowed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Pagination + filtering combined — deferred until T35 lands.
+// TODO(T35): Add filter + pagination tests when filtering is implemented.
+// ---------------------------------------------------------------------------

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -419,6 +419,81 @@ func assertAuthzCheck(t *testing.T, base, userID, resourceID, bit string, wantAl
 
 // ---------------------------------------------------------------------------
 // 6. Pagination + filtering combined
-// TODO(T39): Add filter + pagination integration tests (T35 filtering landed
-// in #61; these tests should exercise search + offset/limit together).
 // ---------------------------------------------------------------------------
+
+func TestIntegration_paginationWithFiltering(t *testing.T) {
+	ts, _ := newTestAPI(t)
+	did := seedDomain(t, ts, "pagfilter")
+	base := domainBase(ts, did)
+
+	for i := 0; i < 7; i++ {
+		seedUser(t, ts, did, fmt.Sprintf("match-%d", i))
+	}
+	seedUser(t, ts, did, "no-hit-1")
+	seedUser(t, ts, did, "no-hit-2")
+
+	t.Run("filtered_total_reflects_search", func(t *testing.T) {
+		var env listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, base+"/users?search=match&limit=3&offset=0", http.StatusOK), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Meta.Total != 7 {
+			t.Fatalf("total should reflect filtered count (7), got %d", env.Meta.Total)
+		}
+		if len(env.Data) != 3 {
+			t.Fatalf("page size should be 3, got %d", len(env.Data))
+		}
+	})
+
+	t.Run("second_page", func(t *testing.T) {
+		var env listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, base+"/users?search=match&limit=3&offset=3", http.StatusOK), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Meta.Total != 7 {
+			t.Fatalf("total should still be 7, got %d", env.Meta.Total)
+		}
+		if len(env.Data) != 3 {
+			t.Fatalf("second page should have 3 items, got %d", len(env.Data))
+		}
+	})
+
+	t.Run("last_page_partial", func(t *testing.T) {
+		var env listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, base+"/users?search=match&limit=3&offset=6", http.StatusOK), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Meta.Total != 7 {
+			t.Fatalf("total should still be 7, got %d", env.Meta.Total)
+		}
+		if len(env.Data) != 1 {
+			t.Fatalf("last page should have 1 item, got %d", len(env.Data))
+		}
+	})
+
+	t.Run("offset_past_filtered_total", func(t *testing.T) {
+		var env listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, base+"/users?search=match&limit=10&offset=100", http.StatusOK), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Meta.Total != 7 {
+			t.Fatalf("total should still be 7, got %d", env.Meta.Total)
+		}
+		if len(env.Data) != 0 {
+			t.Fatalf("data should be empty past total, got %d items", len(env.Data))
+		}
+	})
+
+	t.Run("no_match_returns_zero", func(t *testing.T) {
+		var env listResponse[store.User]
+		if err := json.Unmarshal(mustGet(t, base+"/users?search=zzzzz&limit=10", http.StatusOK), &env); err != nil {
+			t.Fatal(err)
+		}
+		if env.Meta.Total != 0 {
+			t.Fatalf("total should be 0 for no-match search, got %d", env.Meta.Total)
+		}
+		if len(env.Data) != 0 {
+			t.Fatalf("data should be empty, got %d items", len(env.Data))
+		}
+	})
+}

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -390,7 +390,9 @@ func TestIntegration_permissionMaskArithmetic(t *testing.T) {
 		assertAuthzCheck(t, base, uid, r2, "0x1", false)
 	})
 
-	// Must run last: revokes p1, which invalidates earlier check_direct_bit* assertions.
+	// WARNING: must run last — revokes p1, mutating shared state.
+	// Do NOT add t.Parallel() or reorder subtests in this function.
+	// If you need independent assertions, copy fixtures into a separate test.
 	t.Run("revoke_and_recheck", func(t *testing.T) {
 		revokeUserPerm(t, ts, did, uid, p1)
 

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -100,7 +100,7 @@ func TestIntegration_concurrentWrites(t *testing.T) {
 	base := domainBase(ts, domID)
 
 	const n = 20
-	errs := make(chan error, n*3)
+	errs := make(chan error, n)
 	var wg sync.WaitGroup
 
 	for i := 0; i < n; i++ {
@@ -109,16 +109,28 @@ func TestIntegration_concurrentWrites(t *testing.T) {
 			defer wg.Done()
 			title := fmt.Sprintf("user-%d", i)
 
-			b := mustPostJSON(t, base+"/users", fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+			b, err := doRequestErr(http.MethodPost, base+"/users",
+				fmt.Sprintf(`{"title":%q}`, title), http.StatusCreated)
+			if err != nil {
+				errs <- err
+				return
+			}
 			var created struct{ ID string }
 			if err := json.Unmarshal(b, &created); err != nil {
-				errs <- fmt.Errorf("create user %d: %w", i, err)
+				errs <- fmt.Errorf("create user %d unmarshal: %w", i, err)
 				return
 			}
 
-			mustPatchJSON(t, base+"/users/"+created.ID,
-				fmt.Sprintf(`{"title":%q}`, title+"-patched"), http.StatusOK)
-			mustDeleteReq(t, base+"/users/"+created.ID, http.StatusNoContent)
+			if _, err := doRequestErr(http.MethodPatch, base+"/users/"+created.ID,
+				fmt.Sprintf(`{"title":%q}`, title+"-patched"), http.StatusOK); err != nil {
+				errs <- err
+				return
+			}
+			if _, err := doRequestErr(http.MethodDelete, base+"/users/"+created.ID,
+				"", http.StatusNoContent); err != nil {
+				errs <- err
+				return
+			}
 		}(i)
 	}
 

--- a/go/internal/api/integration_test.go
+++ b/go/internal/api/integration_test.go
@@ -418,6 +418,7 @@ func assertAuthzCheck(t *testing.T, base, userID, resourceID, bit string, wantAl
 }
 
 // ---------------------------------------------------------------------------
-// 6. Pagination + filtering combined — deferred until T35 lands.
-// TODO(T35): Add filter + pagination tests when filtering is implemented.
+// 6. Pagination + filtering combined
+// TODO(T39): Add filter + pagination integration tests (T35 filtering landed
+// in #61; these tests should exercise search + offset/limit together).
 // ---------------------------------------------------------------------------

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -67,22 +67,10 @@ func newTestAPI(t *testing.T) (*httptest.Server, store.Store) {
 	return ts, st
 }
 
-// mustPostJSON201 POSTs JSON and returns the body after asserting http.StatusCreated.
-func mustPostJSON201(t *testing.T, urlStr, body string) []byte {
+// mustPostJSON201 is a convenience wrapper for mustPostJSON with http.StatusCreated.
+func mustPostJSON201(t *testing.T, url, body string) []byte {
 	t.Helper()
-	res, err := http.Post(urlStr, "application/json", strings.NewReader(body))
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = res.Body.Close() }()
-	b, err := io.ReadAll(res.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if res.StatusCode != http.StatusCreated {
-		t.Fatalf("POST %s want 201 got %d: %s", urlStr, res.StatusCode, b)
-	}
-	return b
+	return mustPostJSON(t, url, body, http.StatusCreated)
 }
 
 // auditLogEntries returns each newline-delimited JSON object from buf that has audit=true.


### PR DESCRIPTION
## Summary

Add `httptest`-based integration tests (`go/internal/api/integration_test.go`) exercising multi-domain isolation, concurrent write safety (with `-race`), referential integrity challenges, idempotency/conflict checks, permission mask arithmetic with revocation, and pagination combined with search filtering. Shared test helpers live in `helpers_test.go`. A new `make integration` target runs just the integration suite.

28 scenarios across 7 test functions. Tests use `httptest.Server` backed by a real SQLite store (file-backed under `t.TempDir()`).

## Ticket

Fixes #54

## Checklist

- [x] `make test` and `make lint` pass (from repo root)
- [x] Docs updated if behavior or setup changed (`README.md`, `go/README.md`, or `docs/` as needed)
- [x] No secrets or real `.env` values committed