### PR TITLE
feat(authz): T45 — list groups with direct access on a resource (#60)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,0 +1,47 @@
+---
+name: Task / Plan ticket
+about: Track work that has (or needs) a plan file under `plan/`
+title: "[T##] short imperative title"
+labels: []
+---
+
+<!--
+TITLE FORMAT (required): "[T##] short imperative title"
+  • Use the next free Tnn (see existing files under plan/phase-*/).
+  • Examples of good titles:
+      [T50] Fix double increment of authz_checks_total
+      [T48] Typed InvalidInputError and stable public messages
+
+PRIORITY LABEL (required): set exactly one of P1 / P2 / P3 on this issue
+before submitting. The repo's labels are:
+  • P1  — During active development
+  • P2  — Next (after core flows stabilize)
+  • P3  — Later (scale, prod, hardening)
+
+NOTE: Do NOT reuse a closed Tnn for a new ticket. T31 (#42) in particular
+is closed; do not write `TODO(T31)` for unrelated follow-ups.
+-->
+
+## Problem / motivation
+
+<!-- What is wrong, missing, or risky today, and why it matters. -->
+
+## Proposed work
+
+<!-- Bullet list of the deliverables this ticket covers. -->
+
+-
+
+## Plan
+
+See [plan/phase-N/T##-short-name.md](../../plan/phase-N/T##-short-name.md).
+
+## Acceptance criteria
+
+<!-- Bullet list of testable outcomes that mean this ticket is done. -->
+
+-
+
+## Discovered in / related
+
+<!-- Optional: PR or issue that surfaced this work, related Tnn dependencies. -->

--- a/.github/instructions/go.instructions.md
+++ b/.github/instructions/go.instructions.md
@@ -6,10 +6,11 @@ applyTo: "go/**/*.go"
 
 ## Error Handling
 
-- HTTP handlers: return 400 for validation/client errors, 500 for unexpected/internal errors.
-- `store.ErrNotFound` → 404 (used in get, list, delete, and `groupSetParent` handlers).
-- `groupSetParent`: returns 404 when the group or parent is not found, 400 for self-parent/cycle/domain-mismatch validation errors. Other store errors currently also fall through to 400 — see TODO(T31).
-- `addUserToGroup`, `grantUserPermission`, `grantGroupPermission`: currently map **all** store errors to 400 (FK violations are client errors, but closed-DB or unexpected errors should be 500). Tracked in TODO(T31) — requires typed errors in the store layer.
+- HTTP handlers: return 400 for validation/client errors, 404 for not-found, 500 for unexpected/internal errors.
+- `store.ErrNotFound` → 404; `store.ErrFKViolation` (invalid reference / FK violation) → 400; `store.ErrConflict` → 409; `store.ErrInvalidInput` → 400; everything else → 500. Use the shared `writeStoreErr` helper in handlers — do not roll a new mapping.
+- `groupSetParent`: 404 when the group/parent is not found, 400 for self-parent / cycle / domain-mismatch validation errors, otherwise routed through `writeStoreErr`.
+- `addUserToGroup`, `grantUserPermission`, `grantGroupPermission`: also use `writeStoreErr`, so FK violations → 400, duplicates → 409, broken-DB / unexpected → 500.
+- When deferring an issue, reference the matching plan file (`// TODO(T<NN>): ...`) where `T<NN>` is the actual plan you mean — do **not** copy `T31` as a placeholder. T31 is closed (#42) and refers specifically to handler error classification.
 
 ## Concurrency
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **T45 / #60:** `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/groups` — paginated list of groups holding at least one direct `group_permissions` grant on the resource. Each item carries `mask` (OR of all direct group grants for that `(domain, group, resource)`). Only `offset` and `limit` are supported; results are always ordered by `group_id` ascending (any `search`/`search_type`/`sort`/`order` query param returns `400`).
 - **T44 / #59:** `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/users` — paginated list of users in the resource's domain with non-zero effective access on the resource. Each item carries `effective_mask` (OR of direct user grants and grants inherited via group membership). Only `offset` and `limit` are supported; results are always ordered by `user_id` ascending (any `search`/`search_type`/`sort`/`order` query param returns `400`).
 - **T43 / #58:** `GET /api/v1/domains/{domainID}/groups/{groupID}/authz/resources` — paginated list of resources where the group has direct `group_permissions`, with `mask` = bitwise OR of all grants for that `(domain, group, resource)`.
 - **`make gosec`** target in `go/Makefile` and root `Makefile` for running `gosec` security scanner.

--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -434,6 +434,18 @@ components:
           description: Effective mask (OR of direct user grants and group-membership grants) for this user/resource pair as decimal string.
           example: "7"
 
+    ResourceAuthzGroup:
+      type: object
+      required: [group_id, mask]
+      properties:
+        group_id:
+          type: string
+          format: uuid
+        mask:
+          type: string
+          description: OR of all direct group grants for this group/resource pair as decimal string.
+          example: "5"
+
 paths:
   /health:
     get:
@@ -1582,6 +1594,65 @@ paths:
                   offset: 0
                   limit: 20
                   sort: "user_id"
+                  order: "asc"
+        "400":
+          description: Bad request (invalid pagination params)
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "404":
+          description: Domain or resource not found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+        "401":
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorBody"
+
+  /api/v1/domains/{domainID}/resources/{resourceID}/authz/groups:
+    parameters:
+      - $ref: "#/components/parameters/domainID"
+      - $ref: "#/components/parameters/resourceID"
+    get:
+      tags: [Authz]
+      summary: List groups with direct access on a resource
+      description: |
+        Returns groups that have at least one direct grant via `group_permissions` on this resource.
+        Masks are returned as decimal strings (OR of all direct group grants per group).
+
+        Pagination: only `offset` and `limit` are supported. Results are always ordered by `group_id` ascending — `sort` and `order` are not honoured for this endpoint, and any of `search`, `search_type`, `sort`, or `order` in the query string will produce a `400`.
+      parameters:
+        - $ref: "#/components/parameters/offsetParam"
+        - $ref: "#/components/parameters/limitParam"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [data, meta]
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/ResourceAuthzGroup"
+                  meta:
+                    $ref: "#/components/schemas/ListMeta"
+              example:
+                data:
+                  - group_id: "11111111-1111-1111-1111-111111111111"
+                    mask: "5"
+                meta:
+                  total: 1
+                  offset: 0
+                  limit: 20
+                  sort: "group_id"
                   order: "asc"
         "400":
           description: Bad request (invalid pagination params)

--- a/api/postman/access-manager.postman_collection.json
+++ b/api/postman/access-manager.postman_collection.json
@@ -166,6 +166,7 @@
     {"name": "Authz masks", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/authz/masks?user_id={{userId}}&resource_id={{resourceId}}"}},
     {"name": "List user authz resources", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/authz/resources?offset=0&limit=20"}},
     {"name": "List resource authz users", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/resources/{{resourceId}}/authz/users?offset=0&limit=20"}},
+    {"name": "List resource authz groups", "request": {"method": "GET", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/resources/{{resourceId}}/authz/groups?offset=0&limit=20"}},
     {"name": "Revoke group permission", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/groups/{{groupId}}/permissions/{{permissionId}}"}},
     {"name": "Revoke user permission", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/permissions/{{permissionId}}"}},
     {"name": "Remove user from group", "request": {"method": "DELETE", "url": "{{baseUrl}}/api/v1/domains/{{domainId}}/users/{{userId}}/groups/{{groupId}}"}},

--- a/go/e2e/authz_test.go
+++ b/go/e2e/authz_test.go
@@ -405,3 +405,83 @@ func TestAuthz_resourceUsersList(t *testing.T) {
 		t.Fatalf("page user: want %s, got %s", orderedIDs[1], pageItems[0].UserID)
 	}
 }
+
+func TestAuthz_resourceGroupsList(t *testing.T) {
+	c := httpClient()
+	did := seedDomain(t, c, "authz-resource-groups")
+	cleanupDelete(t, c, apiBase()+"/domains/"+did)
+
+	rid := seedResource(t, c, did, "r")
+	cleanupDelete(t, c, domainBase(did)+"/resources/"+rid)
+
+	gA := seedGroup(t, c, did, "gA")
+	gB := seedGroup(t, c, did, "gB")
+	gX := seedGroup(t, c, did, "gX")
+	cleanupDelete(t, c, domainBase(did)+"/groups/"+gA)
+	cleanupDelete(t, c, domainBase(did)+"/groups/"+gB)
+	cleanupDelete(t, c, domainBase(did)+"/groups/"+gX)
+
+	// Two grants for gA on rid (OR = 0x1|0x4 = 5), one grant for gB (0x2).
+	pA1 := seedPermission(t, c, did, "pA1", rid, "0x1")
+	pA2 := seedPermission(t, c, did, "pA2", rid, "0x4")
+	pB := seedPermission(t, c, did, "pB", rid, "0x2")
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pA1)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pA2)
+	cleanupDelete(t, c, domainBase(did)+"/permissions/"+pB)
+
+	grantGroupPerm(t, c, did, gA, pA1)
+	grantGroupPerm(t, c, did, gA, pA2)
+	grantGroupPerm(t, c, did, gB, pB)
+	cleanupRevokeGroupPerm(t, c, did, gA, pA1)
+	cleanupRevokeGroupPerm(t, c, did, gA, pA2)
+	cleanupRevokeGroupPerm(t, c, did, gB, pB)
+
+	type authzGroup struct {
+		GroupID string `json:"group_id"`
+		Mask    string `json:"mask"`
+	}
+
+	base := fmt.Sprintf("%s/resources/%s/authz/groups", domainBase(did), rid)
+	env := mustList(t, c, base+"?offset=0&limit=10")
+	if env.Meta.Total != 2 {
+		t.Fatalf("total: want 2 (gA + gB; gX has no grants), got %d", env.Meta.Total)
+	}
+	var items []authzGroup
+	if err := json.Unmarshal(env.Data, &items); err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("items len: want 2, got %d", len(items))
+	}
+	got := map[string]string{}
+	for _, it := range items {
+		got[it.GroupID] = it.Mask
+	}
+	if got[gA] != "5" {
+		t.Fatalf("gA mask: want 5 (0x1|0x4), got %q", got[gA])
+	}
+	if got[gB] != "2" {
+		t.Fatalf("gB mask: want 2, got %q", got[gB])
+	}
+	if _, ok := got[gX]; ok {
+		t.Fatalf("gX must not appear (no grants)")
+	}
+
+	// Pagination: ordered by group_id ASC.
+	page := mustList(t, c, base+"?offset=1&limit=1")
+	if page.Meta.Total != 2 {
+		t.Fatalf("page total: want 2, got %d", page.Meta.Total)
+	}
+	var pageItems []authzGroup
+	if err := json.Unmarshal(page.Data, &pageItems); err != nil {
+		t.Fatal(err)
+	}
+	if len(pageItems) != 1 {
+		t.Fatalf("page len: want 1, got %d", len(pageItems))
+	}
+	orderedIDs := []string{gA, gB}
+	sort.Strings(orderedIDs)
+	if pageItems[0].GroupID != orderedIDs[1] {
+		t.Fatalf("page group: want %s, got %s", orderedIDs[1], pageItems[0].GroupID)
+	}
+}

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -103,6 +103,7 @@ func (s *Server) Router(reg prometheus.Registerer, gather prometheus.Gatherer) c
 		r.Get("/domains/{domainID}/groups/{groupID}/authz/resources", s.groupAuthzResources)
 
 		r.Get("/domains/{domainID}/resources/{resourceID}/authz/users", s.resourceAuthzUsers)
+		r.Get("/domains/{domainID}/resources/{resourceID}/authz/groups", s.resourceAuthzGroups)
 
 		r.Get("/domains/{domainID}/authz/check", s.authzCheck)
 		r.Get("/domains/{domainID}/authz/masks", s.authzMasks)
@@ -886,6 +887,40 @@ func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
 		resp = append(resp, resourceAuthzUserResponse{
 			UserID:        it.UserID,
 			EffectiveMask: strconv.FormatUint(it.EffectiveMask, 10),
+		})
+	}
+	writeList(w, resp, total, opts)
+}
+
+type resourceAuthzGroupResponse struct {
+	GroupID string `json:"group_id"`
+	Mask    string `json:"mask"`
+}
+
+const resourceAuthzGroupsSortField = "group_id"
+
+func (s *Server) resourceAuthzGroups(w http.ResponseWriter, r *http.Request) {
+	opts, err := parseOffsetLimitOpts(r)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err)
+		return
+	}
+	// Populated for meta only; the store enforces fixed ORDER BY group_permissions.group_id ASC.
+	opts.Sort = resourceAuthzGroupsSortField
+	opts.Order = store.OrderAsc
+
+	domainID := chi.URLParam(r, "domainID")
+	rid := chi.URLParam(r, "resourceID")
+	list, total, err := s.Store.ResourceAuthzGroupsList(r.Context(), domainID, rid, opts)
+	if err != nil {
+		writeStoreErr(w, r, err)
+		return
+	}
+	resp := make([]resourceAuthzGroupResponse, 0, len(list))
+	for _, it := range list {
+		resp = append(resp, resourceAuthzGroupResponse{
+			GroupID: it.GroupID,
+			Mask:    strconv.FormatUint(it.Mask, 10),
 		})
 	}
 	writeList(w, resp, total, opts)

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -1015,6 +1015,174 @@ func TestAPI_resourceAuthzUsers_notFound(t *testing.T) {
 	}
 }
 
+func TestAPI_resourceAuthzGroups_integration(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	gA := uuid.NewString()
+	gB := uuid.NewString()
+
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	for _, gid := range []string{gA, gB} {
+		if err := st.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g" + gid}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// gA gets two grants on rid (OR = 0x1 | 0x4 = 0x5), gB gets one (0x2).
+	pA1 := uuid.NewString()
+	pA2 := uuid.NewString()
+	pB := uuid.NewString()
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pA1, DomainID: domainID, Title: "pA1", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pA2, DomainID: domainID, Title: "pA2", ResourceID: rid, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.PermissionCreate(ctx, &store.Permission{ID: pB, DomainID: domainID, Title: "pB", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantGroupPermission(ctx, domainID, gA, pA1); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantGroupPermission(ctx, domainID, gA, pA2); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.GrantGroupPermission(ctx, domainID, gB, pB); err != nil {
+		t.Fatal(err)
+	}
+
+	base := ts.URL + "/api/v1/domains/" + domainID + "/resources/" + rid + "/authz/groups"
+
+	res, err := http.Get(base + "?offset=0&limit=10")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("status %d: %s", res.StatusCode, b)
+	}
+	var env listResponse[struct {
+		GroupID string `json:"group_id"`
+		Mask    string `json:"mask"`
+	}]
+	if err := json.NewDecoder(res.Body).Decode(&env); err != nil {
+		t.Fatal(err)
+	}
+	if env.Meta.Total != 2 {
+		t.Fatalf("total: want 2, got %d", env.Meta.Total)
+	}
+	if len(env.Data) != 2 {
+		t.Fatalf("len: want 2, got %d", len(env.Data))
+	}
+	gotMasks := map[string]string{}
+	for _, it := range env.Data {
+		gotMasks[it.GroupID] = it.Mask
+	}
+	if gotMasks[gA] != "5" {
+		t.Fatalf("gA mask: want 5, got %q", gotMasks[gA])
+	}
+	if gotMasks[gB] != "2" {
+		t.Fatalf("gB mask: want 2, got %q", gotMasks[gB])
+	}
+
+	// Pagination: ordered by group_id ASC.
+	resPage, err := http.Get(base + "?offset=1&limit=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resPage.Body.Close() }()
+	if resPage.StatusCode != http.StatusOK {
+		t.Fatalf("page status %d", resPage.StatusCode)
+	}
+	var page listResponse[struct {
+		GroupID string `json:"group_id"`
+		Mask    string `json:"mask"`
+	}]
+	if err := json.NewDecoder(resPage.Body).Decode(&page); err != nil {
+		t.Fatal(err)
+	}
+	if page.Meta.Total != 2 || len(page.Data) != 1 {
+		t.Fatalf("page: total=%d len=%d", page.Meta.Total, len(page.Data))
+	}
+	orderedIDs := []string{gA, gB}
+	sort.Strings(orderedIDs)
+	if page.Data[0].GroupID != orderedIDs[1] {
+		t.Fatalf("page group: want %s, got %s", orderedIDs[1], page.Data[0].GroupID)
+	}
+	if page.Meta.Sort != "group_id" || page.Meta.Order != "asc" {
+		t.Fatalf("page meta sort/order: got sort=%q order=%q", page.Meta.Sort, page.Meta.Order)
+	}
+}
+
+func TestAPI_resourceAuthzGroups_unsupportedQueryParams(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	res, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/resources/" + rid + "/authz/groups?search=foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = res.Body.Close() }()
+	if res.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(res.Body)
+		t.Fatalf("unsupported params: want 400, got %d: %s", res.StatusCode, b)
+	}
+	var out map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["error"] != "only limit and offset are supported" {
+		t.Fatalf("unexpected error message: %q", out["error"])
+	}
+}
+
+func TestAPI_resourceAuthzGroups_notFound(t *testing.T) {
+	ts, st := newTestAPI(t)
+	ctx := context.Background()
+	domainID := uuid.NewString()
+	if err := st.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := st.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	resUnknownDomain, err := http.Get(ts.URL + "/api/v1/domains/" + uuid.NewString() + "/resources/" + rid + "/authz/groups")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resUnknownDomain.Body.Close() }()
+	if resUnknownDomain.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown domain: want 404, got %d", resUnknownDomain.StatusCode)
+	}
+
+	resUnknownResource, err := http.Get(ts.URL + "/api/v1/domains/" + domainID + "/resources/" + uuid.NewString() + "/authz/groups")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resUnknownResource.Body.Close() }()
+	if resUnknownResource.StatusCode != http.StatusNotFound {
+		t.Fatalf("unknown resource: want 404, got %d", resUnknownResource.StatusCode)
+	}
+}
+
 func TestAPI_userList_empty(t *testing.T) {
 	ts, _ := newTestAPI(t)
 	var dom store.Domain
@@ -2476,6 +2644,7 @@ func TestAPI_storeErrors(t *testing.T) {
 		{"userAuthzResources", http.MethodGet, "/api/v1/domains/" + domID + "/users/" + userID + "/authz/resources", "", 500},
 		{"groupAuthzResources", http.MethodGet, "/api/v1/domains/" + domID + "/groups/" + groupID + "/authz/resources", "", 500},
 		{"resourceAuthzUsers", http.MethodGet, "/api/v1/domains/" + domID + "/resources/" + resourceID + "/authz/users", "", 500},
+		{"resourceAuthzGroups", http.MethodGet, "/api/v1/domains/" + domID + "/resources/" + resourceID + "/authz/groups", "", 500},
 		{"revokeGroupPerm", http.MethodDelete, "/api/v1/domains/" + domID + "/groups/" + groupID + "/permissions/" + permID, "", 500},
 		{"authzCheck", http.MethodGet, "/api/v1/domains/" + domID + "/authz/check?user_id=" + userID + "&resource_id=" + resourceID + "&access_bit=0x1", "", 500},
 		{"authzMasks", http.MethodGet, "/api/v1/domains/" + domID + "/authz/masks?user_id=" + userID + "&resource_id=" + resourceID, "", 500},

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1104,6 +1104,117 @@ func (s *Store) GroupAuthzResourcesList(ctx context.Context, domainID, groupID s
 	return result, total, nil
 }
 
+// resourceAuthzGroupsBaseSQL joins permissions with group_permissions to
+// select groups holding at least one direct group_permissions grant on
+// (domainID, resourceID). domain_id appears twice: once for p (permissions
+// row) and once for gp (group_permissions row) because both tables carry
+// domain_id independently. p.access_mask > 0 mirrors GroupAuthzResourcesList
+// and ResourceAuthzUsersList: zero masks are no-ops, and any negative legacy
+// values (which PermissionCreate disallows) are excluded for parity with
+// maskFromSQL.
+const resourceAuthzGroupsBaseSQL = `
+FROM permissions p
+INNER JOIN group_permissions gp ON gp.permission_id = p.id
+WHERE p.domain_id = ? AND gp.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0
+`
+
+func (s *Store) ResourceAuthzGroupsList(ctx context.Context, domainID, resourceID string, opts store.ListOpts) ([]store.ResourceAuthzGroup, int64, error) {
+	opts = store.SanitizeListOpts(opts)
+
+	var exists int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM domains WHERE id = ?`, domainID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, store.ErrNotFound
+		}
+		return nil, 0, err
+	}
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM resources WHERE id = ? AND domain_id = ?`, resourceID, domainID).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, 0, store.ErrNotFound
+		}
+		return nil, 0, err
+	}
+
+	baseArgs := []any{domainID, domainID, resourceID}
+
+	var total int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT gp.group_id) `+resourceAuthzGroupsBaseSQL, baseArgs...).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	// opts.Sort / opts.Order are populated by the handler and reflected in the
+	// meta response via writeList. The store always uses a fixed ORDER BY
+	// gp.group_id ASC — Sort/Order opts are not honoured here because the
+	// endpoint intentionally exposes only stable deterministic ordering.
+	listArgs := append(append([]any{}, baseArgs...), opts.Limit, opts.Offset)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT DISTINCT gp.group_id `+resourceAuthzGroupsBaseSQL+` ORDER BY gp.group_id ASC LIMIT ? OFFSET ?`, // #nosec G202
+		listArgs...,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var groupIDs []string
+	for rows.Next() {
+		var gid string
+		if err := rows.Scan(&gid); err != nil {
+			_ = rows.Close()
+			return nil, 0, err
+		}
+		groupIDs = append(groupIDs, gid)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return nil, 0, err
+	}
+	if err := rows.Close(); err != nil {
+		return nil, 0, err
+	}
+	if len(groupIDs) == 0 {
+		return []store.ResourceAuthzGroup{}, total, nil
+	}
+
+	placeholders, err := inPlaceholders(len(groupIDs))
+	if err != nil {
+		return nil, 0, err
+	}
+	maskSQL := `SELECT gp.group_id, p.access_mask FROM permissions p ` + // #nosec G202
+		`INNER JOIN group_permissions gp ON gp.permission_id = p.id ` +
+		`WHERE p.domain_id = ? AND gp.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0 ` +
+		`AND gp.group_id IN (` + placeholders + `)`
+	maskArgs := make([]any, 0, 3+len(groupIDs))
+	maskArgs = append(maskArgs, domainID, domainID, resourceID)
+	for _, gid := range groupIDs {
+		maskArgs = append(maskArgs, gid)
+	}
+
+	maskRows, err := s.db.QueryContext(ctx, maskSQL, maskArgs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer func() { _ = maskRows.Close() }()
+
+	masksByGroup := make(map[string]uint64, len(groupIDs))
+	for maskRows.Next() {
+		var gid string
+		var m int64
+		if err := maskRows.Scan(&gid, &m); err != nil {
+			return nil, 0, err
+		}
+		masksByGroup[gid] |= maskFromSQL(m)
+	}
+	if err := maskRows.Err(); err != nil {
+		return nil, 0, err
+	}
+
+	result := make([]store.ResourceAuthzGroup, 0, len(groupIDs))
+	for _, gid := range groupIDs {
+		result = append(result, store.ResourceAuthzGroup{GroupID: gid, Mask: masksByGroup[gid]})
+	}
+	return result, total, nil
+}
+
 // resourceAuthzUsersBaseSQL selects users in the resource's domain who have a
 // non-zero effective mask on (domainID, resourceID) via direct grants OR via
 // any group they belong to.

