### PR TITLE
feat(authz): T44 — list users with effective access on a resource (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **T44 / #59:** `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/users` — paginated list of users in the resource's domain with non-zero effective access on the resource. Each item carries `effective_mask` (OR of direct user grants and grants inherited via group membership).
+- **T44 / #59:** `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/users` — paginated list of users in the resource's domain with non-zero effective access on the resource. Each item carries `effective_mask` (OR of direct user grants and grants inherited via group membership). Only `offset` and `limit` are supported; results are always ordered by `user_id` ascending (any `search`/`search_type`/`sort`/`order` query param returns `400`).
 - **T43 / #58:** `GET /api/v1/domains/{domainID}/groups/{groupID}/authz/resources` — paginated list of resources where the group has direct `group_permissions`, with `mask` = bitwise OR of all grants for that `(domain, group, resource)`.
 - **`make gosec`** target in `go/Makefile` and root `Makefile` for running `gosec` security scanner.
 - **T35 / #46:** Title search (`?search=`) on all six list endpoints (`LIKE` with escaped wildcards). Optional `?search_type=` parameter: `contains` (default), `starts_with`, `ends_with`. Entity-specific filters: `?parent_group_id=` on groups, `?resource_id=` on permissions. Filters apply to both paged results and `meta.total`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **T44 / #59:** `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/users` — paginated list of users in the resource's domain with non-zero effective access on the resource. Each item carries `effective_mask` (OR of direct user grants and grants inherited via group membership).
 - **T43 / #58:** `GET /api/v1/domains/{domainID}/groups/{groupID}/authz/resources` — paginated list of resources where the group has direct `group_permissions`, with `mask` = bitwise OR of all grants for that `(domain, group, resource)`.
 - **`make gosec`** target in `go/Makefile` and root `Makefile` for running `gosec` security scanner.
 - **T35 / #46:** Title search (`?search=`) on all six list endpoints (`LIKE` with escaped wildcards). Optional `?search_type=` parameter: `contains` (default), `starts_with`, `ends_with`. Entity-specific filters: `?parent_group_id=` on groups, `?resource_id=` on permissions. Filters apply to both paged results and `meta.total`.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -1553,6 +1553,8 @@ paths:
         Returns users in the resource's domain whose effective mask on this resource is non-zero.
         Effective masks are computed as the OR of direct user grants and grants inherited via group membership.
         Effective masks are returned as decimal strings.
+
+        Pagination: only `offset` and `limit` are supported. Results are always ordered by `user_id` ascending — `sort` and `order` are not honoured for this endpoint, and any of `search`, `search_type`, `sort`, or `order` in the query string will produce a `400`.
       parameters:
         - $ref: "#/components/parameters/offsetParam"
         - $ref: "#/components/parameters/limitParam"

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -422,6 +422,18 @@ components:
           description: OR of all direct group grants for this group/resource pair as decimal string.
           example: "5"
 
+    ResourceAuthzUser:
+      type: object
+      required: [user_id, effective_mask]
+      properties:
+        user_id:
+          type: string
+          format: uuid
+        effective_mask:
+          type: string
+          description: Effective mask (OR of direct user grants and group-membership grants) for this user/resource pair as decimal string.
+          example: "7"
+
 paths:
   /health:
     get:
@@ -1519,6 +1531,64 @@ paths:
                 $ref: "#/components/schemas/ErrorBody"
         "404":
           description: Domain or group not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+
+  /api/v1/domains/{domainID}/resources/{resourceID}/authz/users:
+    parameters:
+      - $ref: "#/components/parameters/domainID"
+      - $ref: "#/components/parameters/resourceID"
+    get:
+      tags: [Authz]
+      summary: List users with effective access on a resource
+      description: |
+        Returns users in the resource's domain whose effective mask on this resource is non-zero.
+        Effective masks are computed as the OR of direct user grants and grants inherited via group membership.
+        Effective masks are returned as decimal strings.
+      parameters:
+        - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/limitParam"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ResourceAuthzUser"
+                  meta:
+                    $ref: "#/components/schemas/ListMeta"
+              example:
+                data:
+                  - user_id: "11111111-1111-1111-1111-111111111111"
+                    effective_mask: "7"
+                meta:
+                  total: 1
+                  offset: 0
+                  limit: 20
+                  sort: "user_id"
+                  order: "asc"
+        "400":
+          description: Bad request (invalid pagination params)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "404":
+          description: Domain or resource not found
           content:
             application/json:
               schema:

--- a/api/postman/access-manager.postman_collection.json
+++ b/api/postman/access-manager.postman_collection.json
@@ -165,6 +165,7 @@
     {"name": "Authz check", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/authz/check?user_id={{userId}}&resource_id={{resourceId}}&access_bit=1"}},
     {"name": "Authz masks", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/authz/masks?user_id={{userId}}&resource_id={{resourceId}}"}},
     {"name": "List user authz resources", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/authz/resources?offset=0&limit=20"}},
+    {"name": "List resource authz users", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/resources/{{resourceId}}/authz/users?offset=0&limit=20"}},
     {"name": "Revoke group permission", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups/{{groupId}}/permissions/{{permissionId}}"}},
     {"name": "Revoke user permission", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/permissions/{{permissionId}}"}},
     {"name": "Remove user from group", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/groups/{{groupId}}"}},

--- a/go/e2e/authz_test.go
+++ b/go/e2e/authz_test.go
@@ -323,3 +323,85 @@ func TestAuthz_groupResourcesList(t *testing.T) {
 		t.Fatalf("page resource: want %s, got %s", orderedIDs[1], pageItems[0].ResourceID)
 	}
 }
+
+func TestAuthz_resourceUsersList(t *testing.T) {
+	c := httpClient()
+	did := seedDomain(t, c, "authz-resource-users")
+	cleanupDelete(t, c, apiBase()+"/domains/"+did)
+
+	rid := seedResource(t, c, did, "r")
+	cleanupDelete(t, c, domainBase(did)+"/resources/"+rid)
+
+	uA := seedUser(t, c, did, "uA")
+	uB := seedUser(t, c, did, "uB")
+	uC := seedUser(t, c, did, "uC")
+	cleanupDelete(t, c, domainBase(did)+"/users/"+uA)
+	cleanupDelete(t, c, domainBase(did)+"/users/"+uB)
+	cleanupDelete(t, c, domainBase(did)+"/users/"+uC)
+
+	gid := seedGroup(t, c, did, "g")
+	cleanupDelete(t, c, domainBase(did)+"/groups/"+gid)
+	addMembership(t, c, did, uA, gid)
+	addMembership(t, c, did, uB, gid)
+	cleanupRevokeMembership(t, c, did, uA, gid)
+	cleanupRevokeMembership(t, c, did, uB, gid)
+
+	pDirect := seedPermission(t, c, did, "pDirect", rid, "0x1")
+	pGroup := seedPermission(t, c, did, "pGroup", rid, "0x4")
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pDirect)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pGroup)
+
+	grantUserPerm(t, c, did, uA, pDirect)
+	grantGroupPerm(t, c, did, gid, pGroup)
+	cleanupRevokeUserPerm(t, c, did, uA, pDirect)
+	cleanupRevokeGroupPerm(t, c, did, gid, pGroup)
+
+	type authzUser struct {
+		UserID        string `json:"user_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}
+
+	base := fmt.Sprintf("%s/resources/%s/authz/users", domainBase(did), rid)
+	env := mustList(t, c, base+"?offset=0&limit=10")
+	if env.Meta.Total != 2 {
+		t.Fatalf("total: want 2 (uA + uB; uC has no access), got %d", env.Meta.Total)
+	}
+	var items []authzUser
+	if err := json.Unmarshal(env.Data, &items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items len: want 2, got %d", len(items))
+	}
+	got := map[string]string{}
+	for _, it := range items {
+		got[it.UserID] = it.EffectiveMask
+	}
+	if got[uA] != "5" {
+		t.Fatalf("uA mask: want 5 (0x1 direct | 0x4 group), got %q", got[uA])
+	}
+	if got[uB] != "4" {
+		t.Fatalf("uB mask: want 4 (group only), got %q", got[uB])
+	}
+	if _, ok := got[uC]; ok {
+		t.Fatalf("uC must not appear (no grants)")
+	}
+
+	// Pagination: ordered by user_id ASC.
+	page := mustList(t, c, base+"?offset=1&limit=1")
+	if page.Meta.Total != 2 {
+		t.Fatalf("page total: want 2, got %d", page.Meta.Total)
+	}
+	var pageItems []authzUser
+	if err := json.Unmarshal(page.Data, &pageItems); err != nil {
+		t.Fatal(err)
+	}
+	if len(pageItems) != 1 {
+		t.Fatalf("page len: want 1, got %d", len(pageItems))
+	}
+	orderedIDs := []string{uA, uB}
+	sort.Strings(orderedIDs)
+	if pageItems[0].UserID != orderedIDs[1] {
+		t.Fatalf("page user: want %s, got %s", orderedIDs[1], pageItems[0].UserID)
+	}
+}

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -855,6 +855,13 @@ type resourceAuthzUserResponse struct {
 	EffectiveMask string `json:"effective_mask"`
 }
 
+// resourceAuthzUsersSortField is the meta.sort label returned to clients.
+// It is the public/JSON name ("user_id") for what the store internally
+// orders by (users.id). Both refer to the same column — the store
+// ALWAYS uses a fixed ORDER BY users.id ASC for deterministic pagination
+// regardless of the opts.Sort/Order values set here; those fields exist
+// only so meta.sort/meta.order are populated consistently with other list
+// endpoints.
 const resourceAuthzUsersSortField = "user_id"
 
 func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
@@ -863,6 +870,7 @@ func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
+	// Populated for meta only; the store enforces fixed ORDER BY users.id ASC.
 	opts.Sort = resourceAuthzUsersSortField
 	opts.Order = store.OrderAsc
 

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -102,6 +102,8 @@ func (s *Server) Router(reg prometheus.Registerer, gather prometheus.Gatherer) c
 		r.Delete("/domains/{domainID}/groups/{groupID}/permissions/{permissionID}", s.revokeGroupPermission)
 		r.Get("/domains/{domainID}/groups/{groupID}/authz/resources", s.groupAuthzResources)
 
+		r.Get("/domains/{domainID}/resources/{resourceID}/authz/users", s.resourceAuthzUsers)
+
 		r.Get("/domains/{domainID}/authz/check", s.authzCheck)
 		r.Get("/domains/{domainID}/authz/masks", s.authzMasks)
 	})
@@ -843,6 +845,39 @@ func (s *Server) groupAuthzResources(w http.ResponseWriter, r *http.Request) {
 		resp = append(resp, groupAuthzResourceResponse{
 			ResourceID: it.ResourceID,
 			Mask:       strconv.FormatUint(it.Mask, 10),
+		})
+	}
+	writeList(w, resp, total, opts)
+}
+
+type resourceAuthzUserResponse struct {
+	UserID        string `json:"user_id"`
+	EffectiveMask string `json:"effective_mask"`
+}
+
+const resourceAuthzUsersSortField = "user_id"
+
+func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
+	opts, err := parseOffsetLimitOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	opts.Sort = resourceAuthzUsersSortField
+	opts.Order = store.OrderAsc
+
+	domainID := chi.URLParam(r, "domainID")
+	rid := chi.URLParam(r, "resourceID")
+	list, total, err := s.Store.ResourceAuthzUsersList(r.Context(), domainID, rid, opts)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	resp := make([]resourceAuthzUserResponse, 0, len(list))
+	for _, it := range list {
+		resp = append(resp, resourceAuthzUserResponse{
+			UserID:        it.UserID,
+			EffectiveMask: strconv.FormatUint(it.EffectiveMask, 10),
 		})
 	}
 	writeList(w, resp, total, opts)

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -812,6 +812,209 @@ func TestAPI_groupAuthzResources_notFound(t *testing.T) {
 	}
 }
 
+func TestAPI_resourceAuthzUsers_integration(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	uA := uuid.NewString()
+	uB := uuid.NewString()
+
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, uid := range []string{uA, uB} {
+		if err := st.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u" + uid}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gid := uuid.NewString()
+	if err := st.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AddUserToGroup(ctx, domainID, uA, gid); err != nil {
+		t.Fatal(err)
+	}
+
+	pDirectA1 := uuid.NewString()
+	pDirectA2 := uuid.NewString()
+	pGroup := uuid.NewString()
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pDirectA1, DomainID: domainID, Title: "pA1", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pDirectA2, DomainID: domainID, Title: "pA2", ResourceID: rid, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pG", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantUserPermission(ctx, domainID, uA, pDirectA1); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantUserPermission(ctx, domainID, uA, pDirectA2); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+		t.Fatal(err)
+	}
+
+	base := ts.URL + "/api/v1/domains/" + domainID + "/resources/" + rid + "/authz/users"
+
+	res, err := http.Get(base + "?offset=0&limit=10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[struct {
+		UserID        string `json:"user_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Meta.Total != 1 {
+		t.Fatalf("total: want 1 (uB has no membership/grant), got %d", env.Meta.Total)
+	}
+	if len(env.Data) != 1 {
+		t.Fatalf("len: want 1, got %d", len(env.Data))
+	}
+	if env.Data[0].UserID != uA {
+		t.Fatalf("user: want %s, got %s", uA, env.Data[0].UserID)
+	}
+	if env.Data[0].EffectiveMask != "7" {
+		t.Fatalf("uA mask: want 7 (0x1|0x4 direct | 0x2 group), got %q", env.Data[0].EffectiveMask)
+	}
+
+	// Add uB to the group too -> both users now appear.
+	if err := st.AddUserToGroup(ctx, domainID, uB, gid); err != nil {
+		t.Fatal(err)
+	}
+	res2, err := http.Get(base + "?offset=0&limit=10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res2.Body.Close() }()
+	if res2.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", res2.StatusCode)
+	}
+	var env2 listResponse[struct {
+		UserID        string `json:"user_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}]
+	if err := json.NewDecoder(res2.Body).Decode(&env2); err != nil {
+		t.Fatal(err)
+	}
+	if env2.Meta.Total != 2 || len(env2.Data) != 2 {
+		t.Fatalf("after second membership: total=%d len=%d", env2.Meta.Total, len(env2.Data))
+	}
+	gotMasks := map[string]string{}
+	for _, it := range env2.Data {
+		gotMasks[it.UserID] = it.EffectiveMask
+	}
+	if gotMasks[uA] != "7" {
+		t.Fatalf("uA mask: want 7, got %q", gotMasks[uA])
+	}
+	if gotMasks[uB] != "2" {
+		t.Fatalf("uB mask: want 2, got %q", gotMasks[uB])
+	}
+
+	// Pagination: ordered by user_id ASC.
+	resPage, err := http.Get(base + "?offset=1&limit=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resPage.Body.Close() }()
+	if resPage.StatusCode != http.StatusOK {
+		t.Fatalf("page status %d", resPage.StatusCode)
+	}
+	var page listResponse[struct {
+		UserID        string `json:"user_id"`
+		EffectiveMask string `json:"effective_mask"`
+	}]
+	if err := json.NewDecoder(resPage.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	if page.Meta.Total != 2 || len(page.Data) != 1 {
+		t.Fatalf("page: total=%d len=%d", page.Meta.Total, len(page.Data))
+	}
+	orderedIDs := []string{uA, uB}
+	sort.Strings(orderedIDs)
+	if page.Data[0].UserID != orderedIDs[1] {
+		t.Fatalf("page user: want %s, got %s", orderedIDs[1], page.Data[0].UserID)
+	}
+	if page.Meta.Sort != "user_id" || page.Meta.Order != "asc" {
+		t.Fatalf("page meta sort/order: got sort=%q order=%q", page.Meta.Sort, page.Meta.Order)
+	}
+}
+
+func TestAPI_resourceAuthzUsers_unsupportedQueryParams(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/resources/" + rid + "/authz/users?search=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("unsupported params: want 400, got %d: %s", res.StatusCode, b)
+	}
+	var out map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["error"] != "only limit and offset are supported" {
+		t.Fatalf("unexpected error message: %q", out["error"])
+	}
+}
+
+func TestAPI_resourceAuthzUsers_notFound(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+	domainID := uuid.NewString()
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	resUnknownDomain, err := http.Get(ts.URL + "/api/v1/domains/" + uuid.NewString() + "/resources/" + rid + "/authz/users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resUnknownDomain.Body.Close() }()
+	if resUnknownDomain.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown domain: want 404, got %d", resUnknownDomain.StatusCode)
+	}
+
+	resUnknownResource, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/resources/" + uuid.NewString() + "/authz/users")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resUnknownResource.Body.Close() }()
+	if resUnknownResource.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown resource: want 404, got %d", resUnknownResource.StatusCode)
+	}
+}
+
 func TestAPI_userList_empty(t *testing.T) {
 	ts, _ := newTestAPI(t)
 	var dom store.Domain
@@ -2272,6 +2475,7 @@ func TestAPI_storeErrors(t *testing.T) {
 		{"revokeUserPerm", http.MethodDelete, "/api/v1/domains/" + domID + "/users/" + userID + "/permissions/" + permID, "", 500},
 		{"userAuthzResources", http.MethodGet, "/api/v1/domains/" + domID + "/users/" + userID + "/authz/resources", "", 500},
 		{"groupAuthzResources", http.MethodGet, "/api/v1/domains/" + domID + "/groups/" + groupID + "/authz/resources", "", 500},
+		{"resourceAuthzUsers", http.MethodGet, "/api/v1/domains/" + domID + "/resources/" + resourceID + "/authz/users", "", 500},
 		{"revokeGroupPerm", http.MethodDelete, "/api/v1/domains/" + domID + "/groups/" + groupID + "/permissions/" + permID, "", 500},
 		{"authzCheck", http.MethodGet, "/api/v1/domains/" + domID + "/authz/check?user_id=" + userID + "&resource_id=" + resourceID + "&access_bit=0x1", "", 500},
 		{"authzMasks", http.MethodGet, "/api/v1/domains/" + domID + "/authz/masks?user_id=" + userID + "&resource_id=" + resourceID, "", 500},

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1203,6 +1203,11 @@ func (s *Store) ResourceAuthzUsersList(ctx context.Context, domainID, resourceID
 		return []store.ResourceAuthzUser{}, total, nil
 	}
 
+	// Invariant: len(userIDs) <= opts.Limit which is clamped to store.MaxLimit
+	// (100) by SanitizeListOpts. SQLite's default SQLITE_MAX_VARIABLE_NUMBER
+	// is well above this (>=999), so the IN (?,…) expansions below are safe.
+	// If MaxLimit is ever raised above the SQLite parameter cap, batch the
+	// IN clauses or chunk userIDs.
 	placeholders, err := inPlaceholders(len(userIDs))
 	if err != nil {
 		return nil, 0, err

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1108,6 +1108,12 @@ func (s *Store) GroupAuthzResourcesList(ctx context.Context, domainID, groupID s
 // non-zero effective mask on (domainID, resourceID) via direct grants OR via
 // any group they belong to.
 //
+// `p.access_mask > 0` excludes both zero masks (no-op grants) AND any legacy
+// rows with negative int64 mask values — see maskFromSQL, which similarly
+// coerces negative DB values to 0 with a warning. Such rows can only exist
+// from out-of-band/legacy writes (PermissionCreate validates the range), so
+// silently ignoring them in the listing is intentional and matches T42/T43.
+//
 // Placeholder map (six ?'s, all built from {domainID, resourceID}; keep this
 // table in sync with resourceAuthzUsersBaseArgs):
 //

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1171,7 +1171,9 @@ func (s *Store) ResourceAuthzUsersList(ctx context.Context, domainID, resourceID
 
 	// opts.Sort / opts.Order are populated by the handler and reflected in the
 	// meta response via writeList. The store always uses a fixed ORDER BY
-	// u.id ASC for stable, deterministic pagination.
+	// u.id ASC for stable, deterministic pagination — opts.Sort/Order are
+	// intentionally NOT honoured here. The handler exposes the meta label
+	// "user_id" which is the public name for the same users.id column.
 	listArgs := append(append([]any{}, baseArgs...), opts.Limit, opts.Offset)
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT u.id `+resourceAuthzUsersBaseSQL+` ORDER BY u.id ASC LIMIT ? OFFSET ?`,

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1106,8 +1106,19 @@ func (s *Store) GroupAuthzResourcesList(ctx context.Context, domainID, groupID s
 
 // resourceAuthzUsersBaseSQL selects users in the resource's domain who have a
 // non-zero effective mask on (domainID, resourceID) via direct grants OR via
-// any group they belong to. The placeholder order is:
-//   u.domain_id, p.domain_id, p.resource_id, up.domain_id, gp.domain_id, gm.domain_id
+// any group they belong to.
+//
+// Placeholder map (six ?'s, all built from {domainID, resourceID}; keep this
+// table in sync with resourceAuthzUsersBaseArgs):
+//
+//	1: u.domain_id   = domainID
+//	2: p.domain_id   = domainID
+//	3: p.resource_id = resourceID
+//	4: up.domain_id  = domainID   (direct user grant branch)
+//	5: gp.domain_id  = domainID   (group-inherited grant branch)
+//	6: gm.domain_id  = domainID   (group-membership domain pin)
+//
+// Example with domainID="D" / resourceID="R": all six args are ["D","D","R","D","D","D"].
 const resourceAuthzUsersBaseSQL = `
 FROM users u
 WHERE u.domain_id = ? AND EXISTS (
@@ -1127,6 +1138,9 @@ WHERE u.domain_id = ? AND EXISTS (
 )
 `
 
+// resourceAuthzUsersBaseArgs returns the six positional args for
+// resourceAuthzUsersBaseSQL in placeholder order. Centralised so callers
+// (count + page-select) cannot drift out of sync with the SQL.
 func resourceAuthzUsersBaseArgs(domainID, resourceID string) []any {
 	return []any{domainID, domainID, resourceID, domainID, domainID, domainID}
 }

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1104,6 +1104,149 @@ func (s *Store) GroupAuthzResourcesList(ctx context.Context, domainID, groupID s
 	return result, total, nil
 }
 
+// resourceAuthzUsersBaseSQL selects users in the resource's domain who have a
+// non-zero effective mask on (domainID, resourceID) via direct grants OR via
+// any group they belong to. The placeholder order is:
+//   u.domain_id, p.domain_id, p.resource_id, up.domain_id, gp.domain_id, gm.domain_id
+const resourceAuthzUsersBaseSQL = `
+FROM users u
+WHERE u.domain_id = ? AND EXISTS (
+	SELECT 1 FROM permissions p
+	WHERE p.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0
+	AND (
+		EXISTS (
+			SELECT 1 FROM user_permissions up
+			WHERE up.permission_id = p.id AND up.domain_id = ? AND up.user_id = u.id
+		)
+		OR EXISTS (
+			SELECT 1 FROM group_permissions gp
+			INNER JOIN group_members gm ON gm.group_id = gp.group_id AND gm.user_id = u.id
+			WHERE gp.permission_id = p.id AND gp.domain_id = ? AND gm.domain_id = ?
+		)
+	)
+)
+`
+
+func resourceAuthzUsersBaseArgs(domainID, resourceID string) []any {
+	return []any{domainID, domainID, resourceID, domainID, domainID, domainID}
+}
+
+func (s *Store) ResourceAuthzUsersList(ctx context.Context, domainID, resourceID string, opts store.ListOpts) ([]store.ResourceAuthzUser, int64, error) {
+	opts = store.SanitizeListOpts(opts)
+
+	var exists int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM domains WHERE id = ?`, domainID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, store.ErrNotFound
+		}
+		return nil, 0, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM resources WHERE id = ? AND domain_id = ?`, resourceID, domainID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, store.ErrNotFound
+		}
+		return nil, 0, err
+	}
+
+	baseArgs := resourceAuthzUsersBaseArgs(domainID, resourceID)
+
+	var total int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) `+resourceAuthzUsersBaseSQL, baseArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	// opts.Sort / opts.Order are populated by the handler and reflected in the
+	// meta response via writeList. The store always uses a fixed ORDER BY
+	// u.id ASC for stable, deterministic pagination.
+	listArgs := append(append([]any{}, baseArgs...), opts.Limit, opts.Offset)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT u.id `+resourceAuthzUsersBaseSQL+` ORDER BY u.id ASC LIMIT ? OFFSET ?`,
+		listArgs...,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var userIDs []string
+	for rows.Next() {
+		var uid string
+		if err := rows.Scan(&uid); err != nil {
+			_ = rows.Close()
+			return nil, 0, err
+		}
+		userIDs = append(userIDs, uid)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, err
+	}
+	if len(userIDs) == 0 {
+		return []store.ResourceAuthzUser{}, total, nil
+	}
+
+	placeholders, err := inPlaceholders(len(userIDs))
+	if err != nil {
+		return nil, 0, err
+	}
+
+	masksByUser := make(map[string]uint64, len(userIDs))
+
+	// Direct user grants on this resource.
+	directSQL := `SELECT up.user_id, p.access_mask FROM user_permissions up ` + // #nosec G202
+		`INNER JOIN permissions p ON p.id = up.permission_id ` +
+		`WHERE up.domain_id = ? AND p.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0 ` +
+		`AND up.user_id IN (` + placeholders + `)`
+	directArgs := make([]any, 0, 3+len(userIDs))
+	directArgs = append(directArgs, domainID, domainID, resourceID)
+	for _, uid := range userIDs {
+		directArgs = append(directArgs, uid)
+	}
+	if err := scanUserMasks(ctx, s.db, directSQL, directArgs, masksByUser); err != nil {
+		return nil, 0, err
+	}
+
+	// Indirect grants via group membership.
+	indirectSQL := `SELECT gm.user_id, p.access_mask FROM group_members gm ` + // #nosec G202
+		`INNER JOIN group_permissions gp ON gp.group_id = gm.group_id ` +
+		`INNER JOIN permissions p ON p.id = gp.permission_id ` +
+		`WHERE gm.domain_id = ? AND gp.domain_id = ? AND p.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0 ` +
+		`AND gm.user_id IN (` + placeholders + `)`
+	indirectArgs := make([]any, 0, 4+len(userIDs))
+	indirectArgs = append(indirectArgs, domainID, domainID, domainID, resourceID)
+	for _, uid := range userIDs {
+		indirectArgs = append(indirectArgs, uid)
+	}
+	if err := scanUserMasks(ctx, s.db, indirectSQL, indirectArgs, masksByUser); err != nil {
+		return nil, 0, err
+	}
+
+	result := make([]store.ResourceAuthzUser, 0, len(userIDs))
+	for _, uid := range userIDs {
+		result = append(result, store.ResourceAuthzUser{UserID: uid, EffectiveMask: masksByUser[uid]})
+	}
+	return result, total, nil
+}
+
+func scanUserMasks(ctx context.Context, db *sql.DB, query string, args []any, into map[string]uint64) error {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var uid string
+		var m int64
+		if err := rows.Scan(&uid, &m); err != nil {
+			return err
+		}
+		into[uid] |= maskFromSQL(m)
+	}
+	return rows.Err()
+}
+
 func (s *Store) PermissionMasksForUserResource(ctx context.Context, domainID, userID, resourceID string) ([]uint64, error) {
 	args := make([]any, 0, 2+5)
 	args = append(args, domainID, resourceID)

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -3482,9 +3482,9 @@ func TestResourceAuthzUsersList(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create three users:
-	// uA: direct grant 0x1 + group grant 0x4 -> 0x5
-	// uB: group grant only 0x2 -> 0x2
+	// Create four users:
+	// uA: direct grant 0x1 + group grants 0x2|0x4 -> 0x7
+	// uB: group grants 0x2|0x4 only -> 0x6
 	// uC: direct grant 0x8 plus another direct 0x10 -> 0x18
 	// uX: no access (must NOT appear)
 	uA := uuid.NewString()
@@ -3785,7 +3785,8 @@ func TestResourceAuthzUsersBaseArgs_orderMatchesPlaceholders(t *testing.T) {
 		}
 	}
 	// Sanity: the SQL must contain exactly one '?' per arg position.
-	if got, want := strings.Count(resourceAuthzUsersBaseSQL, "?"), len(want); got != want {
-		t.Fatalf("placeholder count: want %d, got %d", want, got)
+	wantCount := len(want)
+	if got := strings.Count(resourceAuthzUsersBaseSQL, "?"); got != wantCount {
+		t.Fatalf("placeholder count: want %d, got %d", wantCount, got)
 	}
 }

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -3470,305 +3470,322 @@ func TestList_queryContextError(t *testing.T) {
 }
 
 func TestResourceAuthzUsersList(t *testing.T) {
-ctx := context.Background()
-s := newTestStore(t)
+	ctx := context.Background()
+	s := newTestStore(t)
 
-domainID := uuid.NewString()
-if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
-t.Fatal(err)
-}
-rid := uuid.NewString()
-if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
-t.Fatal(err)
-}
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
 
-// Create three users:
-// uA: direct grant 0x1 + group grant 0x4 -> 0x5
-// uB: group grant only 0x2 -> 0x2
-// uC: direct grant 0x8 plus another direct 0x10 -> 0x18
-// uX: no access (must NOT appear)
-uA := uuid.NewString()
-uB := uuid.NewString()
-uC := uuid.NewString()
-uX := uuid.NewString()
-for _, u := range []string{uA, uB, uC, uX} {
-if err := s.UserCreate(ctx, &store.User{ID: u, DomainID: domainID, Title: "u-" + u}); err != nil {
-t.Fatal(err)
-}
-}
+	// Create three users:
+	// uA: direct grant 0x1 + group grant 0x4 -> 0x5
+	// uB: group grant only 0x2 -> 0x2
+	// uC: direct grant 0x8 plus another direct 0x10 -> 0x18
+	// uX: no access (must NOT appear)
+	uA := uuid.NewString()
+	uB := uuid.NewString()
+	uC := uuid.NewString()
+	uX := uuid.NewString()
+	for _, u := range []string{uA, uB, uC, uX} {
+		if err := s.UserCreate(ctx, &store.User{ID: u, DomainID: domainID, Title: "u-" + u}); err != nil {
+			t.Fatal(err)
+		}
+	}
 
-gid := uuid.NewString()
-if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
-t.Fatal(err)
-}
-if err := s.AddUserToGroup(ctx, domainID, uA, gid); err != nil {
-t.Fatal(err)
-}
-if err := s.AddUserToGroup(ctx, domainID, uB, gid); err != nil {
-t.Fatal(err)
-}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uA, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uB, gid); err != nil {
+		t.Fatal(err)
+	}
 
-pUserA := uuid.NewString()
-pGroup := uuid.NewString()
-pUserC1 := uuid.NewString()
-pUserC2 := uuid.NewString()
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserA, DomainID: domainID, Title: "pUserA", ResourceID: rid, AccessMask: 0x1}); err != nil {
-t.Fatal(err)
-}
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pGroup", ResourceID: rid, AccessMask: 0x2 | 0x4}); err != nil {
-t.Fatal(err)
-}
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC1, DomainID: domainID, Title: "pUserC1", ResourceID: rid, AccessMask: 0x8}); err != nil {
-t.Fatal(err)
-}
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC2, DomainID: domainID, Title: "pUserC2", ResourceID: rid, AccessMask: 0x10}); err != nil {
-t.Fatal(err)
-}
+	pUserA := uuid.NewString()
+	pGroup := uuid.NewString()
+	pUserC1 := uuid.NewString()
+	pUserC2 := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserA, DomainID: domainID, Title: "pUserA", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pGroup", ResourceID: rid, AccessMask: 0x2 | 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC1, DomainID: domainID, Title: "pUserC1", ResourceID: rid, AccessMask: 0x8}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC2, DomainID: domainID, Title: "pUserC2", ResourceID: rid, AccessMask: 0x10}); err != nil {
+		t.Fatal(err)
+	}
 
