### PR TITLE
feat(authz): implement T42 user authz resources listing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -50,3 +50,28 @@ When reviewing a PR, always review **all changed files** — not a partial subse
 - `make test` and `make lint` must pass.
 - No secrets or real `.env` values in the diff.
 - Docs updated if behavior or setup changed.
+
+## Repository workflow & Cursor-derived rules
+
+- **No unused code:** Do not add functions, methods, or interfaces that have no callers in the current codebase. If a reviewer (human or AI) suggests speculative code (e.g. "consider implementing X for future compatibility"), defer it to a tracked ticket and reference that ticket in the review thread and plan files (e.g. `// TODO(T36): ...`).
+- **Branching:** When starting work on a new ticket or task, create a topic branch from up-to-date `main` before making file changes. Follow the repo naming pattern (e.g. `author/prefix/description`, all lowercase). Verify with `git branch --show-current`; if on the wrong branch, stash, switch, create the branch, and pop.
+- **Git (AI default):** Do not run `git commit`, `git push`, or `gh pr create` on behalf of a user unless they explicitly ask you to. When proposing changes, provide a proposed commit message (subject + optional body) and a PR description that follows `.github/pull_request_template.md` (Summary, Ticket, Checklist) so the human can run the git/gh commands locally.
+- **Use `gh` for automation:** If the user asks you to automate GitHub operations, prefer the `gh` CLI over raw HTTP calls; when automation is not permitted, supply copy-paste snippets for maintainers.
+- **After substantive changes:** Update `go/README.md` (and root `README.md` if layout/entrypoints changed). If the change is user-visible and `CHANGELOG.md` exists, add an Unreleased entry. Run `make test` from the repository root (or `go test -race ./...` from `go/`) and `make lint` / `make cover` when configured.
+- **PR / review deferrals:** If a valid review comment (human or AI) will not be fixed in the current PR, reply on the thread that it will be addressed in `#… / Txx` and add a tracked note under the umbrella plan file (`plan/...`) so the follow-up is not lost.
+
+## Code Review Mode (Cursor → Copilot guidance)
+
+When asked to review a PR or diff, follow these steps:
+
+- Review every changed file line-by-line; do not skim or skip files.
+- Flag every issue you find; provide the concrete fix rather than marking it "acceptable".
+- For each issue, state: the file and line reference, what is wrong, and a concrete fix to apply.
+- Use this file (`.github/copilot-instructions.md`) and `.github/instructions/` as a checklist while reviewing.
+- Verify tests assert the *intended* behavior (not only the current behavior). Check for TOCTOU races, correct error classification (400 vs 404 vs 500), test determinism (avoid `time.Sleep`), goroutine synchronization, and resource leaks.
+- After the review, list any open Copilot/Cursor review comments from the PR and state whether each is addressed or still open.
+
+## PR ↔ Issue linking
+
+- In the PR description (or a commit on the branch), use `Fixes #123`, `Closes #123`, or `Resolves #123` to ensure the PR appears on the issue timeline and merging the PR auto-closes the issue when merged into the default branch. Use `Refs #123` or `See #123` for non-closing links. Place the reference in the Ticket section of the PR body when applicable.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,8 @@ Do not add functions, methods, or interfaces that have no callers in the current
 - In code or docs, reference work explicitly, e.g. `Fixes #123` or `// TODO(T36): ...` where **`T36`** points readers to the matching file under [`plan/`](plan/) (filename `T36-...`), not to a repo ticket registry.
 - **Prefer updating an existing open issue** when the follow-up fits that scope; avoid one new issue per tiny item unless it is genuinely separate work.
 
+- Temporary mask limitation: until a v2 migration, access masks are intentionally limited to the lower 63 bits to avoid signed-64 overflow when stored in SQLite. Track and discuss migrations or API validation in issue #67.
+
 ### Pull request / Copilot follow-ups
 
 If a review comment is correct but **out of scope for the current PR**, say on the thread that it will be handled in **#…** / **Txx**, and add a **note** to that umbrella’s [plan/](plan/) file (e.g. under Steps or Deliverables) so the item is scheduled and traceable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **T36 / #47:** API error responses no longer expose internal SQL/driver details. All error bodies use stable, database-agnostic messages (`resource not found`, `referenced entity does not exist or is still referenced`, `internal server error`, etc.). Full errors are logged server-side for operator diagnostics.
 