--- a/go/internal/store/sqlite/store.go
+++ b/go/internal/store/sqlite/store.go
@@ -1104,18 +1104,28 @@ func (s *Store) GroupAuthzResourcesList(ctx context.Context, domainID, groupID s
 	return result, total, nil
 }
 
-// resourceAuthzGroupsBaseSQL joins permissions with group_permissions to
-// select groups holding at least one direct group_permissions grant on
-// (domainID, resourceID). domain_id appears twice: once for p (permissions
-// row) and once for gp (group_permissions row) because both tables carry
-// domain_id independently. p.access_mask > 0 mirrors GroupAuthzResourcesList
-// and ResourceAuthzUsersList: zero masks are no-ops, and any negative legacy
+// resourceAuthzGroupsBaseSQL joins permissions with group_permissions and
+// the groups table to select groups holding at least one direct
+// group_permissions grant on (domainID, resourceID).
+//
+// We must filter on BOTH gp.domain_id AND g.domain_id: the
+// group_permissions(group_id) FK references only groups(id) (not the
+// composite (domain_id, id)), and GrantGroupPermission does not validate
+// domain membership. Without the g.domain_id filter, a group from another
+// domain that was granted a permission under this domain (via an
+// out-of-band insert or future cross-domain bug) would leak into the
+// listing. domain_id therefore appears three times: once for p
+// (permissions), once for gp (group_permissions), once for g (groups).
+//
+// p.access_mask > 0 mirrors GroupAuthzResourcesList and
+// ResourceAuthzUsersList: zero masks are no-ops, and any negative legacy
 // values (which PermissionCreate disallows) are excluded for parity with
 // maskFromSQL.
 const resourceAuthzGroupsBaseSQL = `
 FROM permissions p
 INNER JOIN group_permissions gp ON gp.permission_id = p.id
-WHERE p.domain_id = ? AND gp.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0
+INNER JOIN groups g ON g.id = gp.group_id
+WHERE p.domain_id = ? AND gp.domain_id = ? AND g.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0
 `
 
 func (s *Store) ResourceAuthzGroupsList(ctx context.Context, domainID, resourceID string, opts store.ListOpts) ([]store.ResourceAuthzGroup, int64, error) {
@@ -1135,7 +1145,7 @@ func (s *Store) ResourceAuthzGroupsList(ctx context.Context, domainID, resourceI
 		return nil, 0, err
 	}
 
-	baseArgs := []any{domainID, domainID, resourceID}
+	baseArgs := []any{domainID, domainID, domainID, resourceID}
 
 	var total int64
 	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(DISTINCT gp.group_id) `+resourceAuthzGroupsBaseSQL, baseArgs...).Scan(&total); err != nil {
@@ -1181,10 +1191,11 @@ func (s *Store) ResourceAuthzGroupsList(ctx context.Context, domainID, resourceI
 	}
 	maskSQL := `SELECT gp.group_id, p.access_mask FROM permissions p ` + // #nosec G202
 		`INNER JOIN group_permissions gp ON gp.permission_id = p.id ` +
-		`WHERE p.domain_id = ? AND gp.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0 ` +
+		`INNER JOIN groups g ON g.id = gp.group_id ` +
+		`WHERE p.domain_id = ? AND gp.domain_id = ? AND g.domain_id = ? AND p.resource_id = ? AND p.access_mask > 0 ` +
 		`AND gp.group_id IN (` + placeholders + `)`
-	maskArgs := make([]any, 0, 3+len(groupIDs))
-	maskArgs = append(maskArgs, domainID, domainID, resourceID)
+	maskArgs := make([]any, 0, 4+len(groupIDs))
+	maskArgs = append(maskArgs, domainID, domainID, domainID, resourceID)
 	for _, gid := range groupIDs {
 		maskArgs = append(maskArgs, gid)
 	}

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -4010,6 +4010,19 @@ func TestResourceAuthzGroupsList_otherDomainsExcluded(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Insert a cross-domain group_permissions row directly: the row's
+	// domain_id matches the queried domain (so gp.domain_id passes), but
+	// otherGID belongs to otherDomainID. group_permissions(group_id) FKs to
+	// groups(id) only — not the composite (domain_id, id) — so this insert
+	// succeeds even with PRAGMA foreign_keys=ON. The store must still
+	// exclude otherGID from the listing.
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO group_permissions (domain_id, group_id, permission_id) VALUES (?, ?, ?)`,
+		domainID, otherGID, pid,
+	); err != nil {
+		t.Fatal(err)
+	}
+
 	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
 	if err != nil {
 		t.Fatal(err)

--- a/go/internal/store/sqlite/store_test.go
+++ b/go/internal/store/sqlite/store_test.go
@@ -3790,3 +3790,282 @@ func TestResourceAuthzUsersBaseArgs_orderMatchesPlaceholders(t *testing.T) {
 		t.Fatalf("placeholder count: want %d, got %d", wantCount, got)
 	}
 }