-if err := s.GrantUserPermission(ctx, domainID, uA, pUserA); err != nil {
-t.Fatal(err)
-}
-if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
-t.Fatal(err)
-}
-if err := s.GrantUserPermission(ctx, domainID, uC, pUserC1); err != nil {
-t.Fatal(err)
-}
-if err := s.GrantUserPermission(ctx, domainID, uC, pUserC2); err != nil {
-t.Fatal(err)
-}
+	if err := s.GrantUserPermission(ctx, domainID, uA, pUserA); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uC, pUserC1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uC, pUserC2); err != nil {
+		t.Fatal(err)
+	}
 
-// uA -> 0x1 (direct) | 0x6 (group) = 0x7
-// uB -> 0x6 (group)
-// uC -> 0x18
-wantMasks := map[string]uint64{uA: 0x7, uB: 0x6, uC: 0x18}
+	// uA -> 0x1 (direct) | 0x6 (group) = 0x7
+	// uB -> 0x6 (group)
+	// uC -> 0x18
+	wantMasks := map[string]uint64{uA: 0x7, uB: 0x6, uC: 0x18}
 
-list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
-if err != nil {
-t.Fatal(err)
-}
-if total != 3 {
-t.Fatalf("total: want 3, got %d", total)
-}
-if len(list) != 3 {
-t.Fatalf("len: want 3, got %d", len(list))
-}
-gotMasks := map[string]uint64{}
-for _, it := range list {
-gotMasks[it.UserID] = it.EffectiveMask
-}
-for u, m := range wantMasks {
-if gotMasks[u] != m {
-t.Fatalf("user %s mask: want %#x, got %#x", u, m, gotMasks[u])
-}
-}
-if _, ok := gotMasks[uX]; ok {
-t.Fatalf("uX with no access must not appear")
-}
+	list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 3 {
+		t.Fatalf("total: want 3, got %d", total)
+	}
+	if len(list) != 3 {
+		t.Fatalf("len: want 3, got %d", len(list))
+	}
+	gotMasks := map[string]uint64{}
+	for _, it := range list {
+		gotMasks[it.UserID] = it.EffectiveMask
+	}
+	for u, m := range wantMasks {
+		if gotMasks[u] != m {
+			t.Fatalf("user %s mask: want %#x, got %#x", u, m, gotMasks[u])
+		}
+	}
+	if _, ok := gotMasks[uX]; ok {
+		t.Fatalf("uX with no access must not appear")
+	}
 
