### PR TITLE
[T47] API: normalize numeric parse errors and return stable 400

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **T47 / #68:** API numeric parsing for `bit` / `access_mask` (and `authz/check?access_bit=`) no longer leaks raw `strconv.ParseUint` text or echoes user input. Malformed values now return `400 Bad Request` with the stable message `invalid numeric value`; values above the signed-63 limit are rejected at the API boundary with the existing `mask value must be within signed 64-bit range` message before reaching the store.
+
 - **T36 / #47:** API error responses no longer expose internal SQL/driver details. All error bodies use stable, database-agnostic messages (`resource not found`, `referenced entity does not exist or is still referenced`, `internal server error`, etc.). Full errors are logged server-side for operator diagnostics.
 
 - **T46 / #67:** Temporary limitation — access masks are limited to the lower 63 bits (SQLite `INTEGER` is signed 64-bit and current storage casts to `int64`). The API now rejects access-type and permission create/patch requests whose `bit` or `access_mask` would set bit 63 with `400 Bad Request` ("mask value must be within signed 64-bit range"); the SQLite store enforces the same boundary defensively. To be removed by a v2 migration tracked in [#67](https://github.com/DanyalTorabi/access-manager/issues/67).

--- a/go/e2e/helpers_test.go
+++ b/go/e2e/helpers_test.go
@@ -243,9 +243,9 @@ func seedResource(t *testing.T, c *http.Client, domainID, title string) string {
 
 // seedAccessType posts a create-access-type request. The bit string is
 // passed verbatim to the API, which accepts both decimal ("4") and 0x-hex
-// ("0x4") forms via parseUint64. Callers should not normalize either form
-// here so the helpers stay in sync with the API contract documented in
-// api/openapi.yaml.
+// ("0x4") forms via parseUint64Validated. Callers should not normalize
+// either form here so the helpers stay in sync with the API contract
+// documented in api/openapi.yaml.
 func seedAccessType(t *testing.T, c *http.Client, domainID, title, bit string) string {
 	t.Helper()
 	body := fmt.Sprintf(`{"title":%q,"bit":%q}`, title, bit)

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -533,12 +533,8 @@ func (s *Server) accessTypeCreate(w http.ResponseWriter, r *http.Request) {
 	if !readJSON(w, r, &b) {
 		return
 	}
-	bit, err := parseUint64(b.Bit)
+	bit, err := parseUint64Validated(b.Bit, maxAccessMask)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
-		return
-	}
-	if err := validateAccessMask(bit); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
@@ -602,12 +598,8 @@ func (s *Server) accessTypePatch(w http.ResponseWriter, r *http.Request) {
 	}
 	params := store.AccessTypePatchParams{Title: b.Title}
 	if b.Bit != nil {
-		bit, err := parseUint64(*b.Bit)
+		bit, err := parseUint64Validated(*b.Bit, maxAccessMask)
 		if err != nil {
-			writeErr(w, http.StatusBadRequest, err)
-			return
-		}
-		if err := validateAccessMask(bit); err != nil {
 			writeErr(w, http.StatusBadRequest, err)
 			return
 		}
@@ -643,12 +635,8 @@ func (s *Server) permissionCreate(w http.ResponseWriter, r *http.Request) {
 	if !readJSON(w, r, &b) {
 		return
 	}
-	mask, err := parseUint64(b.AccessMask)
+	mask, err := parseUint64Validated(b.AccessMask, maxAccessMask)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
-		return
-	}
-	if err := validateAccessMask(mask); err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
 	}
@@ -716,12 +704,8 @@ func (s *Server) permissionPatch(w http.ResponseWriter, r *http.Request) {
 	}
 	params := store.PermissionPatchParams{Title: b.Title, ResourceID: b.ResourceID}
 	if b.AccessMask != nil {
-		mask, err := parseUint64(*b.AccessMask)
+		mask, err := parseUint64Validated(*b.AccessMask, maxAccessMask)
 		if err != nil {
-			writeErr(w, http.StatusBadRequest, err)
-			return
-		}
-		if err := validateAccessMask(mask); err != nil {
 			writeErr(w, http.StatusBadRequest, err)
 			return
 		}
@@ -976,7 +960,7 @@ func (s *Server) authzCheck(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "user_id, resource_id, and access_bit are required", http.StatusBadRequest)
 		return
 	}
-	bit, err := parseUint64(bitStr)
+	bit, err := parseUint64Validated(bitStr, maxAccessMask)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, err)
 		return
@@ -1274,24 +1258,32 @@ func readJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	return true
 }
 