+
+func TestResourceAuthzGroupsList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Three groups:
+	// gA: two grants on rid (0x1 + 0x4 -> mask 0x5)
+	// gB: one grant on rid (0x2 -> mask 0x2)
+	// gX: no grants on rid (must NOT appear)
+	gA := uuid.NewString()
+	gB := uuid.NewString()
+	gX := uuid.NewString()
+	for _, g := range []string{gA, gB, gX} {
+		if err := s.GroupCreate(ctx, &store.Group{ID: g, DomainID: domainID, Title: "g-" + g}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pA1 := uuid.NewString()
+	pA2 := uuid.NewString()
+	pB := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pA1, DomainID: domainID, Title: "pA1", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pA2, DomainID: domainID, Title: "pA2", ResourceID: rid, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pB, DomainID: domainID, Title: "pB", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gA, pA1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gA, pA2); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gB, pB); err != nil {
+		t.Fatal(err)
+	}
+
+	wantMasks := map[string]uint64{gA: 0x5, gB: 0x2}
+
+	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("total: want 2, got %d", total)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len: want 2, got %d", len(list))
+	}
+	gotMasks := map[string]uint64{}
+	for _, it := range list {
+		gotMasks[it.GroupID] = it.Mask
+	}
+	for g, m := range wantMasks {
+		if gotMasks[g] != m {
+			t.Fatalf("group %s mask: want %#x, got %#x", g, m, gotMasks[g])
+		}
+	}
+	if _, ok := gotMasks[gX]; ok {
+		t.Fatalf("gX with no grants must not appear")
+	}
+
+	page, pageTotal, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 1, Limit: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pageTotal != 2 || len(page) != 1 {
+		t.Fatalf("pagination: total=%d len=%d", pageTotal, len(page))
+	}
+	orderedIDs := []string{gA, gB}
+	sort.Strings(orderedIDs)
+	if page[0].GroupID != orderedIDs[1] {
+		t.Fatalf("pagination group: want %s, got %s", orderedIDs[1], page[0].GroupID)
+	}
+
+	emptyPage, emptyTotal, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 99, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if emptyTotal != 2 || len(emptyPage) != 0 {
+		t.Fatalf("past end: total=%d len=%d", emptyTotal, len(emptyPage))
+	}
+}
+
+func TestResourceAuthzGroupsList_notFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, _, err := s.ResourceAuthzGroupsList(ctx, uuid.NewString(), rid, store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown domain: want ErrNotFound, got %v", err)
+	}
+	if _, _, err := s.ResourceAuthzGroupsList(ctx, domainID, uuid.NewString(), store.ListOpts{Offset: 0, Limit: 10}); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestResourceAuthzGroupsList_noGroups(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 || len(list) != 0 {
+		t.Fatalf("no groups: total=%d len=%d", total, len(list))
+	}
+}
+
+func TestResourceAuthzGroupsList_nonPositiveMasksExcluded(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	gid := uuid.NewString()
+	pidNeg := uuid.NewString()
+	pidZero := uuid.NewString()
+
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO permissions (id, domain_id, title, resource_id, access_mask) VALUES (?, ?, ?, ?, ?)`,
+		pidNeg, domainID, "neg-mask", rid, int64(-1),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO group_permissions (domain_id, group_id, permission_id) VALUES (?, ?, ?)`,
+		domainID, gid, pidNeg,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pidZero, DomainID: domainID, Title: "zero-mask", ResourceID: rid, AccessMask: 0}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pidZero); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 0 || len(list) != 0 {
+		t.Fatalf("non-positive masks should be excluded: total=%d len=%d", total, len(list))
+	}
+}
+
+func TestResourceAuthzGroupsList_otherDomainsExcluded(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	otherDomainID := uuid.NewString()
+	rid := uuid.NewString()
+	gid := uuid.NewString()
+	otherGID := uuid.NewString()
+	pid := uuid.NewString()
+
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: otherDomainID, Title: "other"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: otherGID, DomainID: otherDomainID, Title: "o"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 || list[0].GroupID != gid {
+		t.Fatalf("other-domain groups must not appear: total=%d list=%+v", total, list)
+	}
+}
+
+func TestResourceAuthzGroupsList_limitClampedAtMaxLimit(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+
+	domainID := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	wantTotal := store.MaxLimit + 5
+	for i := 0; i < wantTotal; i++ {
+		gid := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: fmt.Sprintf("g-%03d", i)}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, total1, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: 0, Limit: store.MaxLimit + 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total1 != int64(wantTotal) {
+		t.Fatalf("total1: want %d, got %d", wantTotal, total1)
+	}
+	if len(page1) != store.MaxLimit {
+		t.Fatalf("page1 len: want %d, got %d", store.MaxLimit, len(page1))
+	}
+
+	page2, total2, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{Offset: store.MaxLimit, Limit: store.MaxLimit + 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total2 != int64(wantTotal) {
+		t.Fatalf("total2: want %d, got %d", wantTotal, total2)
+	}
+	if len(page2) != wantTotal-store.MaxLimit {
+		t.Fatalf("page2 len: want %d, got %d", wantTotal-store.MaxLimit, len(page2))
+	}
+}

--- a/go/internal/store/store.go
+++ b/go/internal/store/store.go
@@ -72,6 +72,14 @@ type ResourceAuthzUser struct {
 	EffectiveMask uint64
 }
 
+// ResourceAuthzGroup is one row in the resource authz groups listing: a group
+// with at least one direct group_permissions grant on the resource. Mask is
+// the OR of contributing access_mask values.
+type ResourceAuthzGroup struct {
+	GroupID string
+	Mask    uint64
+}
+
 const (
 	DefaultLimit = 20
 	MaxLimit     = 100
@@ -198,6 +206,7 @@ type Store interface {
 	UserAuthzResourcesList(ctx context.Context, domainID, userID string, opts ListOpts) ([]UserAuthzResource, int64, error)
 	GroupAuthzResourcesList(ctx context.Context, domainID, groupID string, opts ListOpts) ([]GroupAuthzResource, int64, error)
 	ResourceAuthzUsersList(ctx context.Context, domainID, resourceID string, opts ListOpts) ([]ResourceAuthzUser, int64, error)
+	ResourceAuthzGroupsList(ctx context.Context, domainID, resourceID string, opts ListOpts) ([]ResourceAuthzGroup, int64, error)
 
 	DomainCreate(ctx context.Context, d *Domain) error
 	DomainGet(ctx context.Context, id string) (*Domain, error)

--- a/plan/phase-6/T05-authz-benchmarks-load-tests.md
+++ b/plan/phase-6/T05-authz-benchmarks-load-tests.md
@@ -39,6 +39,9 @@ Measure **authz check** latency and throughput under realistic data sizes: **Go 
 ## Deferred from other PRs
 
 - **From T44 (#59 / PR #71) review:** add a perf/regression benchmark for `Store.ResourceAuthzUsersList` (sqlite) that simulates large user/membership counts (1000+ users with mixed direct + group-inherited grants on a single resource). Today the implementation uses a per-user `EXISTS` predicate plus two batched `IN` aggregation queries, bounded by `store.MaxLimit` (100). The benchmark should both establish a baseline and let us evaluate a single-query GROUP BY / aggregated bit-OR alternative if numbers warrant it.
+- **From T45 (#60 / PR #73) review:** external-agent comments **CML3** and **CML9**.
+  - **CML3:** `Store.ResourceAuthzGroupsList` (and the sibling `ResourceAuthzUsersList` / `GroupAuthzResourcesList`) batch-aggregates masks via `IN (?, …)` clauses bounded by `store.MaxLimit` (100). Safe today against SQLite's parameter cap (≥999), but if `MaxLimit` is ever raised significantly the `IN` approach must be reworked (chunk the IDs or fold mask aggregation into the page-select). Add a benchmark that varies the page size near the SQLite parameter cap and document the chunking strategy when triggered.
+  - **CML9:** `GroupSetParent`'s parent-chain cycle detection uses a defensive `maxSteps = 1_000_000` loop. Not a hot path today, but for very deep / pathological tenant graphs this could become expensive. Add a benchmark over a deep parent chain (e.g. 10k+ levels) so we can decide whether to lower the bound, switch to recursive CTE, or memoise.
 
 ## Dependencies
 

--- a/plan/phase-6/T31-handler-error-classification.md
+++ b/plan/phase-6/T31-handler-error-classification.md
@@ -56,8 +56,3 @@ Handlers that mutate relationships (`addUserToGroup`, `grantUserPermission`, `gr
 
 - **T10** (unit test patterns), **T30** (coverage thresholds).
 
-## Deferred from other PRs
-
-- **From T45 (#60 / PR #73) review:** external-agent comments **CML4** and **CML6**.
-  - **CML4:** `wrapConstraintError` in `go/internal/store/sqlite/store.go` falls back to substring matching of error strings (e.g. `"foreign key constraint failed"`). This is fragile across driver/message changes. Once typed sentinels exist (this ticket + T48), centralise the mapping and remove the substring fallback where the driver exposes a numeric code.
-  - **CML6:** delete/exec helpers are inconsistent — some use `wrapConstraintError`, others (e.g. `RemoveUserFromGroup`, `RevokeUserPermission`, `RevokeGroupPermission`) return the raw `err`. Sweep these as part of the typed-error work so all mutating helpers classify errors uniformly.

--- a/plan/phase-6/T31-handler-error-classification.md
+++ b/plan/phase-6/T31-handler-error-classification.md
@@ -55,3 +55,9 @@ Handlers that mutate relationships (`addUserToGroup`, `grantUserPermission`, `gr
 ## Dependencies
 
 - **T10** (unit test patterns), **T30** (coverage thresholds).
+
+## Deferred from other PRs
+
+- **From T45 (#60 / PR #73) review:** external-agent comments **CML4** and **CML6**.
+  - **CML4:** `wrapConstraintError` in `go/internal/store/sqlite/store.go` falls back to substring matching of error strings (e.g. `"foreign key constraint failed"`). This is fragile across driver/message changes. Once typed sentinels exist (this ticket + T48), centralise the mapping and remove the substring fallback where the driver exposes a numeric code.
+  - **CML6:** delete/exec helpers are inconsistent — some use `wrapConstraintError`, others (e.g. `RemoveUserFromGroup`, `RevokeUserPermission`, `RevokeGroupPermission`) return the raw `err`. Sweep these as part of the typed-error work so all mutating helpers classify errors uniformly.

--- a/plan/phase-6/T48-typed-invalidinputerror.md
+++ b/plan/phase-6/T48-typed-invalidinputerror.md
@@ -46,4 +46,7 @@ Replace fragile string-prefix extraction used by `publicInvalidInputMsg` with a 
 ## Deferred from other PRs
 
 - **From T44 (#59 / PR #71) review:** the brittle `err.Error()` prefix parsing in `publicInvalidInputMsg` was flagged again. T48 already owns the typed-error refactor — no T44-specific change needed beyond noting the additional motivation.
-- **From T45 (#60 / PR #73) review:** external-agent comment **CML5** flagged the same `publicInvalidInputMsg` string-prefix coupling (`"store: invalid input: "`). Same disposition: T48 owns the fix; no separate T45 change needed.
+- **From T45 (#60 / PR #73) review:**
+  - **CML5:** same `publicInvalidInputMsg` string-prefix coupling (`"store: invalid input: "`). Disposition: T48 owns the fix; no separate change needed.
+  - **CML4:** `wrapConstraintError` in `go/internal/store/sqlite/store.go` falls back to substring matching of error strings (e.g. `"foreign key constraint failed"`). Fragile across driver/message changes. T31 (#42) introduced typed FK sentinels but the substring fallback remains. While typing more invalid-input branches in T48, also centralise the constraint-error mapping and remove the substring fallback where the driver exposes a numeric code.
+  - **CML6:** delete/exec helpers are inconsistent — some use `wrapConstraintError`, others (e.g. `RemoveUserFromGroup`, `RevokeUserPermission`, `RevokeGroupPermission`) return the raw `err`. Sweep these as part of the typed-error work so all mutating helpers classify errors uniformly.

--- a/plan/phase-6/T48-typed-invalidinputerror.md
+++ b/plan/phase-6/T48-typed-invalidinputerror.md
@@ -46,3 +46,4 @@ Replace fragile string-prefix extraction used by `publicInvalidInputMsg` with a 
 ## Deferred from other PRs
 
 - **From T44 (#59 / PR #71) review:** the brittle `err.Error()` prefix parsing in `publicInvalidInputMsg` was flagged again. T48 already owns the typed-error refactor — no T44-specific change needed beyond noting the additional motivation.
+- **From T45 (#60 / PR #73) review:** external-agent comment **CML5** flagged the same `publicInvalidInputMsg` string-prefix coupling (`"store: invalid input: "`). Same disposition: T48 owns the fix; no separate T45 change needed.

--- a/plan/phase-6/T50-authz-metric-double-increment.md
+++ b/plan/phase-6/T50-authz-metric-double-increment.md
@@ -1,0 +1,69 @@
+# T50 — Fix double increment of `authz_checks_total` (and add per-request test)
+
+**Issue:** [#74](https://github.com/DanyalTorabi/access-manager/issues/74)
+
+## Phase
+
+**Phase 6** — P3 scale, prod, hardening
+
+## Goal
+
+Make the `authz_checks_total` Prometheus counter accurately reflect **one increment per request**, with a label that distinguishes success from failure. Today both `authzCheck` and `authzMasks` increment the counter twice on success and once on failure, which breaks dashboards/alerts.
+
+## Background
+
+In [`go/internal/api/server.go`](../../go/internal/api/server.go), `authzCheck` (around lines 968–984) and `authzMasks` (around lines 996–1006) each call:
+
+```go
+if s.metrics != nil {
+    s.metrics.AuthzTotal.WithLabelValues(domainID).Inc()
+}
+```
+
+**twice** — once before the store call and once after. Effects:
+
+- Successful requests are double-counted.
+- Failing requests are single-counted (the post-call `Inc()` is skipped because of the early `return`).
+- The counter cannot be used for "success rate" or "total throughput" without ad-hoc compensation.
+
+## Deliverables
+
+- `authzCheck` and `authzMasks` each increment the counter **exactly once per request**.
+- A `result` label (`"ok"` / `"err"`) is added to `AuthzTotal` (or, equivalently, two separate counters), recorded once at the end of the handler (e.g. via a `defer` or after the success/error branch).
+- Unit tests assert the increment count for both success and error paths (validation error, closed/broken DB).
+- Grafana dashboard / Prometheus query examples updated if the metric shape changes (label addition is backwards-compatible if existing queries sum across labels, but the dashboard JSON should be reviewed).
+- README / observability docs updated to describe the new `result` label.
+
+## Steps
+
+1. Refactor `internal/api/metrics.go` so `AuthzTotal` carries the `result` label (or split into `authz_checks_success_total` + `authz_checks_error_total` — pick one and document the rationale).
+2. Update `authzCheck` and `authzMasks` to record the metric exactly once at the end of the request, including in early-return error paths (parse error, missing required params, store error).
+3. Add unit tests in `internal/api/metrics_test.go` (or `server_test.go`) that:
+   - Issue one successful `authzCheck` / `authzMasks` request and assert the corresponding metric value increases by exactly 1 with `result="ok"`.
+   - Issue one failing request (e.g. via `newBrokenTestAPI`) and assert the metric increases by exactly 1 with `result="err"`.
+4. Grep the codebase for any other handlers that double-increment metrics (defensive sweep).
+5. Update Grafana dashboard JSON under `observability/` if needed; update `go/README.md` and any observability docs.
+6. Run `make test`, `make lint`, `make cover`.
+
+## Files / paths
+
+- **Edit:** `go/internal/api/metrics.go`, `go/internal/api/server.go`, `go/internal/api/metrics_test.go` (or new `*_test.go`), `observability/grafana/dashboards/*.json`, `go/README.md`.
+
+## Acceptance criteria
+
+- Each `authzCheck` / `authzMasks` request produces exactly one increment of the relevant counter.
+- Tests fail if the double-increment regression is reintroduced.
+- `make test`, `make lint` pass.
+
+## Out of scope
+
+- Adding new authz metrics beyond fixing the double-increment + result label.
+- Changing other counters (e.g. `http_requests_total`) unless the defensive sweep reveals the same bug.
+
+## Dependencies
+
+- **T23** (Observability) — original metric setup.
+
+## Discovered in
+
+- **PR [#73](https://github.com/DanyalTorabi/access-manager/pull/73) (T45 / #60) review:** external-agent comments **CML1**, **CML2**, **CML10** flagged the double-increment, the missing `result` label, and the lack of a per-request increment test. Out of scope for T45 (handler change, not authz listing) and tracked here.


### PR DESCRIPTION
## Summary

Implements `GET /api/v1/domains/{domainID}/resources/{resourceID}/authz/groups`: a paginated listing of groups that hold at least one direct `group_permissions` grant on the resource, with `mask` = bitwise OR of contributing `access_mask` values per group. Results are always ordered by `group_id` ascending; only `offset` and `limit` are accepted (any `search`/`search_type`/`sort`/`order` query param returns `400`). Mirrors the T43 group-side endpoint, plus full integration + e2e + OpenAPI/Postman/CHANGELOG updates.

Highlights:

- New `store.ResourceAuthzGroup` type and `Store.ResourceAuthzGroupsList` interface method.
- SQLite implementation: paginated `SELECT DISTINCT gp.group_id` followed by a single batched `IN (?,…)` mask-aggregation query, mirroring `GroupAuthzResourcesList`. `p.access_mask > 0` excludes both zero-mask no-ops and any legacy negative values.
- HTTP handler `resourceAuthzGroups` + route registration; meta returns `sort=group_id`, `order=asc`.
- Store unit tests: happy path, ordering+pagination, notFound (unknown domain/resource), no-groups, non-positive masks excluded, other-domain groups excluded, and `MaxLimit` clamp.
- API integration tests: happy path, pagination meta, unsupported query params, notFound; broken-store row added so a closed-DB request classifies as `500`.
- E2E `TestAuthz_resourceGroupsList` (gA two grants OR'd to `5`, gB grant `2`, gX excluded; ASC pagination).
- OpenAPI: new `ResourceAuthzGroup` schema + path documented. Postman: `List resource authz groups` request added.
- CHANGELOG: Unreleased entry under T45 / #60.

## Ticket

Fixes #60 — plan: [plan/phase-6/T45-resource-authz-groups.md](plan/phase-6/T45-resource-authz-groups.md).

## Checklist

- [x] `make test` and `make lint` pass (from repo root)
- [x] Docs updated if behavior or setup changed (OpenAPI, Postman, CHANGELOG)
- [x] No secrets or real `.env` values committed