-// Pagination + ordering by user_id ASC.
-page, pageTotal, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 1, Limit: 1})
-if err != nil {
-t.Fatal(err)
-}
-if pageTotal != 3 || len(page) != 1 {
-t.Fatalf("pagination: total=%d len=%d", pageTotal, len(page))
-}
-orderedIDs := []string{uA, uB, uC}
-sort.Strings(orderedIDs)
-if page[0].UserID != orderedIDs[1] {
-t.Fatalf("pagination user: want %s, got %s", orderedIDs[1], page[0].UserID)
-}
+	// Pagination + ordering by user_id ASC.
+	page, pageTotal, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 1, Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pageTotal != 3 || len(page) != 1 {
+		t.Fatalf("pagination: total=%d len=%d", pageTotal, len(page))
+	}
+	orderedIDs := []string{uA, uB, uC}
+	sort.Strings(orderedIDs)
+	if page[0].UserID != orderedIDs[1] {
+		t.Fatalf("pagination user: want %s, got %s", orderedIDs[1], page[0].UserID)
+	}
 
-emptyPage, emptyTotal, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 99, Limit: 10})
-if err != nil {
-t.Fatal(err)
-}
-if emptyTotal != 3 || len(emptyPage) != 0 {
-t.Fatalf("past end: total=%d len=%d", emptyTotal, len(emptyPage))
-}
+	emptyPage, emptyTotal, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 99, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if emptyTotal != 3 || len(emptyPage) != 0 {
+		t.Fatalf("past end: total=%d len=%d", emptyTotal, len(emptyPage))
+	}
 }
 
 func TestResourceAuthzUsersList_notFound(t *testing.T) {
-ctx := context.Background()
-s := newTestStore(t)
+	ctx := context.Background()
+	s := newTestStore(t)
 
-domainID := uuid.NewString()
-if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
-t.Fatal(err)
-}
-rid := uuid.NewString()
-if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
-t.Fatal(err)
-}
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
 