-// TODO(T36): parseUint64 errors are passed to writeErr, which exposes
-// strconv.ParseUint messages containing user input. Not a SQL leak but not
-// a stable message either. Tracked on #47.
-func parseUint64(s string) (uint64, error) {
-	return strconv.ParseUint(s, 0, 64)
-}
+// errInvalidNumericValue is the stable, client-safe error returned when a
+// query/body field cannot be parsed as a uint64. It intentionally does not
+// echo back the raw input or the underlying strconv message.
+var errInvalidNumericValue = errors.New("invalid numeric value")
+
+// errAccessMaskOutOfRange is the stable, client-safe error returned when a
+// mask/bit value is parseable but exceeds the API's signed-63 limit (see
+// issue #67 / T46). Wording must stay backward-compatible with existing
+// clients and tests.
+var errAccessMaskOutOfRange = errors.New("mask value must be within signed 64-bit range")
 
 // maxAccessMask is the largest mask value permitted by the API until a v2
 // migration stores full uint64 values. Bit 63 (1<<63) is reserved to avoid
 // signed-64 overflow when masks are persisted in SQLite. See issue #67 / T46.
 const maxAccessMask uint64 = 1<<63 - 1
 
-// validateAccessMask rejects mask/bit values that would set bit 63. Returns
-// nil for values in [0, 1<<63 - 1]. The error message is stable and safe to
-// return to clients; it intentionally does not echo back the user input.
-func validateAccessMask(m uint64) error {
-	if m > maxAccessMask {
-		return errors.New("mask value must be within signed 64-bit range")
+// parseUint64Validated parses s as a uint64 (decimal or `0x` hex). When
+// max > 0 it also rejects values greater than max. The returned errors are
+// stable, client-safe sentinels and never embed the user input.
+func parseUint64Validated(s string, max uint64) (uint64, error) {
+	n, err := strconv.ParseUint(s, 0, 64)
+	if err != nil {
+		return 0, errInvalidNumericValue
 	}
-	return nil
+	if max > 0 && n > max {
+		return 0, errAccessMaskOutOfRange
+	}
+	return n, nil
 }

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -1274,11 +1274,30 @@ var errAccessMaskOutOfRange = errors.New("mask value must be within signed 64-bi
 // signed-64 overflow when masks are persisted in SQLite. See issue #67 / T46.
 const maxAccessMask uint64 = 1<<63 - 1
 
-// parseUint64Validated parses s as a uint64 (decimal or `0x` hex). When
-// max > 0 it also rejects values greater than max. The returned errors are
-// stable, client-safe sentinels and never embed the user input.
+// maxNumericInputLen caps the length of strings accepted by
+// parseUint64Validated. The longest legal input is 18 chars (`0x` + 16 hex
+// digits) for full uint64; 32 leaves comfortable headroom while bounding
+// CPU on pathological inputs without depending on outer body-size limits.
+const maxNumericInputLen = 32
+
+// parseUint64Validated parses s as a uint64 in either base 10 (decimal)
+// or base 16 (with a `0x`/`0X` prefix), matching the format documented in
+// api/openapi.yaml. Other strconv.ParseUint(base=0) modes (octal `0nnn`,
+// binary `0b…`) are intentionally rejected so the wire format stays
+// unambiguous. When max > 0 the helper also rejects values greater than
+// max. The returned errors are stable, client-safe sentinels and never
+// embed the user input.
 func parseUint64Validated(s string, max uint64) (uint64, error) {
-	n, err := strconv.ParseUint(s, 0, 64)
+	if len(s) == 0 || len(s) > maxNumericInputLen {
+		return 0, errInvalidNumericValue
+	}
+	base := 10
+	digits := s
+	if len(s) > 2 && s[0] == '0' && (s[1] == 'x' || s[1] == 'X') {
+		base = 16
+		digits = s[2:]
+	}
+	n, err := strconv.ParseUint(digits, base, 64)
 	if err != nil {
 		return 0, errInvalidNumericValue
 	}

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -4464,4 +4465,166 @@ func TestAPI_accessTypeList_invalidOrder(t *testing.T) {
 	if res.StatusCode != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", res.StatusCode)
 	}
+}
+
+// --- T47: parseUint64Validated and stable numeric parse errors ---
+
+// TestParseUint64Validated covers the validated parse helper directly: every
+// rejection path returns a stable sentinel error and never embeds the raw
+// strconv message or the user input.
+func TestParseUint64Validated(t *testing.T) {
+const max = maxAccessMask // 1<<63 - 1
+type tc struct {
+name    string
+in      string
+max     uint64
+want    uint64
+wantErr error
+}
+cases := []tc{
+{"decimal_zero", "0", max, 0, nil},
+{"decimal_small", "42", max, 42, nil},
+{"hex_lower", "0x1f", max, 31, nil},
+{"hex_upper", "0X10", max, 16, nil},
+{"max_signed64_ok", "0x7FFFFFFFFFFFFFFF", max, 1<<63 - 1, nil},
+{"max_disabled_accepts_full_uint64", "0xFFFFFFFFFFFFFFFF", 0, ^uint64(0), nil},
+
+{"empty_string", "", max, 0, errInvalidNumericValue},
+{"non_numeric", "notanumber", max, 0, errInvalidNumericValue},
+{"trailing_garbage", "12abc", max, 0, errInvalidNumericValue},
+{"negative", "-1", max, 0, errInvalidNumericValue},
+{"plus_sign", "+1", max, 0, errInvalidNumericValue},
+{"malformed_hex", "0xZZ", max, 0, errInvalidNumericValue},
+{"overflow_uint64", "0x10000000000000000", max, 0, errInvalidNumericValue},
+
+{"out_of_range_bit63", "0x8000000000000000", max, 0, errAccessMaskOutOfRange},
+{"out_of_range_max_uint64", "0xFFFFFFFFFFFFFFFF", max, 0, errAccessMaskOutOfRange},
+}
+for _, c := range cases {
+t.Run(c.name, func(t *testing.T) {
+got, err := parseUint64Validated(c.in, c.max)
+if !errors.Is(err, c.wantErr) {
+t.Fatalf("err = %v, want %v", err, c.wantErr)
+}
+if err == nil && got != c.want {
+t.Fatalf("got = %d, want %d", got, c.want)
+}
+if err != nil {
+if strings.Contains(err.Error(), c.in) && c.in != "" {
+t.Fatalf("error message %q must not echo input %q", err.Error(), c.in)
+}
+if strings.Contains(err.Error(), "strconv") {
+t.Fatalf("error message %q leaks strconv internals", err.Error())
+}
+}
+})
+}
+}
+
+// TestAPI_numericParseErrors_stableMessages asserts that the API surfaces the
+// stable "invalid numeric value" message (not strconv text) for malformed
+// numeric input on every handler that parses bit / access_mask. Status code
+// is asserted before the body is read.
+func TestAPI_numericParseErrors_stableMessages(t *testing.T) {
+ts, _ := newTestAPI(t)
+dom := mustCreateDomain(t, ts)
+base := ts.URL + "/api/v1/domains/" + dom
+rBody := mustPostJSON201(t, base+"/resources", `{"title":"r"}`)
+var resrc store.Resource
+if err := json.Unmarshal(rBody, &resrc); err != nil {
+t.Fatal(err)
+}
+atBody := mustPostJSON201(t, base+"/access-types", `{"title":"a","bit":"0x1"}`)
+var at store.AccessType
+if err := json.Unmarshal(atBody, &at); err != nil {
+t.Fatal(err)
+}
+pBody := mustPostJSON201(t, base+"/permissions", fmt.Sprintf(`{"title":"p","resource_id":%q,"access_mask":"0x1"}`, resrc.ID))
+var perm store.Permission
+if err := json.Unmarshal(pBody, &perm); err != nil {
+t.Fatal(err)
+}
+
+const wantMsg = "invalid numeric value"
+const badInput = "notanumber"
+assertBad := func(t *testing.T, res *http.Response) {
+t.Helper()
+if res.StatusCode != http.StatusBadRequest {
+b, _ := io.ReadAll(res.Body)
+_ = res.Body.Close()
+t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
+}
+b, _ := io.ReadAll(res.Body)
+_ = res.Body.Close()
+body := string(b)
+if !strings.Contains(body, wantMsg) {
+t.Fatalf("want stable message %q, got %s", wantMsg, body)
+}
+if strings.Contains(body, "strconv") || strings.Contains(body, badInput) {
+t.Fatalf("body leaks strconv text or echoes input: %s", body)
+}
+}
+doPatch := func(t *testing.T, url, body string) *http.Response {
+t.Helper()
+req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(body))
+req.Header.Set("Content-Type", "application/json")
+res, err := http.DefaultClient.Do(req)
+if err != nil {
+t.Fatal(err)
+}
+return res
+}
+
+t.Run("accessTypeCreate", func(t *testing.T) {
+res, err := http.Post(base+"/access-types", "application/json",
+strings.NewReader(`{"title":"x","bit":"`+badInput+`"}`))
+if err != nil {
+t.Fatal(err)
+}
+assertBad(t, res)
+})
+t.Run("accessTypePatch", func(t *testing.T) {
+assertBad(t, doPatch(t, base+"/access-types/"+at.ID, `{"bit":"`+badInput+`"}`))
+})
+t.Run("permissionCreate", func(t *testing.T) {
+res, err := http.Post(base+"/permissions", "application/json",
+strings.NewReader(fmt.Sprintf(`{"title":"p2","resource_id":%q,"access_mask":"`+badInput+`"}`, resrc.ID)))
+if err != nil {
+t.Fatal(err)
+}
+assertBad(t, res)
+})
+t.Run("permissionPatch", func(t *testing.T) {
+assertBad(t, doPatch(t, base+"/permissions/"+perm.ID, `{"access_mask":"`+badInput+`"}`))
+})
+t.Run("authzCheck_accessBit", func(t *testing.T) {
+url := fmt.Sprintf("%s/authz/check?user_id=u&resource_id=r&access_bit=%s", base, badInput)
+res, err := http.Get(url)
+if err != nil {
+t.Fatal(err)
+}
+assertBad(t, res)
+})
+}
+
+// TestAPI_authzCheck_accessBitOutOfRange asserts authzCheck rejects a bit
+// value above the signed-63 limit before reaching the store.
+func TestAPI_authzCheck_accessBitOutOfRange(t *testing.T) {
+ts, _ := newTestAPI(t)
+dom := mustCreateDomain(t, ts)
+url := fmt.Sprintf("%s/api/v1/domains/%s/authz/check?user_id=u&resource_id=r&access_bit=0x8000000000000000", ts.URL, dom)
+res, err := http.Get(url)
+if err != nil {
+t.Fatal(err)
+}
+if res.StatusCode != http.StatusBadRequest {
+b, _ := io.ReadAll(res.Body)
+_ = res.Body.Close()
+t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
+}
+b, _ := io.ReadAll(res.Body)
+_ = res.Body.Close()
+if !strings.Contains(string(b), "mask value must be within signed 64-bit range") {
+t.Fatalf("want stable range error, got %s", b)
+}
 }

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -4488,6 +4488,9 @@ func TestParseUint64Validated(t *testing.T) {
 		{"hex_upper", "0X10", max, 16, nil},
 		{"max_signed64_ok", "0x7FFFFFFFFFFFFFFF", max, 1<<63 - 1, nil},
 		{"max_disabled_accepts_full_uint64", "0xFFFFFFFFFFFFFFFF", 0, ^uint64(0), nil},
+		// Leading-zero decimals are not interpreted as octal (which strconv
+		// base 0 would do — "010" -> 8). Helper uses base 10 so "010" -> 10.
+		{"leading_zero_decimal", "010", max, 10, nil},
 
 		{"empty_string", "", max, 0, errInvalidNumericValue},
 		{"non_numeric", "notanumber", max, 0, errInvalidNumericValue},
@@ -4496,6 +4499,15 @@ func TestParseUint64Validated(t *testing.T) {
 		{"plus_sign", "+1", max, 0, errInvalidNumericValue},
 		{"malformed_hex", "0xZZ", max, 0, errInvalidNumericValue},
 		{"overflow_uint64", "0x10000000000000000", max, 0, errInvalidNumericValue},
+		// strconv.ParseUint(base=0) would accept these; the helper must
+		// reject them so the wire format stays "decimal or 0x hex" as
+		// documented in api/openapi.yaml.
+		{"binary_rejected", "0b10", max, 0, errInvalidNumericValue},
+		{"hex_prefix_only", "0x", max, 0, errInvalidNumericValue},
+		{"leading_whitespace", " 1", max, 0, errInvalidNumericValue},
+		{"trailing_whitespace", "1 ", max, 0, errInvalidNumericValue},
+		// Defensive length cap (maxNumericInputLen).
+		{"too_long", strings.Repeat("9", 33), max, 0, errInvalidNumericValue},
 
 		{"out_of_range_bit63", "0x8000000000000000", max, 0, errAccessMaskOutOfRange},
 		{"out_of_range_max_uint64", "0xFFFFFFFFFFFFFFFF", max, 0, errAccessMaskOutOfRange},
@@ -4549,19 +4561,21 @@ func TestAPI_numericParseErrors_stableMessages(t *testing.T) {
 	const badInput = "notanumber"
 	assertBad := func(t *testing.T, res *http.Response) {
 		t.Helper()
+		defer func() { _ = res.Body.Close() }()
 		if res.StatusCode != http.StatusBadRequest {
 			b, _ := io.ReadAll(res.Body)
-			_ = res.Body.Close()
 			t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
 		}
-		b, _ := io.ReadAll(res.Body)
-		_ = res.Body.Close()
-		body := string(b)
-		if !strings.Contains(body, wantMsg) {
-			t.Fatalf("want stable message %q, got %s", wantMsg, body)
+		var body map[string]string
+		if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
 		}
-		if strings.Contains(body, "strconv") || strings.Contains(body, badInput) {
-			t.Fatalf("body leaks strconv text or echoes input: %s", body)
+		got := body["error"]
+		if got != wantMsg {
+			t.Fatalf(`body["error"] = %q, want %q`, got, wantMsg)
+		}
+		if strings.Contains(got, badInput) {
+			t.Fatalf(`body["error"] echoes input: %q`, got)
 		}
 	}
 	doPatch := func(t *testing.T, url, body string) *http.Response {
@@ -4617,14 +4631,16 @@ func TestAPI_authzCheck_accessBitOutOfRange(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer func() { _ = res.Body.Close() }()
 	if res.StatusCode != http.StatusBadRequest {
 		b, _ := io.ReadAll(res.Body)
-		_ = res.Body.Close()
 		t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
 	}
-	b, _ := io.ReadAll(res.Body)
-	_ = res.Body.Close()
-	if !strings.Contains(string(b), "mask value must be within signed 64-bit range") {
-		t.Fatalf("want stable range error, got %s", b)
+	var body map[string]string
+	if err := json.NewDecoder(res.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if got, want := body["error"], "mask value must be within signed 64-bit range"; got != want {
+		t.Fatalf(`body["error"] = %q, want %q`, got, want)
 	}
 }

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -4473,52 +4473,52 @@ func TestAPI_accessTypeList_invalidOrder(t *testing.T) {
 // rejection path returns a stable sentinel error and never embeds the raw
 // strconv message or the user input.
 func TestParseUint64Validated(t *testing.T) {
-const max = maxAccessMask // 1<<63 - 1
-type tc struct {
-name    string
-in      string
-max     uint64
-want    uint64
-wantErr error
-}
-cases := []tc{
-{"decimal_zero", "0", max, 0, nil},
-{"decimal_small", "42", max, 42, nil},
-{"hex_lower", "0x1f", max, 31, nil},
-{"hex_upper", "0X10", max, 16, nil},
-{"max_signed64_ok", "0x7FFFFFFFFFFFFFFF", max, 1<<63 - 1, nil},
-{"max_disabled_accepts_full_uint64", "0xFFFFFFFFFFFFFFFF", 0, ^uint64(0), nil},
+	const max = maxAccessMask // 1<<63 - 1
+	type tc struct {
+		name    string
+		in      string
+		max     uint64
+		want    uint64
+		wantErr error
+	}
+	cases := []tc{
+		{"decimal_zero", "0", max, 0, nil},
+		{"decimal_small", "42", max, 42, nil},
+		{"hex_lower", "0x1f", max, 31, nil},
+		{"hex_upper", "0X10", max, 16, nil},
+		{"max_signed64_ok", "0x7FFFFFFFFFFFFFFF", max, 1<<63 - 1, nil},
+		{"max_disabled_accepts_full_uint64", "0xFFFFFFFFFFFFFFFF", 0, ^uint64(0), nil},
 
-{"empty_string", "", max, 0, errInvalidNumericValue},
-{"non_numeric", "notanumber", max, 0, errInvalidNumericValue},
-{"trailing_garbage", "12abc", max, 0, errInvalidNumericValue},
-{"negative", "-1", max, 0, errInvalidNumericValue},
-{"plus_sign", "+1", max, 0, errInvalidNumericValue},
-{"malformed_hex", "0xZZ", max, 0, errInvalidNumericValue},
-{"overflow_uint64", "0x10000000000000000", max, 0, errInvalidNumericValue},
+		{"empty_string", "", max, 0, errInvalidNumericValue},
+		{"non_numeric", "notanumber", max, 0, errInvalidNumericValue},
+		{"trailing_garbage", "12abc", max, 0, errInvalidNumericValue},
+		{"negative", "-1", max, 0, errInvalidNumericValue},
+		{"plus_sign", "+1", max, 0, errInvalidNumericValue},
+		{"malformed_hex", "0xZZ", max, 0, errInvalidNumericValue},
+		{"overflow_uint64", "0x10000000000000000", max, 0, errInvalidNumericValue},
 
-{"out_of_range_bit63", "0x8000000000000000", max, 0, errAccessMaskOutOfRange},
-{"out_of_range_max_uint64", "0xFFFFFFFFFFFFFFFF", max, 0, errAccessMaskOutOfRange},
-}
-for _, c := range cases {
-t.Run(c.name, func(t *testing.T) {
-got, err := parseUint64Validated(c.in, c.max)
-if !errors.Is(err, c.wantErr) {
-t.Fatalf("err = %v, want %v", err, c.wantErr)
-}
-if err == nil && got != c.want {
-t.Fatalf("got = %d, want %d", got, c.want)
-}
-if err != nil {
-if strings.Contains(err.Error(), c.in) && c.in != "" {
-t.Fatalf("error message %q must not echo input %q", err.Error(), c.in)
-}
-if strings.Contains(err.Error(), "strconv") {
-t.Fatalf("error message %q leaks strconv internals", err.Error())
-}
-}
-})
-}
+		{"out_of_range_bit63", "0x8000000000000000", max, 0, errAccessMaskOutOfRange},
+		{"out_of_range_max_uint64", "0xFFFFFFFFFFFFFFFF", max, 0, errAccessMaskOutOfRange},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got, err := parseUint64Validated(c.in, c.max)
+			if !errors.Is(err, c.wantErr) {
+				t.Fatalf("err = %v, want %v", err, c.wantErr)
+			}
+			if err == nil && got != c.want {
+				t.Fatalf("got = %d, want %d", got, c.want)
+			}
+			if err != nil {
+				if strings.Contains(err.Error(), c.in) && c.in != "" {
+					t.Fatalf("error message %q must not echo input %q", err.Error(), c.in)
+				}
+				if strings.Contains(err.Error(), "strconv") {
+					t.Fatalf("error message %q leaks strconv internals", err.Error())
+				}
+			}
+		})
+	}
 }
 
 // TestAPI_numericParseErrors_stableMessages asserts that the API surfaces the
@@ -4526,105 +4526,105 @@ t.Fatalf("error message %q leaks strconv internals", err.Error())
 // numeric input on every handler that parses bit / access_mask. Status code
 // is asserted before the body is read.
 func TestAPI_numericParseErrors_stableMessages(t *testing.T) {
-ts, _ := newTestAPI(t)
-dom := mustCreateDomain(t, ts)
-base := ts.URL + "/api/v1/domains/" + dom
-rBody := mustPostJSON201(t, base+"/resources", `{"title":"r"}`)
-var resrc store.Resource
-if err := json.Unmarshal(rBody, &resrc); err != nil {
-t.Fatal(err)
-}
-atBody := mustPostJSON201(t, base+"/access-types", `{"title":"a","bit":"0x1"}`)
-var at store.AccessType
-if err := json.Unmarshal(atBody, &at); err != nil {
-t.Fatal(err)
-}
-pBody := mustPostJSON201(t, base+"/permissions", fmt.Sprintf(`{"title":"p","resource_id":%q,"access_mask":"0x1"}`, resrc.ID))
-var perm store.Permission
-if err := json.Unmarshal(pBody, &perm); err != nil {
-t.Fatal(err)
-}
+	ts, _ := newTestAPI(t)
+	dom := mustCreateDomain(t, ts)
+	base := ts.URL + "/api/v1/domains/" + dom
+	rBody := mustPostJSON201(t, base+"/resources", `{"title":"r"}`)
+	var resrc store.Resource
+	if err := json.Unmarshal(rBody, &resrc); err != nil {
+		t.Fatal(err)
+	}
+	atBody := mustPostJSON201(t, base+"/access-types", `{"title":"a","bit":"0x1"}`)
+	var at store.AccessType
+	if err := json.Unmarshal(atBody, &at); err != nil {
+		t.Fatal(err)
+	}
+	pBody := mustPostJSON201(t, base+"/permissions", fmt.Sprintf(`{"title":"p","resource_id":%q,"access_mask":"0x1"}`, resrc.ID))
+	var perm store.Permission
+	if err := json.Unmarshal(pBody, &perm); err != nil {
+		t.Fatal(err)
+	}
 
-const wantMsg = "invalid numeric value"
-const badInput = "notanumber"
-assertBad := func(t *testing.T, res *http.Response) {
-t.Helper()
-if res.StatusCode != http.StatusBadRequest {
-b, _ := io.ReadAll(res.Body)
-_ = res.Body.Close()
-t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
-}
-b, _ := io.ReadAll(res.Body)
-_ = res.Body.Close()
-body := string(b)
-if !strings.Contains(body, wantMsg) {
-t.Fatalf("want stable message %q, got %s", wantMsg, body)
-}
-if strings.Contains(body, "strconv") || strings.Contains(body, badInput) {
-t.Fatalf("body leaks strconv text or echoes input: %s", body)
-}
-}
-doPatch := func(t *testing.T, url, body string) *http.Response {
-t.Helper()
-req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(body))
-req.Header.Set("Content-Type", "application/json")
-res, err := http.DefaultClient.Do(req)
-if err != nil {
-t.Fatal(err)
-}
-return res
-}
+	const wantMsg = "invalid numeric value"
+	const badInput = "notanumber"
+	assertBad := func(t *testing.T, res *http.Response) {
+		t.Helper()
+		if res.StatusCode != http.StatusBadRequest {
+			b, _ := io.ReadAll(res.Body)
+			_ = res.Body.Close()
+			t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
+		}
+		b, _ := io.ReadAll(res.Body)
+		_ = res.Body.Close()
+		body := string(b)
+		if !strings.Contains(body, wantMsg) {
+			t.Fatalf("want stable message %q, got %s", wantMsg, body)
+		}
+		if strings.Contains(body, "strconv") || strings.Contains(body, badInput) {
+			t.Fatalf("body leaks strconv text or echoes input: %s", body)
+		}
+	}
+	doPatch := func(t *testing.T, url, body string) *http.Response {
+		t.Helper()
+		req, _ := http.NewRequest(http.MethodPatch, url, strings.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return res
+	}
 
-t.Run("accessTypeCreate", func(t *testing.T) {
-res, err := http.Post(base+"/access-types", "application/json",
-strings.NewReader(`{"title":"x","bit":"`+badInput+`"}`))
-if err != nil {
-t.Fatal(err)
-}
-assertBad(t, res)
-})
-t.Run("accessTypePatch", func(t *testing.T) {
-assertBad(t, doPatch(t, base+"/access-types/"+at.ID, `{"bit":"`+badInput+`"}`))
-})
-t.Run("permissionCreate", func(t *testing.T) {
-res, err := http.Post(base+"/permissions", "application/json",
-strings.NewReader(fmt.Sprintf(`{"title":"p2","resource_id":%q,"access_mask":"`+badInput+`"}`, resrc.ID)))
-if err != nil {
-t.Fatal(err)
-}
-assertBad(t, res)
-})
-t.Run("permissionPatch", func(t *testing.T) {
-assertBad(t, doPatch(t, base+"/permissions/"+perm.ID, `{"access_mask":"`+badInput+`"}`))
-})
-t.Run("authzCheck_accessBit", func(t *testing.T) {
-url := fmt.Sprintf("%s/authz/check?user_id=u&resource_id=r&access_bit=%s", base, badInput)
-res, err := http.Get(url)
-if err != nil {
-t.Fatal(err)
-}
-assertBad(t, res)
-})
+	t.Run("accessTypeCreate", func(t *testing.T) {
+		res, err := http.Post(base+"/access-types", "application/json",
+			strings.NewReader(`{"title":"x","bit":"`+badInput+`"}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBad(t, res)
+	})
+	t.Run("accessTypePatch", func(t *testing.T) {
+		assertBad(t, doPatch(t, base+"/access-types/"+at.ID, `{"bit":"`+badInput+`"}`))
+	})
+	t.Run("permissionCreate", func(t *testing.T) {
+		res, err := http.Post(base+"/permissions", "application/json",
+			strings.NewReader(fmt.Sprintf(`{"title":"p2","resource_id":%q,"access_mask":"`+badInput+`"}`, resrc.ID)))
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBad(t, res)
+	})
+	t.Run("permissionPatch", func(t *testing.T) {
+		assertBad(t, doPatch(t, base+"/permissions/"+perm.ID, `{"access_mask":"`+badInput+`"}`))
+	})
+	t.Run("authzCheck_accessBit", func(t *testing.T) {
+		url := fmt.Sprintf("%s/authz/check?user_id=u&resource_id=r&access_bit=%s", base, badInput)
+		res, err := http.Get(url)
+		if err != nil {
+			t.Fatal(err)
+		}
+		assertBad(t, res)
+	})
 }
 
 // TestAPI_authzCheck_accessBitOutOfRange asserts authzCheck rejects a bit
 // value above the signed-63 limit before reaching the store.
 func TestAPI_authzCheck_accessBitOutOfRange(t *testing.T) {
-ts, _ := newTestAPI(t)
-dom := mustCreateDomain(t, ts)
-url := fmt.Sprintf("%s/api/v1/domains/%s/authz/check?user_id=u&resource_id=r&access_bit=0x8000000000000000", ts.URL, dom)
-res, err := http.Get(url)
-if err != nil {
-t.Fatal(err)
-}
-if res.StatusCode != http.StatusBadRequest {
-b, _ := io.ReadAll(res.Body)
-_ = res.Body.Close()
-t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
-}
-b, _ := io.ReadAll(res.Body)
-_ = res.Body.Close()
-if !strings.Contains(string(b), "mask value must be within signed 64-bit range") {
-t.Fatalf("want stable range error, got %s", b)
-}
+	ts, _ := newTestAPI(t)
+	dom := mustCreateDomain(t, ts)
+	url := fmt.Sprintf("%s/api/v1/domains/%s/authz/check?user_id=u&resource_id=r&access_bit=0x8000000000000000", ts.URL, dom)
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != http.StatusBadRequest {
+		b, _ := io.ReadAll(res.Body)
+		_ = res.Body.Close()
+		t.Fatalf("want 400, got %d: %s", res.StatusCode, b)
+	}
+	b, _ := io.ReadAll(res.Body)
+	_ = res.Body.Close()
+	if !strings.Contains(string(b), "mask value must be within signed 64-bit range") {
+		t.Fatalf("want stable range error, got %s", b)
+	}
 }


### PR DESCRIPTION
## Summary

Replaces the thin `parseUint64` wrapper (which forwarded raw `strconv.ParseUint` text and the user's input back to clients) with a single `parseUint64Validated(s, max)` helper that returns stable, client-safe sentinel errors and folds the previous separate `validateAccessMask` call into the same step. Every API site that parses `bit` / `access_mask` (access-type and permission create/patch, plus `authz/check?access_bit=`) now rejects malformed and out-of-range values at the API boundary with a fixed message, before reaching the store.

Drops `validateAccessMask` (no longer used) and the `TODO(T36)` comment that tracked this work.

## Ticket

Fixes #68 — T47 (plan: [`plan/phase-6/T47-parseuint64-error-handling.md`](plan/phase-6/T47-parseuint64-error-handling.md)).

## Checklist

- [x] `make test` and `make lint` pass (from repo root)
- [x] Docs updated if behavior or setup changed (CHANGELOG Unreleased entry; e2e helper comment refreshed)
- [x] No secrets or real `.env` values committed

## Notes for reviewers

- Wording for the range error (`"mask value must be within signed 64-bit range"`) is preserved verbatim from T46 (#67) so existing API consumers and tests keep working.
- The new parse error wording (`"invalid numeric value"`) is the new stable message — see new `TestAPI_numericParseErrors_stableMessages` and `TestParseUint64Validated`.
- `authzCheck` now also enforces the signed-63 range on `access_bit`. It was previously parse-only; range was only checked at the store layer for create/patch, never for authz checks. New `TestAPI_authzCheck_accessBitOutOfRange` covers it.
- Out of scope (tracked separately): typed `InvalidInputError` to replace `publicInvalidInputMsg` string-prefix coupling — T48 (#69).