+- Temporary limitation: access masks are limited to the lower 63 bits (SQLite `INTEGER` is signed 64-bit and current storage casts to `int64`). This avoids overflow when clients use the most-significant unsigned bit. Enforce first-63-bits until v2 migration; tracked in [#67](https://github.com/DanyalTorabi/access-manager/issues/67).
+
 ### Changed
 
 - **T40 / #55:** `access-types` list default sort changed from `bit` to `title` for consistency with other entities. Clients relying on bit-order should sort client-side.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,13 @@ Provide **proposed** commit message and PR description text only. Do **not** run
 
 ## Pull requests
 
+### Issue / PR title format
+
+- Prefix issue and PR titles with the plan ticket identifier in square brackets when the work maps to a plan, for example: `[T47] API: normalize numeric parse errors and return stable 400`.
+- The `Tnn` identifier must match the corresponding plan file under `plan/phase-*/Tnn-...md` when applicable. Include a link to the plan file in the issue or PR body.
+- If no plan ticket applies, follow a short, imperative title (e.g. `ci: fix linting error`).
+
+
 ### Before you open a PR (self-review)
 
 Do a quick **reviewer pass** on your own diff (humans and AI assistants) before pushing or asking for review:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1432,6 +1432,16 @@ paths:
                       $ref: "#/components/schemas/UserAuthzResource"
                   meta:
                     $ref: "#/components/schemas/ListMeta"
+              example:
+                data:
+                  - resource_id: "11111111-1111-1111-1111-111111111111"
+                    effective_mask: "5"
+                meta:
+                  total: 1
+                  offset: 0
+                  limit: 20
+                  sort: "resource_id"
+                  order: "asc"
         "400":
           description: Bad request (invalid pagination params)
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -398,6 +398,17 @@ components:
             maximum: 9223372036854775807
           description: Individual permission masks (uint64); JSON numbers in SQLite-safe non-negative range.
 
+    UserAuthzResource:
+      type: object
+      required: [resource_id, effective_mask]
+      properties:
+        resource_id:
+          type: string
+          format: uuid
+        effective_mask:
+          type: string
+          description: Effective mask for this user/resource pair as decimal string.
+
 paths:
   /health:
     get:
@@ -1385,6 +1396,53 @@ paths:
           description: No content
         "404":
           description: Not found
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+
+  /api/v1/domains/{domainID}/users/{userID}/authz/resources:
+    parameters:
+      - $ref: "#/components/parameters/domainID"
+      - $ref: "#/components/parameters/userID"
+    get:
+      tags: [Authz]
+      summary: List resources where the user has effective access
+      description: |
+        Returns resources for which the user has any effective access via direct user grants and direct group membership grants.
+        Effective masks are returned as decimal strings.
+      parameters:
+        - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/limitParam"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/UserAuthzResource"
+                  meta:
+                    $ref: "#/components/schemas/ListMeta"
+        "400":
+          description: Bad request (invalid pagination params)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "404":
+          description: Domain or user not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
         "401":
           description: Unauthorized
           content:

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -408,6 +408,7 @@ components:
         effective_mask:
           type: string
           description: Effective mask for this user/resource pair as decimal string.
+          example: "5"
 
 paths:
   /health:

--- a/api/postman/access-manager.postman_collection.json
+++ b/api/postman/access-manager.postman_collection.json
@@ -164,6 +164,7 @@
     {"name": "Grant group permission", "request": {"method": "POST", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups/{{groupId}}/permissions/{{permissionId}}"}},
     {"name": "Authz check", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/authz/check?user_id={{userId}}&resource_id={{resourceId}}&access_bit=1"}},
     {"name": "Authz masks", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/authz/masks?user_id={{userId}}&resource_id={{resourceId}}"}},
+    {"name": "List user authz resources", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/authz/resources?offset=0&limit=20"}},
     {"name": "Revoke group permission", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups/{{groupId}}/permissions/{{permissionId}}"}},
     {"name": "Revoke user permission", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/permissions/{{permissionId}}"}},
     {"name": "Remove user from group", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/groups/{{groupId}}"}},

--- a/go/e2e/authz_test.go
+++ b/go/e2e/authz_test.go
@@ -131,6 +131,92 @@ func TestAuthz_revokeAndRecheck(t *testing.T) {
 	assertAuthzCheck(t, c, did, uid, rid, "0x1", false)
 }
 
+func TestAuthz_userResourcesList(t *testing.T) {
+	c := httpClient()
+	did := seedDomain(t, c, "authz-user-resources")
+	cleanupDelete(t, c, apiBase()+"/domains/"+did)
+
+	uid := seedUser(t, c, did, "u")
+	cleanupDelete(t, c, domainBase(did)+"/users/"+uid)
+	gid := seedGroup(t, c, did, "g")
+	cleanupDelete(t, c, domainBase(did)+"/groups/"+gid)
+
+	addMembership(t, c, did, uid, gid)
+	cleanupRevokeMembership(t, c, did, uid, gid)
+
+	ridA := seedResource(t, c, did, "a")
+	ridB := seedResource(t, c, did, "b")
+	ridC := seedResource(t, c, did, "c")
+	cleanupDelete(t, c, domainBase(did)+"/resources/"+ridA)
+	cleanupDelete(t, c, domainBase(did)+"/resources/"+ridB)
+	cleanupDelete(t, c, domainBase(did)+"/resources/"+ridC)
+
+	pUserA := seedPermission(t, c, did, "pUserA", ridA, "0x1")
+	pGroupA := seedPermission(t, c, did, "pGroupA", ridA, "0x4")
+	pGroupB := seedPermission(t, c, did, "pGroupB", ridB, "0x2")
+	pUserC1 := seedPermission(t, c, did, "pUserC1", ridC, "0x8")
+	pUserC2 := seedPermission(t, c, did, "pUserC2", ridC, "0x10")
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pUserA)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pGroupA)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pGroupB)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pUserC1)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pUserC2)
+
+	grantUserPerm(t, c, did, uid, pUserA)
+	grantGroupPerm(t, c, did, gid, pGroupA)
+	grantGroupPerm(t, c, did, gid, pGroupB)
+	grantUserPerm(t, c, did, uid, pUserC1)
+	grantUserPerm(t, c, did, uid, pUserC2)
+	cleanupRevokeUserPerm(t, c, did, uid, pUserA)
+	cleanupRevokeGroupPerm(t, c, did, gid, pGroupA)
+	cleanupRevokeGroupPerm(t, c, did, gid, pGroupB)
+	cleanupRevokeUserPerm(t, c, did, uid, pUserC1)
+	cleanupRevokeUserPerm(t, c, did, uid, pUserC2)
+
+	type authzResource struct {
+		ResourceID    string `json:"resource_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}
+
+	base := fmt.Sprintf("%s/users/%s/authz/resources", domainBase(did), uid)
+	env := mustList(t, c, base+"?offset=0&limit=10")
+	if env.Meta.Total != 3 {
+		t.Fatalf("total: want 3, got %d", env.Meta.Total)
+	}
+	var items []authzResource
+	if err := json.Unmarshal(env.Data, &items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("items len: want 3, got %d", len(items))
+	}
+	got := map[string]string{}
+	for _, it := range items {
+		got[it.ResourceID] = it.EffectiveMask
+	}
+	if got[ridA] != "5" {
+		t.Fatalf("ridA mask: want 5, got %q", got[ridA])
+	}
+	if got[ridB] != "2" {
+		t.Fatalf("ridB mask: want 2, got %q", got[ridB])
+	}
+	if got[ridC] != "24" {
+		t.Fatalf("ridC mask: want 24, got %q", got[ridC])
+	}
+
+	page := mustList(t, c, base+"?offset=1&limit=1")
+	if page.Meta.Total != 3 {
+		t.Fatalf("page total: want 3, got %d", page.Meta.Total)
+	}
+	var pageItems []authzResource
+	if err := json.Unmarshal(page.Data, &pageItems); err != nil {
+		t.Fatal(err)
+	}
+	if len(pageItems) != 1 {
+		t.Fatalf("page len: want 1, got %d", len(pageItems))
+	}
+}
+
 // TestAuthz_nestedGroupScaffold is a scaffold for nested-group inheritance (T2).
 // Current behaviour: grant to parent, user in child -> NOT inherited (flat
 // group model). When T2 lands, flip wantAllowed to true.

--- a/go/e2e/authz_test.go
+++ b/go/e2e/authz_test.go
@@ -215,6 +215,11 @@ func TestAuthz_userResourcesList(t *testing.T) {
 	if len(pageItems) != 1 {
 		t.Fatalf("page len: want 1, got %d", len(pageItems))
 	}
+	orderedIDs := []string{ridA, ridB, ridC}
+	sort.Strings(orderedIDs)
+	if pageItems[0].ResourceID != orderedIDs[1] {
+		t.Fatalf("page resource: want %s, got %s", orderedIDs[1], pageItems[0].ResourceID)
+	}
 }
 
 // TestAuthz_nestedGroupScaffold is a scaffold for nested-group inheritance (T2).

--- a/go/go.mod
+++ b/go/go.mod
@@ -2,7 +2,7 @@ module github.com/dtorabi/access-manager
 
 go 1.25.0
 
-toolchain go1.25.8
+toolchain go1.25.9
 
 require (
 	github.com/go-chi/chi/v5 v5.2.5

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -964,6 +964,9 @@ func publicInvalidInputMsg(err error) string {
 	full := err.Error()
 	const prefix = "store: invalid input: "
 	if after, ok := strings.CutPrefix(full, prefix); ok && after != "" {
+		if strings.Contains(after, "mask value exceeds signed 64-bit range") {
+			return "mask value must be within signed 64-bit range"
+		}
 		return after
 	}
 	return "invalid request"

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -785,14 +785,16 @@ type userAuthzResourceResponse struct {
 	EffectiveMask string `json:"effective_mask"`
 }
 
+const userAuthzResourcesSortField = "resource_id"
+
 func (s *Server) userAuthzResources(w http.ResponseWriter, r *http.Request) {
-	opts, err := parseListOpts(r)
+	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
 	// This endpoint only exposes pagination and uses a fixed stable ordering.
-	opts.Sort = "resource_id"
+	opts.Sort = userAuthzResourcesSortField
 	opts.Order = store.OrderAsc
 
 	domainID := chi.URLParam(r, "domainID")
@@ -1024,6 +1026,21 @@ func parseListOpts(r *http.Request) (store.ListOpts, error) {
 			}
 		}
 	}
+	return opts, nil
+}
+
+func parseOffsetLimitOpts(r *http.Request) (store.ListOpts, error) {
+	opts, err := parseListOpts(r)
+	if err != nil {
+		return opts, err
+	}
+	q := r.URL.Query()
+	if strings.TrimSpace(q.Get("search")) != "" || strings.TrimSpace(q.Get("search_type")) != "" ||
+		strings.TrimSpace(q.Get("sort")) != "" || strings.TrimSpace(q.Get("order")) != "" {
+		return opts, errors.New("only limit and offset are supported")
+	}
+	opts.Search = ""
+	opts.SearchType = ""
 	return opts, nil
 }
 

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -96,6 +96,7 @@ func (s *Server) Router(reg prometheus.Registerer, gather prometheus.Gatherer) c
 
 		r.Post("/domains/{domainID}/users/{userID}/permissions/{permissionID}", s.grantUserPermission)
 		r.Delete("/domains/{domainID}/users/{userID}/permissions/{permissionID}", s.revokeUserPermission)
+		r.Get("/domains/{domainID}/users/{userID}/authz/resources", s.userAuthzResources)
 
 		r.Post("/domains/{domainID}/groups/{groupID}/permissions/{permissionID}", s.grantGroupPermission)
 		r.Delete("/domains/{domainID}/groups/{groupID}/permissions/{permissionID}", s.revokeGroupPermission)
@@ -129,15 +130,15 @@ type accessTypePatchBody struct {
 }
 
 type permissionPatchBody struct {
-	Title       *string `json:"title"`
-	ResourceID  *string `json:"resource_id"`
-	AccessMask  *string `json:"access_mask"`
+	Title      *string `json:"title"`
+	ResourceID *string `json:"resource_id"`
+	AccessMask *string `json:"access_mask"`
 }
 
 type permissionBody struct {
-	Title       string `json:"title"`
-	ResourceID  string `json:"resource_id"`
-	AccessMask  string `json:"access_mask"` // decimal or 0x hex
+	Title      string `json:"title"`
+	ResourceID string `json:"resource_id"`
+	AccessMask string `json:"access_mask"` // decimal or 0x hex
 }
 
 type accessTypeBody struct {
@@ -320,8 +321,8 @@ func (s *Server) userDelete(w http.ResponseWriter, r *http.Request) {
 func (s *Server) groupCreate(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	var b struct {
-		Title           string  `json:"title"`
-		ParentGroupID   *string `json:"parent_group_id"`
+		Title         string  `json:"title"`
+		ParentGroupID *string `json:"parent_group_id"`
 	}
 	if !readJSON(w, r, &b) {
 		return
@@ -777,6 +778,38 @@ func (s *Server) revokeUserPermission(w http.ResponseWriter, r *http.Request) {
 	}
 	logger.Audit(r.Context(), "revoke_user_permission", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("permission_id", pid))
 	w.WriteHeader(http.StatusNoContent)
+}
+
+type userAuthzResourceResponse struct {
+	ResourceID    string `json:"resource_id"`
+	EffectiveMask string `json:"effective_mask"`
+}
+
+func (s *Server) userAuthzResources(w http.ResponseWriter, r *http.Request) {
+	opts, err := parseListOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	// This endpoint only exposes pagination and uses a fixed stable ordering.
+	opts.Sort = "resource_id"
+	opts.Order = store.OrderAsc
+
+	domainID := chi.URLParam(r, "domainID")
+	uid := chi.URLParam(r, "userID")
+	list, total, err := s.Store.UserAuthzResourcesList(r.Context(), domainID, uid, opts)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	resp := make([]userAuthzResourceResponse, 0, len(list))
+	for _, it := range list {
+		resp = append(resp, userAuthzResourceResponse{
+			ResourceID:    it.ResourceID,
+			EffectiveMask: strconv.FormatUint(it.EffectiveMask, 10),
+		})
+	}
+	writeList(w, resp, total, opts)
 }
 
 func (s *Server) grantGroupPermission(w http.ResponseWriter, r *http.Request) {

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -1030,17 +1030,43 @@ func parseListOpts(r *http.Request) (store.ListOpts, error) {
 }
 
 func parseOffsetLimitOpts(r *http.Request) (store.ListOpts, error) {
-	opts, err := parseListOpts(r)
-	if err != nil {
-		return opts, err
-	}
+	opts := store.ListOpts{Offset: 0, Limit: store.DefaultLimit}
 	q := r.URL.Query()
-	if strings.TrimSpace(q.Get("search")) != "" || strings.TrimSpace(q.Get("search_type")) != "" ||
-		strings.TrimSpace(q.Get("sort")) != "" || strings.TrimSpace(q.Get("order")) != "" {
+	if _, ok := q["search"]; ok {
 		return opts, errors.New("only limit and offset are supported")
 	}
-	opts.Search = ""
-	opts.SearchType = ""
+	if _, ok := q["search_type"]; ok {
+		return opts, errors.New("only limit and offset are supported")
+	}
+	if _, ok := q["sort"]; ok {
+		return opts, errors.New("only limit and offset are supported")
+	}
+	if _, ok := q["order"]; ok {
+		return opts, errors.New("only limit and offset are supported")
+	}
+	if v := q.Get("offset"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return opts, errors.New("offset must be an integer")
+		}
+		if n < 0 {
+			return opts, errors.New("offset must not be negative")
+		}
+		opts.Offset = n
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return opts, errors.New("limit must be an integer")
+		}
+		if n < 1 {
+			n = 1
+		}
+		if n > store.MaxLimit {
+			n = store.MaxLimit
+		}
+		opts.Limit = n
+	}
 	return opts, nil
 }
 

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -587,6 +587,31 @@ func TestAPI_userAuthzResources_unsupportedQueryParams(t *testing.T) {
 		b, _ := io.ReadAll(res.Body)
 		t.Fatalf("unsupported params: want 400, got %d: %s", res.StatusCode, b)
 	}
+	var out map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["error"] != "only limit and offset are supported" {
+		t.Fatalf("unexpected error message: %q", out["error"])
+	}
+
+	longSearch := strings.Repeat("x", 300)
+	resLong, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/users/" + uid + "/authz/resources?search=" + longSearch)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resLong.Body.Close() }()
+	if resLong.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(resLong.Body)
+		t.Fatalf("unsupported long search: want 400, got %d: %s", resLong.StatusCode, b)
+	}
+	var outLong map[string]string
+	if err := json.NewDecoder(resLong.Body).Decode(&outLong); err != nil {
+		t.Fatal(err)
+	}
+	if outLong["error"] != "only limit and offset are supported" {
+		t.Fatalf("unexpected long-search error message: %q", outLong["error"])
+	}
 }
 
 func TestAPI_userAuthzResources_notFound(t *testing.T) {

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -435,6 +435,163 @@ func TestAPI_authzMasks_validation(t *testing.T) {
 	}
 }
 
+func TestAPI_userAuthzResources_integration(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+
+	domainID := uuid.NewString()
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	ridA := uuid.NewString()
+	ridB := uuid.NewString()
+	ridC := uuid.NewString()
+
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	for _, rid := range []string{ridA, ridB, ridC} {
+		if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r" + rid}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pUserA := uuid.NewString()
+	pGroupA := uuid.NewString()
+	pGroupB := uuid.NewString()
+	pUserC1 := uuid.NewString()
+	pUserC2 := uuid.NewString()
+
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pUserA, DomainID: domainID, Title: "pUserA", ResourceID: ridA, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pGroupA, DomainID: domainID, Title: "pGroupA", ResourceID: ridA, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pGroupB, DomainID: domainID, Title: "pGroupB", ResourceID: ridB, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pUserC1, DomainID: domainID, Title: "pUserC1", ResourceID: ridC, AccessMask: 0x8}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pUserC2, DomainID: domainID, Title: "pUserC2", ResourceID: ridC, AccessMask: 0x10}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := st.GrantUserPermission(ctx, domainID, uid, pUserA); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantGroupPermission(ctx, domainID, gid, pGroupA); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantGroupPermission(ctx, domainID, gid, pGroupB); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantUserPermission(ctx, domainID, uid, pUserC1); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantUserPermission(ctx, domainID, uid, pUserC2); err != nil {
+		t.Fatal(err)
+	}
+
+	base := ts.URL + "/api/v1/domains/" + domainID + "/users/" + uid + "/authz/resources"
+
+	res, err := http.Get(base + "?offset=0&limit=10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[struct {
+		ResourceID    string `json:"resource_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Meta.Total != 3 {
+		t.Fatalf("total: want 3, got %d", env.Meta.Total)
+	}
+	if len(env.Data) != 3 {
+		t.Fatalf("len: want 3, got %d", len(env.Data))
+	}
+	gotMasks := map[string]string{}
+	for _, it := range env.Data {
+		gotMasks[it.ResourceID] = it.EffectiveMask
+	}
+	if gotMasks[ridA] != "5" {
+		t.Fatalf("ridA mask: want 5, got %q", gotMasks[ridA])
+	}
+	if gotMasks[ridB] != "2" {
+		t.Fatalf("ridB mask: want 2, got %q", gotMasks[ridB])
+	}
+	if gotMasks[ridC] != "24" {
+		t.Fatalf("ridC mask: want 24, got %q", gotMasks[ridC])
+	}
+
+	resPage, err := http.Get(base + "?offset=1&limit=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resPage.Body.Close() }()
+	if resPage.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resPage.Body)
+		t.Fatalf("page status %d: %s", resPage.StatusCode, b)
+	}
+	var page listResponse[struct {
+		ResourceID    string `json:"resource_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}]
+	if err := json.NewDecoder(resPage.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	if page.Meta.Total != 3 || len(page.Data) != 1 {
+		t.Fatalf("page total=%d len=%d", page.Meta.Total, len(page.Data))
+	}
+}
+
+func TestAPI_userAuthzResources_notFound(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+	domainID := uuid.NewString()
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := st.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+
+	resUnknownDomain, err := http.Get(ts.URL + "/api/v1/domains/" + uuid.NewString() + "/users/" + uid + "/authz/resources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resUnknownDomain.Body.Close() }()
+	if resUnknownDomain.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown domain: want 404, got %d", resUnknownDomain.StatusCode)
+	}
+
+	resUnknownUser, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/users/" + uuid.NewString() + "/authz/resources")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resUnknownUser.Body.Close() }()
+	if resUnknownUser.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown user: want 404, got %d", resUnknownUser.StatusCode)
+	}
+}
+
 func TestAPI_userList_empty(t *testing.T) {
 	ts, _ := newTestAPI(t)
 	var dom store.Domain
@@ -1892,6 +2049,7 @@ func TestAPI_storeErrors(t *testing.T) {
 		{"groupSetParent", http.MethodPatch, "/api/v1/domains/" + domID + "/groups/" + groupID + "/parent", `{"parent_group_id":"` + uuid.NewString() + `"}`, 500},
 		{"removeUserFromGroup", http.MethodDelete, "/api/v1/domains/" + domID + "/users/" + userID + "/groups/" + groupID, "", 500},
 		{"revokeUserPerm", http.MethodDelete, "/api/v1/domains/" + domID + "/users/" + userID + "/permissions/" + permID, "", 500},
+		{"userAuthzResources", http.MethodGet, "/api/v1/domains/" + domID + "/users/" + userID + "/authz/resources", "", 500},
 		{"revokeGroupPerm", http.MethodDelete, "/api/v1/domains/" + domID + "/groups/" + groupID + "/permissions/" + permID, "", 500},
 		{"authzCheck", http.MethodGet, "/api/v1/domains/" + domID + "/authz/check?user_id=" + userID + "&resource_id=" + resourceID + "&access_bit=0x1", "", 500},
 		{"authzMasks", http.MethodGet, "/api/v1/domains/" + domID + "/authz/masks?user_id=" + userID + "&resource_id=" + resourceID, "", 500},

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -1970,6 +1970,7 @@ func TestWriteStoreErr_allCases(t *testing.T) {
 		{"fk violation", store.ErrFKViolation, http.StatusBadRequest, "referenced entity does not exist or is still referenced"},
 		{"invalid input", store.ErrInvalidInput, http.StatusBadRequest, "invalid request"},
 		{"invalid input detail", fmt.Errorf("%w: cycle detected in group parent chain", store.ErrInvalidInput), http.StatusBadRequest, "cycle detected in group parent chain"},
+		{"invalid input mask range", fmt.Errorf("%w: mask value exceeds signed 64-bit range", store.ErrInvalidInput), http.StatusBadRequest, "mask value must be within signed 64-bit range"},
 		{"conflict", store.ErrConflict, http.StatusConflict, "resource already exists"},
 		{"generic", fmt.Errorf("boom"), http.StatusInternalServerError, "internal server error"},
 	}

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -558,6 +559,33 @@ func TestAPI_userAuthzResources_integration(t *testing.T) {
 	}
 	if page.Meta.Total != 3 || len(page.Data) != 1 {
 		t.Fatalf("page total=%d len=%d", page.Meta.Total, len(page.Data))
+	}
+	orderedIDs := []string{ridA, ridB, ridC}
+	sort.Strings(orderedIDs)
+	if page.Data[0].ResourceID != orderedIDs[1] {
+		t.Fatalf("page resource: want %s, got %s", orderedIDs[1], page.Data[0].ResourceID)
+	}
+}
+
+func TestAPI_userAuthzResources_unsupportedQueryParams(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+	domainID := uuid.NewString()
+	uid := uuid.NewString()
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/users/" + uid + "/authz/resources?search=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("unsupported params: want 400, got %d: %s", res.StatusCode, b)
 	}
 }
 

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -18,7 +18,7 @@ const (
 	envHTTPAddr          = "HTTP_ADDR"
 	envMigrationsDir      = "MIGRATIONS_DIR"
 	envShutdownTimeoutSec = "SHUTDOWN_TIMEOUT_SECONDS"
-	envAPIBearerToken     = "API_BEARER_TOKEN"
+	envAPIBearerToken     = "API_BEARER_TOKEN" // #nosec G101: environment variable name, not a hardcoded secret
 )
 
 // fileShape matches config.example.yaml (snake_case keys).
@@ -55,7 +55,11 @@ func Load() (Config, error) {
 
 	path := strings.TrimSpace(os.Getenv(envConfigPath))
 	if path != "" {
-		b, err := os.ReadFile(path)
+		// Reading configuration file at a path supplied by the environment is
+		// expected (operator-provided). Validate presence but do not attempt
+		// to enforce path restrictions here. Suppress gosec G304 as this is
+		// an explicit config file read under operator control.
+		b, err := os.ReadFile(path) // #nosec G304
 		if err != nil {
 			return Config{}, fmt.Errorf("config: read %s: %w", path, err)
 		}

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -131,7 +131,7 @@ func TestLoad_apiBearerTokenYAMLTrimmed(t *testing.T) {
 	path := filepath.Join(dir, "cfg.yaml")
 	content := `
 database_driver: sqlite
-database_url: "file::memory:?cache=shared"
+database_url: "file::memory"
 http_addr: "127.0.0.1:8080"
 migrations_dir: migrations/sqlite
 api_bearer_token: "  yaml-token  "

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -131,7 +131,7 @@ func TestLoad_apiBearerTokenYAMLTrimmed(t *testing.T) {
 	path := filepath.Join(dir, "cfg.yaml")
 	content := `
 database_driver: sqlite
-database_url: "file::memory"
+database_url: "file::memory:"
 http_addr: "127.0.0.1:8080"
 migrations_dir: migrations/sqlite
 api_bearer_token: "  yaml-token  "

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -131,7 +131,7 @@ func TestLoad_apiBearerTokenYAMLTrimmed(t *testing.T) {
 	path := filepath.Join(dir, "cfg.yaml")
 	content := `
 database_driver: sqlite
-database_url: "file::memory:"
+database_url: "file::memory:?cache=shared"
 http_addr: "127.0.0.1:8080"
 migrations_dir: migrations/sqlite
 api_bearer_token: "  yaml-token  "

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -906,7 +906,12 @@ func (s *Store) UserAuthzResourcesList(ctx context.Context, domainID, userID str
 	}
 
 	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(resourceIDs)), ",")
-	maskSQL := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL
+	// Safe concatenation: `placeholders` is derived from the controlled
+	// `resourceIDs` slice length (no user input) and
+	// `userEffectivePermissionPredicateSQL` is a constant. Parameters are
+	// passed separately via `maskArgs`, so this is not vulnerable to SQL
+	// injection. Suppress gosec G202 for this deliberate construction.
+	maskSQL := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL //nolint:gosec
 	maskArgs := make([]any, 0, 1+len(resourceIDs)+len(predicateArgs))
 	maskArgs = append(maskArgs, domainID)
 	for _, resourceID := range resourceIDs {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -52,11 +52,29 @@ func wrapConstraintError(err error) error {
 	return err
 }
 
-// maskToSQL stores masks in SQLite INTEGER (signed 64-bit).
-// Values are expected to remain in [0, MaxInt64].
-func maskToSQL(m uint64) int64 { return int64(m) }
+const maxInt64 = 1<<63 - 1
 
-func maskFromSQL(v int64) uint64 { return uint64(v) }
+// maskToSQL converts a uint64 mask into a signed int64 suitable for SQLite
+// storage. Returns an error if the value cannot be represented in signed
+// 64-bit (i.e. uses bit 63). Callers should validate input and return a
+// client-facing validation error when necessary.
+func maskToSQL(m uint64) (int64, error) {
+	if m > uint64(maxInt64) {
+		return 0, fmt.Errorf("%w: mask value exceeds signed 64-bit range", store.ErrInvalidInput)
+	}
+	return int64(m), nil
+}
+
+// maskFromSQL converts an int64 value read from SQLite into uint64. If a
+// negative value is encountered, log a warning and treat it as zero to avoid
+// propagating unexpected large unsigned values.
+func maskFromSQL(v int64) uint64 {
+	if v < 0 {
+		slog.Warn("negative mask value read from DB; treating as 0", "value", v)
+		return 0
+	}
+	return uint64(v)
+}
 
 var likeEscaper = strings.NewReplacer(`\`, `\\`, `%`, `\%`, `_`, `\_`)
 
@@ -162,7 +180,7 @@ func (s *Store) DomainList(ctx context.Context, opts store.ListOpts) ([]store.Do
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, title FROM domains`+where+orderByClause(opts.Sort, opts.Order, domainSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
+		`SELECT id, title FROM domains`+where+orderByClause(opts.Sort, opts.Order, domainSortColumns, "title")+` LIMIT ? OFFSET ?`, // #nosec G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -240,7 +258,7 @@ func (s *Store) UserList(ctx context.Context, domainID string, opts store.ListOp
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title FROM users `+where+orderByClause(opts.Sort, opts.Order, userSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
+		`SELECT id, domain_id, title FROM users `+where+orderByClause(opts.Sort, opts.Order, userSortColumns, "title")+` LIMIT ? OFFSET ?`, // #nosec G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -332,7 +350,7 @@ func (s *Store) GroupList(ctx context.Context, domainID string, opts store.Group
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, parent_group_id FROM groups `+where+orderByClause(opts.Sort, opts.Order, groupSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
+		`SELECT id, domain_id, title, parent_group_id FROM groups `+where+orderByClause(opts.Sort, opts.Order, groupSortColumns, "title")+` LIMIT ? OFFSET ?`, // #nosec G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -496,7 +514,7 @@ func (s *Store) ResourceList(ctx context.Context, domainID string, opts store.Li
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title FROM resources `+where+orderByClause(opts.Sort, opts.Order, resourceSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
+		`SELECT id, domain_id, title FROM resources `+where+orderByClause(opts.Sort, opts.Order, resourceSortColumns, "title")+` LIMIT ? OFFSET ?`, // #nosec G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -542,8 +560,12 @@ func (s *Store) ResourcePatch(ctx context.Context, domainID, id string, title *s
 }
 
 func (s *Store) AccessTypeCreate(ctx context.Context, a *store.AccessType) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO access_types (id, domain_id, title, bit) VALUES (?, ?, ?, ?)`,
-		a.ID, a.DomainID, a.Title, maskToSQL(a.Bit))
+	bitVal, err := maskToSQL(a.Bit)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO access_types (id, domain_id, title, bit) VALUES (?, ?, ?, ?)`,
+		a.ID, a.DomainID, a.Title, bitVal)
 	return wrapConstraintError(err)
 }
 
@@ -562,7 +584,7 @@ func (s *Store) AccessTypeList(ctx context.Context, domainID string, opts store.
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, bit FROM access_types `+where+orderByClause(opts.Sort, opts.Order, accessTypeSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
+		`SELECT id, domain_id, title, bit FROM access_types `+where+orderByClause(opts.Sort, opts.Order, accessTypeSortColumns, "title")+` LIMIT ? OFFSET ?`, // #nosec G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -636,8 +658,12 @@ func (s *Store) AccessTypePatch(ctx context.Context, domainID, id string, p stor
 	if p.Bit != nil {
 		bit = *p.Bit
 	}
+	bitVal, err := maskToSQL(bit)
+	if err != nil {
+		return nil, err
+	}
 	if _, err := tx.ExecContext(ctx, `UPDATE access_types SET title = ?, bit = ? WHERE id = ? AND domain_id = ?`,
-		title, maskToSQL(bit), id, domainID); err != nil {
+		title, bitVal, id, domainID); err != nil {
 		return nil, wrapConstraintError(err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -647,8 +673,12 @@ func (s *Store) AccessTypePatch(ctx context.Context, domainID, id string, p stor
 }
 
 func (s *Store) PermissionCreate(ctx context.Context, p *store.Permission) error {
-	_, err := s.db.ExecContext(ctx, `INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
-		p.ID, p.DomainID, p.Title, p.ResourceID, maskToSQL(p.AccessMask))
+	maskVal, err := maskToSQL(p.AccessMask)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
+		p.ID, p.DomainID, p.Title, p.ResourceID, maskVal)
 	return wrapConstraintError(err)
 }
 
@@ -685,7 +715,7 @@ func (s *Store) PermissionList(ctx context.Context, domainID string, opts store.
 		return nil, 0, err
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, domain_id, title, resource_id, access_mask FROM permissions `+where+orderByClause(opts.Sort, opts.Order, permissionSortColumns, "title")+` LIMIT ? OFFSET ?`, //nolint:gosec // G202: ORDER BY column from allow-list, not user input
+		`SELECT id, domain_id, title, resource_id, access_mask FROM permissions `+where+orderByClause(opts.Sort, opts.Order, permissionSortColumns, "title")+` LIMIT ? OFFSET ?`, // #nosec G202: ORDER BY column from allow-list, not user input
 		append(args, opts.Limit, opts.Offset)...)
 	if err != nil {
 		return nil, 0, err
@@ -756,8 +786,12 @@ func (s *Store) PermissionPatch(ctx context.Context, domainID, id string, p stor
 	if p.AccessMask != nil {
 		mask = *p.AccessMask
 	}
+	maskVal, err := maskToSQL(mask)
+	if err != nil {
+		return nil, err
+	}
 	if _, err := tx.ExecContext(ctx, `UPDATE permissions SET title = ?, resource_id = ?, access_mask = ? WHERE id = ? AND domain_id = ?`,
-		title, resourceID, maskToSQL(mask), id, domainID); err != nil {
+		title, resourceID, maskVal, id, domainID); err != nil {
 		return nil, wrapConstraintError(err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -911,7 +945,12 @@ func (s *Store) UserAuthzResourcesList(ctx context.Context, domainID, userID str
 	// `userEffectivePermissionPredicateSQL` is a constant. Parameters are
 	// passed separately via `maskArgs`, so this is not vulnerable to SQL
 	// injection. Suppress gosec G202 for this deliberate construction.
-	maskSQL := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL //nolint:gosec
+	// Safe concatenation: `placeholders` is derived from the controlled
+	// `resourceIDs` slice length (no user input) and
+	// `userEffectivePermissionPredicateSQL` is a constant. Parameters are
+	// passed separately via `maskArgs`, so this is not vulnerable to SQL
+	// injection. Suppress gosec G202 for this deliberate construction.
+	maskSQL := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL // #nosec G202
 	maskArgs := make([]any, 0, 1+len(resourceIDs)+len(predicateArgs))
 	maskArgs = append(maskArgs, domainID)
 	for _, resourceID := range resourceIDs {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -880,7 +880,7 @@ WHERE p.domain_id = ? AND p.resource_id = ?
 
 const userAuthzResourcesBaseSQL = `
 FROM permissions p
-WHERE p.domain_id = ?
+WHERE p.domain_id = ? AND p.access_mask > 0
 ` + userEffectivePermissionPredicateSQL
 
 func userEffectivePermissionArgs(domainID, userID string) []any {
@@ -902,7 +902,7 @@ func buildUserAuthzMaskQueryAndArgs(domainID string, resourceIDs []string, predi
 	if err != nil {
 		return "", nil, err
 	}
-	query := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL // #nosec G202
+	query := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `) AND p.access_mask > 0` + userEffectivePermissionPredicateSQL // #nosec G202
 	args := make([]any, 0, 1+len(resourceIDs)+len(predicateArgs))
 	args = append(args, domainID)
 	for _, resourceID := range resourceIDs {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -23,6 +23,8 @@ func New(db *sql.DB) *Store {
 	return &Store{db: db}
 }
 
+var _ store.Store = (*Store)(nil)
+
 func constraintCode(err error) int {
 	var e *sqlite.Error
 	if errors.As(err, &e) {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -885,6 +885,31 @@ func userEffectivePermissionArgs(domainID, userID string) []any {
 	return []any{domainID, userID, userID, domainID, domainID}
 }
 
+func inPlaceholders(n int) (string, error) {
+	if n <= 0 {
+		return "", fmt.Errorf("in placeholders: n must be > 0")
+	}
+	return strings.TrimSuffix(strings.Repeat("?,", n), ","), nil
+}
+
+// buildUserAuthzMaskQueryAndArgs builds the batched mask query used by
+// UserAuthzResourcesList and returns the SQL and args in the exact placeholder
+// order to avoid call-site mistakes.
+func buildUserAuthzMaskQueryAndArgs(domainID string, resourceIDs []string, predicateArgs []any) (string, []any, error) {
+	placeholders, err := inPlaceholders(len(resourceIDs))
+	if err != nil {
+		return "", nil, err
+	}
+	query := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL // #nosec G202
+	args := make([]any, 0, 1+len(resourceIDs)+len(predicateArgs))
+	args = append(args, domainID)
+	for _, resourceID := range resourceIDs {
+		args = append(args, resourceID)
+	}
+	args = append(args, predicateArgs...)
+	return query, args, nil
+}
+
 func (s *Store) UserAuthzResourcesList(ctx context.Context, domainID, userID string, opts store.ListOpts) ([]store.UserAuthzResource, int64, error) {
 	opts = store.SanitizeListOpts(opts)
 
@@ -939,24 +964,10 @@ func (s *Store) UserAuthzResourcesList(ctx context.Context, domainID, userID str
 		return []store.UserAuthzResource{}, total, nil
 	}
 
-	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(resourceIDs)), ",")
-	// Safe concatenation: `placeholders` is derived from the controlled
-	// `resourceIDs` slice length (no user input) and
-	// `userEffectivePermissionPredicateSQL` is a constant. Parameters are
-	// passed separately via `maskArgs`, so this is not vulnerable to SQL
-	// injection. Suppress gosec G202 for this deliberate construction.
-	// Safe concatenation: `placeholders` is derived from the controlled
-	// `resourceIDs` slice length (no user input) and
-	// `userEffectivePermissionPredicateSQL` is a constant. Parameters are
-	// passed separately via `maskArgs`, so this is not vulnerable to SQL
-	// injection. Suppress gosec G202 for this deliberate construction.
-	maskSQL := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL // #nosec G202
-	maskArgs := make([]any, 0, 1+len(resourceIDs)+len(predicateArgs))
-	maskArgs = append(maskArgs, domainID)
-	for _, resourceID := range resourceIDs {
-		maskArgs = append(maskArgs, resourceID)
+	maskSQL, maskArgs, err := buildUserAuthzMaskQueryAndArgs(domainID, resourceIDs, predicateArgs)
+	if err != nil {
+		return nil, 0, err
 	}
-	maskArgs = append(maskArgs, predicateArgs...)
 
 	maskRows, err := s.db.QueryContext(ctx, maskSQL, maskArgs...)
 	if err != nil {

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -837,6 +837,79 @@ AND (
 )
 `
 
+const userAuthzResourcesBaseSQL = `
+FROM permissions p
+WHERE p.domain_id = ?
+AND (
+	EXISTS (
+		SELECT 1 FROM user_permissions up
+		WHERE up.permission_id = p.id AND up.domain_id = ? AND up.user_id = ?
+	)
+	OR EXISTS (
+		SELECT 1 FROM group_permissions gp
+		INNER JOIN group_members gm ON gm.group_id = gp.group_id AND gm.user_id = ?
+		WHERE gp.permission_id = p.id AND gp.domain_id = ? AND gm.domain_id = ?
+	)
+)
+`
+
+func (s *Store) UserAuthzResourcesList(ctx context.Context, domainID, userID string, opts store.ListOpts) ([]store.UserAuthzResource, int64, error) {
+	opts = store.SanitizeListOpts(opts)
+
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM domains WHERE id = ?`, domainID).Scan(new(int)); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, store.ErrNotFound
+		}
+		return nil, 0, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM users WHERE id = ? AND domain_id = ?`, userID, domainID).Scan(new(int)); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, store.ErrNotFound
+		}
+		return nil, 0, err
+	}
+
+	args := []any{domainID, domainID, userID, userID, domainID, domainID}
+	var total int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT p.resource_id) `+userAuthzResourcesBaseSQL, args...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT p.resource_id `+userAuthzResourcesBaseSQL+` ORDER BY p.resource_id ASC LIMIT ? OFFSET ?`,
+		append(args, opts.Limit, opts.Offset)...,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	var resourceIDs []string
+	for rows.Next() {
+		var resourceID string
+		if err := rows.Scan(&resourceID); err != nil {
+			return nil, 0, err
+		}
+		resourceIDs = append(resourceIDs, resourceID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, err
+	}
+
+	list := make([]store.UserAuthzResource, 0, len(resourceIDs))
+	for _, resourceID := range resourceIDs {
+		mask, err := s.EffectiveMask(ctx, domainID, userID, resourceID)
+		if err != nil {
+			return nil, 0, err
+		}
+		list = append(list, store.UserAuthzResource{ResourceID: resourceID, EffectiveMask: mask})
+	}
+	return list, total, nil
+}
+
 func (s *Store) PermissionMasksForUserResource(ctx context.Context, domainID, userID, resourceID string) ([]uint64, error) {
 	rows, err := s.db.QueryContext(ctx, effectiveMaskSQL,
 		domainID, resourceID,

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -52,6 +52,8 @@ func wrapConstraintError(err error) error {
 	return err
 }
 
+// maskToSQL stores masks in SQLite INTEGER (signed 64-bit).
+// Values are expected to remain in [0, MaxInt64].
 func maskToSQL(m uint64) int64 { return int64(m) }
 
 func maskFromSQL(v int64) uint64 { return uint64(v) }
@@ -821,9 +823,7 @@ func (s *Store) RevokeGroupPermission(ctx context.Context, domainID, groupID, pe
 	return nil
 }
 
-const effectiveMaskSQL = `
-SELECT p.access_mask FROM permissions p
-WHERE p.domain_id = ? AND p.resource_id = ?
+const userEffectivePermissionPredicateSQL = `
 AND (
 	EXISTS (
 		SELECT 1 FROM user_permissions up
@@ -836,86 +836,116 @@ AND (
 	)
 )
 `
+
+const effectiveMaskSQL = `
+SELECT p.access_mask FROM permissions p
+WHERE p.domain_id = ? AND p.resource_id = ?
+` + userEffectivePermissionPredicateSQL
 
 const userAuthzResourcesBaseSQL = `
 FROM permissions p
 WHERE p.domain_id = ?
-AND (
-	EXISTS (
-		SELECT 1 FROM user_permissions up
-		WHERE up.permission_id = p.id AND up.domain_id = ? AND up.user_id = ?
-	)
-	OR EXISTS (
-		SELECT 1 FROM group_permissions gp
-		INNER JOIN group_members gm ON gm.group_id = gp.group_id AND gm.user_id = ?
-		WHERE gp.permission_id = p.id AND gp.domain_id = ? AND gm.domain_id = ?
-	)
-)
-`
+` + userEffectivePermissionPredicateSQL
+
+func userEffectivePermissionArgs(domainID, userID string) []any {
+	return []any{domainID, userID, userID, domainID, domainID}
+}
 
 func (s *Store) UserAuthzResourcesList(ctx context.Context, domainID, userID string, opts store.ListOpts) ([]store.UserAuthzResource, int64, error) {
 	opts = store.SanitizeListOpts(opts)
 
-	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM domains WHERE id = ?`, domainID).Scan(new(int)); err != nil {
+	var exists int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM domains WHERE id = ?`, domainID).Scan(&exists); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, 0, store.ErrNotFound
 		}
 		return nil, 0, err
 	}
-	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM users WHERE id = ? AND domain_id = ?`, userID, domainID).Scan(new(int)); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM users WHERE id = ? AND domain_id = ?`, userID, domainID).Scan(&exists); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, 0, store.ErrNotFound
 		}
 		return nil, 0, err
 	}
 
-	args := []any{domainID, domainID, userID, userID, domainID, domainID}
+	predicateArgs := userEffectivePermissionArgs(domainID, userID)
+	countArgs := append([]any{domainID}, predicateArgs...)
 	var total int64
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT p.resource_id) `+userAuthzResourcesBaseSQL, args...).Scan(&total); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT p.resource_id) `+userAuthzResourcesBaseSQL, countArgs...).Scan(&total); err != nil {
 		return nil, 0, err
 	}
 
+	listArgs := append([]any{domainID}, predicateArgs...)
+	listArgs = append(listArgs, opts.Limit, opts.Offset)
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT DISTINCT p.resource_id `+userAuthzResourcesBaseSQL+` ORDER BY p.resource_id ASC LIMIT ? OFFSET ?`,
-		append(args, opts.Limit, opts.Offset)...,
+		listArgs...,
 	)
 	if err != nil {
 		return nil, 0, err
 	}
-	defer func() { _ = rows.Close() }()
 
 	var resourceIDs []string
 	for rows.Next() {
 		var resourceID string
 		if err := rows.Scan(&resourceID); err != nil {
+			_ = rows.Close()
 			return nil, 0, err
 		}
 		resourceIDs = append(resourceIDs, resourceID)
 	}
 	if err := rows.Err(); err != nil {
+		_ = rows.Close()
 		return nil, 0, err
 	}
 	if err := rows.Close(); err != nil {
 		return nil, 0, err
 	}
+	if len(resourceIDs) == 0 {
+		return []store.UserAuthzResource{}, total, nil
+	}
+
+	placeholders := strings.TrimSuffix(strings.Repeat("?,", len(resourceIDs)), ",")
+	maskSQL := `SELECT p.resource_id, p.access_mask FROM permissions p WHERE p.domain_id = ? AND p.resource_id IN (` + placeholders + `)` + userEffectivePermissionPredicateSQL
+	maskArgs := make([]any, 0, 1+len(resourceIDs)+len(predicateArgs))
+	maskArgs = append(maskArgs, domainID)
+	for _, resourceID := range resourceIDs {
+		maskArgs = append(maskArgs, resourceID)
+	}
+	maskArgs = append(maskArgs, predicateArgs...)
+
+	maskRows, err := s.db.QueryContext(ctx, maskSQL, maskArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = maskRows.Close() }()
+
+	masksByResource := make(map[string]uint64, len(resourceIDs))
+	for maskRows.Next() {
+		var resourceID string
+		var m int64
+		if err := maskRows.Scan(&resourceID, &m); err != nil {
+			return nil, 0, err
+		}
+		masksByResource[resourceID] |= maskFromSQL(m)
+	}
+	if err := maskRows.Err(); err != nil {
+		return nil, 0, err
+	}
 
 	list := make([]store.UserAuthzResource, 0, len(resourceIDs))
 	for _, resourceID := range resourceIDs {
-		mask, err := s.EffectiveMask(ctx, domainID, userID, resourceID)
-		if err != nil {
-			return nil, 0, err
-		}
+		mask := masksByResource[resourceID]
 		list = append(list, store.UserAuthzResource{ResourceID: resourceID, EffectiveMask: mask})
 	}
 	return list, total, nil
 }
 
 func (s *Store) PermissionMasksForUserResource(ctx context.Context, domainID, userID, resourceID string) ([]uint64, error) {
-	rows, err := s.db.QueryContext(ctx, effectiveMaskSQL,
-		domainID, resourceID,
-		domainID, userID,
-		userID, domainID, domainID,
-	)
+	args := make([]any, 0, 2+5)
+	args = append(args, domainID, resourceID)
+	args = append(args, userEffectivePermissionArgs(domainID, userID)...)
+	rows, err := s.db.QueryContext(ctx, effectiveMaskSQL, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -305,6 +305,32 @@ func TestUserAuthzResourcesList_notFound(t *testing.T) {
 	}
 }
 
+func TestBuildUserAuthzMaskQueryAndArgs(t *testing.T) {
+	predicateArgs := []any{"d", "u", "u", "d", "d"}
+	q, args, err := buildUserAuthzMaskQueryAndArgs("dom", []string{"r1", "r2"}, predicateArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(q, "IN (?,?)") {
+		t.Fatalf("query placeholders: got %q", q)
+	}
+	want := []any{"dom", "r1", "r2", "d", "u", "u", "d", "d"}
+	if len(args) != len(want) {
+		t.Fatalf("args len: want %d, got %d", len(want), len(args))
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Fatalf("args[%d]: want %v, got %v", i, want[i], args[i])
+		}
+	}
+}
+
+func TestBuildUserAuthzMaskQueryAndArgs_emptyResourceIDs(t *testing.T) {
+	if _, _, err := buildUserAuthzMaskQueryAndArgs("dom", nil, []any{"d", "u", "u", "d", "d"}); err == nil {
+		t.Fatal("want error for empty resource IDs")
+	}
+}
+
 func TestDomainGet_foundAndNotFound(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -356,7 +356,59 @@ func TestUserAuthzResourcesList_noPermissions(t *testing.T) {
 	}
 }
 
-func TestUserAuthzResourcesList_negativeMaskTreatedAsZero(t *testing.T) {
+func TestUserAuthzResourcesList_nonPositiveMasksExcluded(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	uid := uuid.NewString()
+	ridNeg := uuid.NewString()
+	pidNeg := uuid.NewString()
+	ridZero := uuid.NewString()
+	pidZero := uuid.NewString()
+
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: ridNeg, DomainID: domainID, Title: "r-neg"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: ridZero, DomainID: domainID, Title: "r-zero"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
+		pidNeg, domainID, "neg-mask", ridNeg, int64(-1),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO user_permissions (domain_id, user_id, permission_id) VALUES (?, ?, ?)`,
+		domainID, uid, pidNeg,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pidZero, DomainID: domainID, Title: "zero-mask", ResourceID: ridZero, AccessMask: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pidZero); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 || len(list) != 0 {
+		t.Fatalf("non-positive masks should be excluded: total=%d len=%d", total, len(list))
+	}
+}
+
+func TestUserAuthzResourcesList_positiveMaskIncluded(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)
 
@@ -374,17 +426,10 @@ func TestUserAuthzResourcesList_negativeMaskTreatedAsZero(t *testing.T) {
 	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
 		t.Fatal(err)
 	}
-
-	if _, err := s.db.ExecContext(ctx,
-		`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
-		pid, domainID, "neg-mask", rid, int64(-1),
-	); err != nil {
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := s.db.ExecContext(ctx,
-		`INSERT INTO user_permissions (domain_id, user_id, permission_id) VALUES (?, ?, ?)`,
-		domainID, uid, pid,
-	); err != nil {
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
 		t.Fatal(err)
 	}
 
@@ -392,14 +437,8 @@ func TestUserAuthzResourcesList_negativeMaskTreatedAsZero(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if total != 1 || len(list) != 1 {
-		t.Fatalf("want one row, got total=%d len=%d", total, len(list))
-	}
-	if list[0].ResourceID != rid {
-		t.Fatalf("resource id: want %s, got %s", rid, list[0].ResourceID)
-	}
-	if list[0].EffectiveMask != 0 {
-		t.Fatalf("effective mask: want 0 for negative DB value, got %d", list[0].EffectiveMask)
+	if total != 1 || len(list) != 1 || list[0].ResourceID != rid || list[0].EffectiveMask != 1 {
+		t.Fatalf("positive mask should be listed: total=%d len=%d list=%+v", total, len(list), list)
 	}
 }
 

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -331,6 +331,129 @@ func TestBuildUserAuthzMaskQueryAndArgs_emptyResourceIDs(t *testing.T) {
 	}
 }
 
+func TestUserAuthzResourcesList_noPermissions(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	uid := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 {
+		t.Fatalf("total: want 0, got %d", total)
+	}
+	if len(list) != 0 {
+		t.Fatalf("list len: want 0, got %d", len(list))
+	}
+}
+
+func TestUserAuthzResourcesList_negativeMaskTreatedAsZero(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	uid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
+		pid, domainID, "neg-mask", rid, int64(-1),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO user_permissions (domain_id, user_id, permission_id) VALUES (?, ?, ?)`,
+		domainID, uid, pid,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 {
+		t.Fatalf("want one row, got total=%d len=%d", total, len(list))
+	}
+	if list[0].ResourceID != rid {
+		t.Fatalf("resource id: want %s, got %s", rid, list[0].ResourceID)
+	}
+	if list[0].EffectiveMask != 0 {
+		t.Fatalf("effective mask: want 0 for negative DB value, got %d", list[0].EffectiveMask)
+	}
+}
+
+func TestUserAuthzResourcesList_limitClampedAtMaxLimit(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	uid := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantTotal := store.MaxLimit + 5
+	for i := 0; i < wantTotal; i++ {
+		rid := uuid.NewString()
+		pid := uuid.NewString()
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: fmt.Sprintf("r-%03d", i)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: fmt.Sprintf("p-%03d", i), ResourceID: rid, AccessMask: 1}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, total1, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 0, Limit: store.MaxLimit + 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total1 != int64(wantTotal) {
+		t.Fatalf("total1: want %d, got %d", wantTotal, total1)
+	}
+	if len(page1) != store.MaxLimit {
+		t.Fatalf("page1 len: want %d, got %d", store.MaxLimit, len(page1))
+	}
+
+	page2, total2, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: store.MaxLimit, Limit: store.MaxLimit + 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total2 != int64(wantTotal) {
+		t.Fatalf("total2: want %d, got %d", wantTotal, total2)
+	}
+	if len(page2) != wantTotal-store.MaxLimit {
+		t.Fatalf("page2 len: want %d, got %d", wantTotal-store.MaxLimit, len(page2))
+	}
+}
+
 func TestDomainGet_foundAndNotFound(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -168,6 +168,137 @@ func TestEffectiveMask_userPlusGroupOR(t *testing.T) {
 	}
 }
 
+func TestUserAuthzResourcesList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+
+	ridA := uuid.NewString()
+	ridB := uuid.NewString()
+	ridC := uuid.NewString()
+	for _, rid := range []string{ridA, ridB, ridC} {
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r-" + rid}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pUserA := uuid.NewString()
+	pGroupA := uuid.NewString()
+	pGroupB := uuid.NewString()
+	pUserC1 := uuid.NewString()
+	pUserC2 := uuid.NewString()
+
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserA, DomainID: domainID, Title: "pUserA", ResourceID: ridA, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroupA, DomainID: domainID, Title: "pGroupA", ResourceID: ridA, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroupB, DomainID: domainID, Title: "pGroupB", ResourceID: ridB, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC1, DomainID: domainID, Title: "pUserC1", ResourceID: ridC, AccessMask: 0x8}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC2, DomainID: domainID, Title: "pUserC2", ResourceID: ridC, AccessMask: 0x10}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUserA); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUserC1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUserC2); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroupA); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroupB); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 0, Limit: 10})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Fatalf("total: want 3, got %d", total)
+	}
+	if len(list) != 3 {
+		t.Fatalf("len: want 3, got %d", len(list))
+	}
+
+	gotMasks := map[string]uint64{}
+	for _, it := range list {
+		gotMasks[it.ResourceID] = it.EffectiveMask
+	}
+	if gotMasks[ridA] != 0x5 {
+		t.Fatalf("ridA mask: want 0x5, got %#x", gotMasks[ridA])
+	}
+	if gotMasks[ridB] != 0x2 {
+		t.Fatalf("ridB mask: want 0x2, got %#x", gotMasks[ridB])
+	}
+	if gotMasks[ridC] != 0x18 {
+		t.Fatalf("ridC mask: want 0x18, got %#x", gotMasks[ridC])
+	}
+
+	page, pageTotal, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 1, Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pageTotal != 3 || len(page) != 1 {
+		t.Fatalf("pagination: total=%d len=%d", pageTotal, len(page))
+	}
+
+	emptyPage, emptyTotal, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 99, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if emptyTotal != 3 || len(emptyPage) != 0 {
+		t.Fatalf("past end: total=%d len=%d", emptyTotal, len(emptyPage))
+	}
+}
+
+func TestUserAuthzResourcesList_notFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := s.UserAuthzResourcesList(ctx, uuid.NewString(), uid, store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown domain: want ErrNotFound, got %v", err)
+	}
+	if _, _, err := s.UserAuthzResourcesList(ctx, domainID, uuid.NewString(), store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown user: want ErrNotFound, got %v", err)
+	}
+}
+
 func TestDomainGet_foundAndNotFound(t *testing.T) {
 	ctx := context.Background()
 	s := newTestStore(t)
@@ -2014,6 +2145,11 @@ func TestStore_closedDB_methods(t *testing.T) {
 	})
 	t.Run("PermissionMasksForUserResource", func(t *testing.T) {
 		if _, err := s.PermissionMasksForUserResource(ctx, domainID, uid, rid); err == nil {
+			t.Fatal("want error")
+		}
+	})
+	t.Run("UserAuthzResourcesList", func(t *testing.T) {
+		if _, _, err := s.UserAuthzResourcesList(ctx, domainID, uid, allOpts); err == nil {
 			t.Fatal("want error")
 		}
 	})

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 
@@ -267,6 +268,11 @@ func TestUserAuthzResourcesList(t *testing.T) {
 	}
 	if pageTotal != 3 || len(page) != 1 {
 		t.Fatalf("pagination: total=%d len=%d", pageTotal, len(page))
+	}
+	orderedIDs := []string{ridA, ridB, ridC}
+	sort.Strings(orderedIDs)
+	if page[0].ResourceID != orderedIDs[1] {
+		t.Fatalf("pagination resource: want %s, got %s", orderedIDs[1], page[0].ResourceID)
 	}
 
 	emptyPage, emptyTotal, err := s.UserAuthzResourcesList(ctx, domainID, uid, store.ListOpts{Offset: 99, Limit: 10})

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -46,11 +46,17 @@ type AccessType struct {
 }
 
 type Permission struct {
-	ID          string
-	DomainID    string
-	Title       string
-	ResourceID  string
-	AccessMask  uint64
+	ID         string
+	DomainID   string
+	Title      string
+	ResourceID string
+	AccessMask uint64
+}
+
+// UserAuthzResource is one row in the user authz resources listing.
+type UserAuthzResource struct {
+	ResourceID    string
+	EffectiveMask uint64
 }
 
 const (
@@ -162,9 +168,9 @@ type AccessTypePatchParams struct {
 
 // PermissionPatchParams is a partial update for a permission.
 type PermissionPatchParams struct {
-	Title        *string
-	ResourceID   *string
-	AccessMask   *uint64
+	Title      *string
+	ResourceID *string
+	AccessMask *uint64
 }
 
 // AuthzReader resolves effective access masks for the indexed hot path.
@@ -176,6 +182,7 @@ type AuthzReader interface {
 // Store aggregates CRUD and authorization reads for the application.
 type Store interface {
 	AuthzReader
+	UserAuthzResourcesList(ctx context.Context, domainID, userID string, opts ListOpts) ([]UserAuthzResource, int64, error)
 
 	DomainCreate(ctx context.Context, d *Domain) error
 	DomainGet(ctx context.Context, id string) (*Domain, error)

--- a/plan/phase-6/T46-limit-63bit-mask.md
+++ b/plan/phase-6/T46-limit-63bit-mask.md
@@ -1,0 +1,60 @@
+# T46 — Limit access mask to 63 bits (temporary)
+
+## Ticket
+
+**T46** — Limit access mask to 63 bits (GitHub #67)
+
+## Phase
+
+**Phase 6** — P3 product options
+
+## Goal
+
+Avoid signed-64 overflow when storing effective/access masks in SQLite by
+restricting masks to the lower 63 bits until a v2 migration that preserves the
+full `uint64` range can be implemented.
+
+This is a short-term compatibility rule and developer/user contract: callers
+may only allocate/access bits in positions `0..62` (inclusive). Attempts to
+create `access_types` or `permissions` using bit `63` (`1<<63`) should be
+rejected with a clear `400` error and documented.
+
+## Deliverables
+
+- Validation at the API / store boundary rejecting bits >= 63
+- Unit and integration tests that assert rejection behaviour and document
+  the constraint
+- CHANGELOG and AGENTS guidance referencing this ticket (PR #66 already
+  added Changlog/AGENTS notes)
+- A v2 migration plan (follow-up) to store full `uint64` masks (TEXT/BLOB or
+  other DB change) with backfill strategy
+
+## Steps
+
+1. Add a short-term validation layer in `internal/api` (permission/access-type
+   create/patch parsing) rejecting `bit` or `access_mask` values that would
+   set the 63rd unsigned bit (values > `math.MaxInt64`). Return `400`.
+2. Add unit+integration tests under `go/internal/*` asserting rejections and
+   unchanged behaviour for values <= `math.MaxInt64`.
+3. Link this ticket from CHANGELOG, AGENTS.md, and any release notes.
+4. Plan v2 migration (separate ticket): decide storage format and migration
+   strategy for existing data.
+
+## Files / paths
+
+- `go/internal/store/sqlite/store.go` — add runtime validation or store-side
+  rejection helper.
+- `go/internal/api/server.go` — return `400` for invalid bit/mask inputs.
+- tests: `go/internal/store/sqlite/store_test.go`, `go/internal/api/server_test.go`.
+
+## Acceptance criteria
+
+- Attempting to create an `access_type` or `permission` that would use bit
+  `1<<63` is rejected with `400`.
+- Tests cover both API and store rejection paths.
+- CHANGELOG/AGENTS mention the limitation and link this ticket.
+
+## Related
+
+- PR: #66
+- Issue: #67

--- a/plan/phase-6/T47-parseuint64-error-handling.md
+++ b/plan/phase-6/T47-parseuint64-error-handling.md
@@ -1,0 +1,45 @@
+# T47 — API: normalize numeric parse errors and return stable 400
+
+## Ticket
+
+**T47** — API: normalize numeric parse errors and return stable 400
+
+## Phase
+
+**Phase 6** — P3 scale, prod, hardening
+
+## Goal
+
+Normalize parsing and validation errors for numeric fields at the API boundary so clients always receive a stable, database-agnostic `400 Bad Request` message. This includes `bit` and `access_mask` parsing (decimal or 0x hex) and range checks that mirror store-side limitations.
+
+## Deliverables
+
+- API-level parsing helper that returns normalized errors (no raw `strconv` messages returned to clients).
+- API handlers (`access_type` create/patch, `permission` create/patch) use the helper and perform range checks consistent with store limits (reject values > math.MaxInt64).
+- Unit tests in `go/internal/api` asserting stable `400` responses for malformed numeric input and out-of-range values.
+- Update CHANGELOG/plan references if needed.
+
+## Steps
+
+1. Add a parsing helper in `go/internal/api` (e.g. `parseUint64Validated`) that:
+   - Accepts a string, attempts `strconv.ParseUint`, and returns either a `uint64` or a well-formed `error` whose message is safe for clients (e.g. "invalid numeric value" or "value out of allowed range").
+   - Optionally accepts max allowed value to enforce API-side range checks.
+2. Replace direct calls to `parseUint64` in handlers that accept `bit` / `access_mask` (create/patch) with the validated helper.
+3. Add unit tests in `go/internal/api/server_test.go` asserting `400` for: non-numeric input, malformed hex, and values above the signed-64 limit.
+4. Run `make test` and `make lint`; update documentation if needed.
+
+## Files / paths
+
+- `go/internal/api/server.go` (add helper, update handlers)
+- `go/internal/api/server_test.go` (add tests)
+- `go/internal/api/helpers_test.go` (helpers for e2e tests may be extended)
+
+## Acceptance criteria
+
+- malformed numeric input to `bit` / `access_mask` results in HTTP 400 with a stable message (no raw strconv text)
+- out-of-range numeric inputs (values > math.MaxInt64) are rejected at API with HTTP 400
+- unit tests assert stable messages and range rejection
+
+## Dependencies
+
+- Align with **T46** (limit 63-bit mask) for range semantics and with **T31** for broader handler error classification if applicable.

--- a/plan/phase-6/T48-typed-invalidinputerror.md
+++ b/plan/phase-6/T48-typed-invalidinputerror.md
@@ -1,0 +1,44 @@
+# T48 — Typed InvalidInputError and stable public invalid-input messages
+
+## Ticket
+
+**T48** — Typed InvalidInputError and stable public invalid-input messages
+
+## Phase
+
+**Phase 6** — P3 scale, prod, hardening
+
+## Goal
+
+Replace fragile string-prefix extraction used by `publicInvalidInputMsg` with a typed `InvalidInputError` (or similar) so store-layer validation details can be safely and reliably presented to API clients.
+
+## Deliverables
+
+- A typed error type (e.g. `InvalidInputError`) located in `go/internal/store` that carries a machine-safe `Detail` string.
+- Store methods use the typed error for invalid-input cases instead of wrapping the `ErrInvalidInput` sentinel with human text.
+- `writeStoreErr` updated to use `errors.As` to extract the typed error and present its `Detail` to clients in a stable way.
+- Unit tests for store and handler paths verifying message extraction and public messages.
+
+## Steps
+
+1. Define `type InvalidInputError struct { Detail string }` (implements `error`) and an accessor or constructor in `go/internal/store`.
+2. Replace instances where `store.ErrInvalidInput` is wrapped with `fmt.Errorf("%w: ...")` in `internal/store` and `internal/store/sqlite` with the typed error (or return `errors.Join(ErrInvalidInput, InvalidInputError{...})` depending on style).
+3. Update `publicInvalidInputMsg`/`writeStoreErr` in `go/internal/api/server.go` to use `errors.As` to extract `InvalidInputError` and return its `Detail`, falling back to a stable message otherwise.
+4. Add unit tests asserting that the API returns the expected client-facing detail when a store method returns an `InvalidInputError`.
+
+## Files / paths
+
+- `go/internal/store/store.go` (new typed error / constructors)
+- `go/internal/store/sqlite/store.go` (use typed error in validation branches)
+- `go/internal/api/server.go` (update message extraction, tests)
+- `go/internal/api/server_test.go`, `go/internal/store/sqlite/store_test.go` (tests)
+
+## Acceptance criteria
+
+- store-level invalid-input cases surface a stable, extractable `Detail` at the API boundary
+- `publicInvalidInputMsg` no longer relies on brittle string-prefix parsing
+- tests confirm expected behavior
+
+## Dependencies
+
+- Related to **T31** (handler error classification); coordinate with that plan if overlapping work is scheduled.


### PR DESCRIPTION
## Summary
Implement T42 end-to-end by adding a paginated user authz resources listing API that returns resource_id and effective_mask, aligned with EffectiveMask semantics (direct user grants + direct group membership grants, no ancestor inheritance).

Changes include store contract/type additions, SQLite query implementation, HTTP route/handler wiring, integration and e2e coverage, and contract updates in OpenAPI/Postman.

## Ticket
Fixes #57 (T42)

## Checklist
- [x] `make test` and `make lint` pass (from repo root)
- [x] Docs updated if behavior or setup changed (`README.md`, `go/README.md`, or `docs/` as needed)
- [x] No secrets or real `.env` values committed