-if _, _, err := s.ResourceAuthzUsersList(ctx, uuid.NewString(), rid, store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
-t.Fatalf("unknown domain: want ErrNotFound, got %v", err)
-}
-if _, _, err := s.ResourceAuthzUsersList(ctx, domainID, uuid.NewString(), store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
-t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
-}
+	if _, _, err := s.ResourceAuthzUsersList(ctx, uuid.NewString(), rid, store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown domain: want ErrNotFound, got %v", err)
+	}
+	if _, _, err := s.ResourceAuthzUsersList(ctx, domainID, uuid.NewString(), store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
+	}
 }
 
 func TestResourceAuthzUsersList_noUsers(t *testing.T) {
-ctx := context.Background()
-s := newTestStore(t)
+	ctx := context.Background()
+	s := newTestStore(t)
 
-domainID := uuid.NewString()
-rid := uuid.NewString()
-if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
-t.Fatal(err)
-}
-if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
-t.Fatal(err)
-}
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
 
-list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
-if err != nil {
-t.Fatal(err)
-}
-if total != 0 || len(list) != 0 {
-t.Fatalf("no users: total=%d len=%d", total, len(list))
-}
+	list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 || len(list) != 0 {
+		t.Fatalf("no users: total=%d len=%d", total, len(list))
+	}
 }
 
 func TestResourceAuthzUsersList_nonPositiveMasksExcluded(t *testing.T) {
-ctx := context.Background()
-s := newTestStore(t)
+	ctx := context.Background()
+	s := newTestStore(t)
 
-domainID := uuid.NewString()
-rid := uuid.NewString()
-uid := uuid.NewString()
-pidNeg := uuid.NewString()
-pidZero := uuid.NewString()
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	uid := uuid.NewString()
+	pidNeg := uuid.NewString()
+	pidZero := uuid.NewString()
 
-if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
-t.Fatal(err)
-}
-if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
-t.Fatal(err)
-}
-if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
-t.Fatal(err)
-}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
 
-if _, err := s.db.ExecContext(ctx,
-`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
-pidNeg, domainID, "neg-mask", rid, int64(-1),
-); err != nil {
-t.Fatal(err)
-}
-if _, err := s.db.ExecContext(ctx,
-`INSERT INTO user_permissions (domain_id, user_id, permission_id) VALUES (?, ?, ?)`,
-domainID, uid, pidNeg,
-); err != nil {
-t.Fatal(err)
-}
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pidZero, DomainID: domainID, Title: "zero-mask", ResourceID: rid, AccessMask: 0}); err != nil {
-t.Fatal(err)
-}
-if err := s.GrantUserPermission(ctx, domainID, uid, pidZero); err != nil {
-t.Fatal(err)
-}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
+		pidNeg, domainID, "neg-mask", rid, int64(-1),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO user_permissions (domain_id, user_id, permission_id) VALUES (?, ?, ?)`,
+		domainID, uid, pidNeg,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pidZero, DomainID: domainID, Title: "zero-mask", ResourceID: rid, AccessMask: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pidZero); err != nil {
+		t.Fatal(err)
+	}
 
-list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
-if err != nil {
-t.Fatal(err)
-}
-if total != 0 || len(list) != 0 {
-t.Fatalf("non-positive masks should be excluded: total=%d len=%d", total, len(list))
-}
+	list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 || len(list) != 0 {
+		t.Fatalf("non-positive masks should be excluded: total=%d len=%d", total, len(list))
+	}
 }
 
 func TestResourceAuthzUsersList_otherDomainsExcluded(t *testing.T) {
-ctx := context.Background()
-s := newTestStore(t)
+	ctx := context.Background()
+	s := newTestStore(t)
 
-domainID := uuid.NewString()
-otherDomainID := uuid.NewString()
-rid := uuid.NewString()
-uid := uuid.NewString()
-otherUID := uuid.NewString()
-pid := uuid.NewString()
+	domainID := uuid.NewString()
+	otherDomainID := uuid.NewString()
+	rid := uuid.NewString()
+	uid := uuid.NewString()
+	otherUID := uuid.NewString()
+	pid := uuid.NewString()
 
-if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
-t.Fatal(err)
-}
-if err := s.DomainCreate(ctx, &store.Domain{ID: otherDomainID, Title: "other"}); err != nil {
-t.Fatal(err)
-}
-if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
-t.Fatal(err)
-}
-if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
-t.Fatal(err)
-}
-if err := s.UserCreate(ctx, &store.User{ID: otherUID, DomainID: otherDomainID, Title: "o"}); err != nil {
-t.Fatal(err)
-}
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x1}); err != nil {
-t.Fatal(err)
-}
-if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
-t.Fatal(err)
-}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: otherDomainID, Title: "other"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: otherUID, DomainID: otherDomainID, Title: "o"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
 
-list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
-if err != nil {
-t.Fatal(err)
-}
-if total != 1 || len(list) != 1 || list[0].UserID != uid {
-t.Fatalf("other-domain users must not appear: total=%d list=%+v", total, list)
-}
+	list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 || list[0].UserID != uid {
+		t.Fatalf("other-domain users must not appear: total=%d list=%+v", total, list)
+	}
 }
 
 func TestResourceAuthzUsersList_limitClampedAtMaxLimit(t *testing.T) {
-ctx := context.Background()
-s := newTestStore(t)
+	ctx := context.Background()
+	s := newTestStore(t)
 
-domainID := uuid.NewString()
-rid := uuid.NewString()
-pid := uuid.NewString()
-if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
-t.Fatal(err)
-}
-if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
-t.Fatal(err)
-}
-if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
-t.Fatal(err)
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantTotal := store.MaxLimit + 5
+	for i := 0; i < wantTotal; i++ {
+		uid := uuid.NewString()
+		if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: fmt.Sprintf("u-%03d", i)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, total1, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: store.MaxLimit + 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total1 != int64(wantTotal) {
+		t.Fatalf("total1: want %d, got %d", wantTotal, total1)
+	}
+	if len(page1) != store.MaxLimit {
+		t.Fatalf("page1 len: want %d, got %d", store.MaxLimit, len(page1))
+	}
+
+	page2, total2, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: store.MaxLimit, Limit: store.MaxLimit + 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total2 != int64(wantTotal) {
+		t.Fatalf("total2: want %d, got %d", wantTotal, total2)
+	}
+	if len(page2) != wantTotal-store.MaxLimit {
+		t.Fatalf("page2 len: want %d, got %d", wantTotal-store.MaxLimit, len(page2))
+	}
 }
 
-wantTotal := store.MaxLimit + 5
-for i := 0; i < wantTotal; i++ {
-uid := uuid.NewString()
-if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: fmt.Sprintf("u-%03d", i)}); err != nil {
-t.Fatal(err)
-}
-if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
-t.Fatal(err)
-}
-}
-
-page1, total1, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: store.MaxLimit + 50})
-if err != nil {
-t.Fatal(err)
-}
-if total1 != int64(wantTotal) {
-t.Fatalf("total1: want %d, got %d", wantTotal, total1)
-}
-if len(page1) != store.MaxLimit {
-t.Fatalf("page1 len: want %d, got %d", store.MaxLimit, len(page1))
-}
-
-page2, total2, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: store.MaxLimit, Limit: store.MaxLimit + 50})
-if err != nil {
-t.Fatal(err)
-}
-if total2 != int64(wantTotal) {
-t.Fatalf("total2: want %d, got %d", wantTotal, total2)
-}
-if len(page2) != wantTotal-store.MaxLimit {
-t.Fatalf("page2 len: want %d, got %d", wantTotal-store.MaxLimit, len(page2))
-}
+func TestResourceAuthzUsersBaseArgs_orderMatchesPlaceholders(t *testing.T) {
+	got := resourceAuthzUsersBaseArgs("D", "R")
+	want := []any{"D", "D", "R", "D", "D", "D"}
+	if len(got) != len(want) {
+		t.Fatalf("len: want %d, got %d", len(want), len(got))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("arg[%d]: want %v, got %v", i, want[i], got[i])
+		}
+	}
+	// Sanity: the SQL must contain exactly one '?' per arg position.
+	if got, want := strings.Count(resourceAuthzUsersBaseSQL, "?"), len(want); got != want {
+		t.Fatalf("placeholder count: want %d, got %d", want, got)
+	}
 }

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -3468,3 +3468,307 @@ func TestList_queryContextError(t *testing.T) {
 		}
 	})
 }
+
+func TestResourceAuthzUsersList(t *testing.T) {
+ctx := context.Background()
+s := newTestStore(t)
+
+domainID := uuid.NewString()
+if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+t.Fatal(err)
+}
+rid := uuid.NewString()
+if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+t.Fatal(err)
+}
+
+// Create three users:
+// uA: direct grant 0x1 + group grant 0x4 -> 0x5
+// uB: group grant only 0x2 -> 0x2
+// uC: direct grant 0x8 plus another direct 0x10 -> 0x18
+// uX: no access (must NOT appear)
+uA := uuid.NewString()
+uB := uuid.NewString()
+uC := uuid.NewString()
+uX := uuid.NewString()
+for _, u := range []string{uA, uB, uC, uX} {
+if err := s.UserCreate(ctx, &store.User{ID: u, DomainID: domainID, Title: "u-" + u}); err != nil {
+t.Fatal(err)
+}
+}
+
+gid := uuid.NewString()
+if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+t.Fatal(err)
+}
+if err := s.AddUserToGroup(ctx, domainID, uA, gid); err != nil {
+t.Fatal(err)
+}
+if err := s.AddUserToGroup(ctx, domainID, uB, gid); err != nil {
+t.Fatal(err)
+}
+
+pUserA := uuid.NewString()
+pGroup := uuid.NewString()
+pUserC1 := uuid.NewString()
+pUserC2 := uuid.NewString()
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserA, DomainID: domainID, Title: "pUserA", ResourceID: rid, AccessMask: 0x1}); err != nil {
+t.Fatal(err)
+}
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pGroup", ResourceID: rid, AccessMask: 0x2 | 0x4}); err != nil {
+t.Fatal(err)
+}
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC1, DomainID: domainID, Title: "pUserC1", ResourceID: rid, AccessMask: 0x8}); err != nil {
+t.Fatal(err)
+}
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pUserC2, DomainID: domainID, Title: "pUserC2", ResourceID: rid, AccessMask: 0x10}); err != nil {
+t.Fatal(err)
+}
+
+if err := s.GrantUserPermission(ctx, domainID, uA, pUserA); err != nil {
+t.Fatal(err)
+}
+if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+t.Fatal(err)
+}
+if err := s.GrantUserPermission(ctx, domainID, uC, pUserC1); err != nil {
+t.Fatal(err)
+}
+if err := s.GrantUserPermission(ctx, domainID, uC, pUserC2); err != nil {
+t.Fatal(err)
+}
+
+// uA -> 0x1 (direct) | 0x6 (group) = 0x7
+// uB -> 0x6 (group)
+// uC -> 0x18
+wantMasks := map[string]uint64{uA: 0x7, uB: 0x6, uC: 0x18}
+
+list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+if err != nil {
+t.Fatal(err)
+}
+if total != 3 {
+t.Fatalf("total: want 3, got %d", total)
+}
+if len(list) != 3 {
+t.Fatalf("len: want 3, got %d", len(list))
+}
+gotMasks := map[string]uint64{}
+for _, it := range list {
+gotMasks[it.UserID] = it.EffectiveMask
+}
+for u, m := range wantMasks {
+if gotMasks[u] != m {
+t.Fatalf("user %s mask: want %#x, got %#x", u, m, gotMasks[u])
+}
+}
+if _, ok := gotMasks[uX]; ok {
+t.Fatalf("uX with no access must not appear")
+}
+
+// Pagination + ordering by user_id ASC.
+page, pageTotal, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 1, Limit: 1})
+if err != nil {
+t.Fatal(err)
+}
+if pageTotal != 3 || len(page) != 1 {
+t.Fatalf("pagination: total=%d len=%d", pageTotal, len(page))
+}
+orderedIDs := []string{uA, uB, uC}
+sort.Strings(orderedIDs)
+if page[0].UserID != orderedIDs[1] {
+t.Fatalf("pagination user: want %s, got %s", orderedIDs[1], page[0].UserID)
+}
+
+emptyPage, emptyTotal, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 99, Limit: 10})
+if err != nil {
+t.Fatal(err)
+}
+if emptyTotal != 3 || len(emptyPage) != 0 {
+t.Fatalf("past end: total=%d len=%d", emptyTotal, len(emptyPage))
+}
+}
+
+func TestResourceAuthzUsersList_notFound(t *testing.T) {
+ctx := context.Background()
+s := newTestStore(t)
+
+domainID := uuid.NewString()
+if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+t.Fatal(err)
+}
+rid := uuid.NewString()
+if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+t.Fatal(err)
+}
+
+if _, _, err := s.ResourceAuthzUsersList(ctx, uuid.NewString(), rid, store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+t.Fatalf("unknown domain: want ErrNotFound, got %v", err)
+}
+if _, _, err := s.ResourceAuthzUsersList(ctx, domainID, uuid.NewString(), store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
+}
+}
+
+func TestResourceAuthzUsersList_noUsers(t *testing.T) {
+ctx := context.Background()
+s := newTestStore(t)
+
+domainID := uuid.NewString()
+rid := uuid.NewString()
+if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+t.Fatal(err)
+}
+if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+t.Fatal(err)
+}
+
+list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+if err != nil {
+t.Fatal(err)
+}
+if total != 0 || len(list) != 0 {
+t.Fatalf("no users: total=%d len=%d", total, len(list))
+}
+}
+
+func TestResourceAuthzUsersList_nonPositiveMasksExcluded(t *testing.T) {
+ctx := context.Background()
+s := newTestStore(t)
+
+domainID := uuid.NewString()
+rid := uuid.NewString()
+uid := uuid.NewString()
+pidNeg := uuid.NewString()
+pidZero := uuid.NewString()
+
+if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+t.Fatal(err)
+}
+if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+t.Fatal(err)
+}
+if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+t.Fatal(err)
+}
+
+if _, err := s.db.ExecContext(ctx,
+`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
+pidNeg, domainID, "neg-mask", rid, int64(-1),
+); err != nil {
+t.Fatal(err)
+}
+if _, err := s.db.ExecContext(ctx,
+`INSERT INTO user_permissions (domain_id, user_id, permission_id) VALUES (?, ?, ?)`,
+domainID, uid, pidNeg,
+); err != nil {
+t.Fatal(err)
+}
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pidZero, DomainID: domainID, Title: "zero-mask", ResourceID: rid, AccessMask: 0}); err != nil {
+t.Fatal(err)
+}
+if err := s.GrantUserPermission(ctx, domainID, uid, pidZero); err != nil {
+t.Fatal(err)
+}
+
+list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+if err != nil {
+t.Fatal(err)
+}
+if total != 0 || len(list) != 0 {
+t.Fatalf("non-positive masks should be excluded: total=%d len=%d", total, len(list))
+}
+}
+
+func TestResourceAuthzUsersList_otherDomainsExcluded(t *testing.T) {
+ctx := context.Background()
+s := newTestStore(t)
+
+domainID := uuid.NewString()
+otherDomainID := uuid.NewString()
+rid := uuid.NewString()
+uid := uuid.NewString()
+otherUID := uuid.NewString()
+pid := uuid.NewString()
+
+if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+t.Fatal(err)
+}
+if err := s.DomainCreate(ctx, &store.Domain{ID: otherDomainID, Title: "other"}); err != nil {
+t.Fatal(err)
+}
+if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+t.Fatal(err)
+}
+if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+t.Fatal(err)
+}
+if err := s.UserCreate(ctx, &store.User{ID: otherUID, DomainID: otherDomainID, Title: "o"}); err != nil {
+t.Fatal(err)
+}
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x1}); err != nil {
+t.Fatal(err)
+}
+if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+t.Fatal(err)
+}
+
+list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+if err != nil {
+t.Fatal(err)
+}
+if total != 1 || len(list) != 1 || list[0].UserID != uid {
+t.Fatalf("other-domain users must not appear: total=%d list=%+v", total, list)
+}
+}
+
+func TestResourceAuthzUsersList_limitClampedAtMaxLimit(t *testing.T) {
+ctx := context.Background()
+s := newTestStore(t)
+
+domainID := uuid.NewString()
+rid := uuid.NewString()
+pid := uuid.NewString()
+if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+t.Fatal(err)
+}
+if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+t.Fatal(err)
+}
+if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+t.Fatal(err)
+}
+
+wantTotal := store.MaxLimit + 5
+for i := 0; i < wantTotal; i++ {
+uid := uuid.NewString()
+if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: fmt.Sprintf("u-%03d", i)}); err != nil {
+t.Fatal(err)
+}
+if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+t.Fatal(err)
+}
+}
+
+page1, total1, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: store.MaxLimit + 50})
+if err != nil {
+t.Fatal(err)
+}
+if total1 != int64(wantTotal) {
+t.Fatalf("total1: want %d, got %d", wantTotal, total1)
+}
+if len(page1) != store.MaxLimit {
+t.Fatalf("page1 len: want %d, got %d", store.MaxLimit, len(page1))
+}
+
+page2, total2, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{Offset: store.MaxLimit, Limit: store.MaxLimit + 50})
+if err != nil {
+t.Fatal(err)
+}
+if total2 != int64(wantTotal) {
+t.Fatalf("total2: want %d, got %d", wantTotal, total2)
+}
+if len(page2) != wantTotal-store.MaxLimit {
+t.Fatalf("page2 len: want %d, got %d", wantTotal-store.MaxLimit, len(page2))
+}
+}

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -65,6 +65,13 @@ type GroupAuthzResource struct {
 	Mask       uint64
 }
 
+// ResourceAuthzUser is one row in the resource authz users listing: a user
+// in the resource's domain whose effective mask on that resource is non-zero.
+type ResourceAuthzUser struct {
+	UserID        string
+	EffectiveMask uint64
+}
+
 const (
 	DefaultLimit = 20
 	MaxLimit     = 100
@@ -190,6 +197,7 @@ type Store interface {
 	AuthzReader
 	UserAuthzResourcesList(ctx context.Context, domainID, userID string, opts ListOpts) ([]UserAuthzResource, int64, error)
 	GroupAuthzResourcesList(ctx context.Context, domainID, groupID string, opts ListOpts) ([]GroupAuthzResource, int64, error)
+	ResourceAuthzUsersList(ctx context.Context, domainID, resourceID string, opts ListOpts) ([]ResourceAuthzUser, int64, error)
 
 	DomainCreate(ctx context.Context, d *Domain) error
 	DomainGet(ctx context.Context, id string) (*Domain, error)

--- a/plan/phase-6/T05-authz-benchmarks-load-tests.md
+++ b/plan/phase-6/T05-authz-benchmarks-load-tests.md
@@ -36,6 +36,10 @@ Measure **authz check** latency and throughput under realistic data sizes: **Go 
 
 - Production load testing customer data.
 
+## Deferred from other PRs
+
+- **From T44 (#59 / PR #71) review:** add a perf/regression benchmark for `Store.ResourceAuthzUsersList` (sqlite) that simulates large user/membership counts (1000+ users with mixed direct + group-inherited grants on a single resource). Today the implementation uses a per-user `EXISTS` predicate plus two batched `IN` aggregation queries, bounded by `store.MaxLimit` (100). The benchmark should both establish a baseline and let us evaluate a single-query GROUP BY / aggregated bit-OR alternative if numbers warrant it.
+
 ## Dependencies
 
 - **T4** optional comparison target.

--- a/plan/phase-6/T48-typed-invalidinputerror.md
+++ b/plan/phase-6/T48-typed-invalidinputerror.md
@@ -42,3 +42,7 @@ Replace fragile string-prefix extraction used by `publicInvalidInputMsg` with a 
 ## Dependencies
 
 - Related to **T31** (handler error classification); coordinate with that plan if overlapping work is scheduled.
+
+## Deferred from other PRs
+
+- **From T44 (#59 / PR #71) review:** the brittle `err.Error()` prefix parsing in `publicInvalidInputMsg` was flagged again. T48 already owns the typed-error refactor — no T44-specific change needed beyond noting the additional motivation.

--- a/plan/phase-6/T49-shared-authz-response-dtos.md
+++ b/plan/phase-6/T49-shared-authz-response-dtos.md
@@ -1,0 +1,56 @@
+# T49 — Centralise shared authz listing response DTOs
+
+## Ticket
+
+**T49** — Centralise shared authz listing response DTOs (GitHub [#72](https://github.com/DanyalTorabi/access-manager/issues/72))
+
+## Phase
+
+**Phase 6** — P3 scale, prod, hardening
+
+## Goal
+
+Reduce duplication in the small per-handler response structs used by the three authz listing endpoints (T42 user→resources, T43 group→resources, T44 resource→users; later T45 resource→groups) by extracting one or more shared DTO types and (optionally) a small mapping helper. Today each handler defines its own `*Response` struct with two fields and an inline mapping loop, which is fine in isolation but is starting to repeat.
+
+## Deliverables
+
+- One small DTO package (or a few exported types in `go/internal/api`) covering the authz listing response shapes:
+  - `{principal_id (or resource_id), mask-as-decimal-string}` rows
+  - shared mapping helper that converts `[]store.X` → `[]DTO`
+- Handlers (`userAuthzResources`, `groupAuthzResources`, `resourceAuthzUsers`, plus T45 once landed) updated to use the shared DTO/helper.
+- No JSON wire-format change — every existing field name and decimal-string formatting must be preserved exactly. Existing API/integration/e2e tests must pass without modification.
+- Optional: short doc comment on the shared type referencing the OpenAPI schemas (`UserAuthzResource`, `GroupAuthzResource`, `ResourceAuthzUser`, `ResourceAuthzGroup`).
+
+## Steps
+
+1. Inventory the existing per-handler response structs in `go/internal/api/server.go`:
+   `userAuthzResourceResponse`, `groupAuthzResourceResponse`, `resourceAuthzUserResponse`, plus T45's response when added.
+2. Decide on the shared shape — likely two small types because the JSON field names differ (`resource_id` vs `user_id`/`group_id` and `effective_mask` vs `mask`).
+3. Extract those types and a `toDTOSlice` helper (generic over the source row type) and route all four handlers through it.
+4. Run `make test` (existing API + e2e tests) and `make lint`; confirm no JSON payload diffs.
+
+## Files / paths
+
+- `go/internal/api/server.go` (DTO extraction + handler updates)
+- `go/internal/api/server_test.go` (no behavioural change expected; only update if struct names referenced)
+- Possibly a new `go/internal/api/authz_dto.go` if grouping is preferred.
+
+## Acceptance criteria
+
+- The four authz listing handlers share their response DTOs / mapping helper instead of defining bespoke per-handler structs.
+- Wire format (field names, decimal-string masks, list envelope) is unchanged — existing API and e2e tests pass without edits.
+- `make test` and `make lint` clean.
+
+## Out of scope
+
+- Renaming any JSON field or changing mask serialization format.
+- Refactoring non-authz list responses.
+- Changing pagination meta semantics.
+
+## Dependencies
+
+- Best done after **T45** (#60) is merged so all four endpoints exist and can be migrated in one pass.
+
+## Deferred from other PRs
+
+- **From T44 (#59 / PR #71) review (CM13):** the suggestion to centralise shared authz DTOs to reduce duplication. Deferred to this ticket because the cleanup is most valuable once T45 lands and there is a fourth handler to migrate in the same change.


### PR DESCRIPTION
## Summary

Implements `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/users` (T44): paginated list of users in the resource's domain whose effective mask on that resource is non-zero. Each item carries `effective_mask` = OR of direct user grants and grants inherited via group membership. Uses a stable `ORDER BY u.id ASC` and exposes only `offset` / `limit` (search/sort/order are not honoured here, matching T42/T43).

Implementation notes:
- Page selection runs a single SELECT against `users u WHERE u.domain_id = ? AND EXISTS(<effective predicate>)`, ordered/limited.
- Mask aggregation for the returned page is done with two batched `IN (?,…)` queries (direct `user_permissions` + group-membership grants), then OR'd per user.
- Domain and resource existence are validated up front and map to 404 via `store.ErrNotFound`.
- Non-positive permission masks are excluded (`p.access_mask > 0`), consistent with T42/T43.

## Ticket

Fixes #59 — T44 (plan/phase-6/T44-resource-authz-users.md), under umbrella #56 / T41.

## Checklist

- [x] `make test` and `make lint` pass (from repo root)
- [x] e2e suite (`make e2e` against a local `go run ./cmd/server`) passes locally
- [x] OpenAPI (`api/openapi.yaml`) and Postman collection updated
- [x] CHANGELOG "Unreleased" entry added
- [x] No secrets or real `.env` values committed