### PR TITLE
[T55] Thread *http.Request through writeJSON for encode-failure logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **T55 / #88:** `writeJSON` encode-failure log entries now include `method` and `path` fields so operators can identify the failing endpoint. `*http.Request` is threaded through `writeJSON`, `writeErr`, and `writeList`; all handler call sites updated. No behaviour change when encoding succeeds.
+
 ### Added
 
 - **T52 / #80:** API request/response error hardening — `writeJSON` now logs encode failures at ERROR level instead of silently discarding them; `readJSON` rejects trailing JSON tokens after the first value (returns **400** with `"request body must contain exactly one JSON value"`); request body decode failures are logged server-side with a structured `kind` label (`empty_body`, `json_syntax`, `json_type`, `json_unknown_field`, `json_decode`, `body_too_large`, `trailing_data`) without echoing raw user input in client responses or server logs; all client-facing decode error messages are now stable and sanitized. List-handler use of `writeInternalErr` is explicitly documented as intentional.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **T55 / #88:** `writeJSON` encode-failure log entries now include `method` and `path` fields so operators can identify the failing endpoint. `*http.Request` is threaded through `writeJSON`, `writeErr`, and `writeList`; all handler call sites updated. No behaviour change when encoding succeeds.
-
 ### Added
 
 - **T52 / #80:** API request/response error hardening — `writeJSON` now logs encode failures at ERROR level instead of silently discarding them; `readJSON` rejects trailing JSON tokens after the first value (returns **400** with `"request body must contain exactly one JSON value"`); request body decode failures are logged server-side with a structured `kind` label (`empty_body`, `json_syntax`, `json_type`, `json_unknown_field`, `json_decode`, `body_too_large`, `trailing_data`) without echoing raw user input in client responses or server logs; all client-facing decode error messages are now stable and sanitized. List-handler use of `writeInternalErr` is explicitly documented as intentional.
@@ -52,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **T55 / #88:** `writeJSON` encode-failure log entries now include `method` and `path` fields so operators can identify the failing endpoint. `*http.Request` is threaded through `writeJSON`, `writeErr`, and `writeList`; all handler call sites updated. No behaviour change when encoding succeeds.
 - **T50 / #74:** `authz_checks_total` now carries a `result` label (`ok`/`err`) and is incremented **exactly once per request** in `authzCheck` and `authzMasks` (previously success was double-counted and errors single-counted). Existing alert rules or queries that select `authz_checks_total{...}` without aggregating across `result` must add the new label or wrap with `sum without(result)(...)`. See T53 below for the subsequent label-cardinality fix.
 - **T53 / #81 (breaking):** `authz_checks_total` no longer carries a `domain_id` label. The metric now has exactly one label (`result=ok|err`), bounding cardinality to 2 series regardless of tenant count. The Grafana dashboard panel query is updated accordingly. **Migration:** remove `domain_id` selectors from any alert rules or external dashboards — `authz_checks_total{domain_id="..."}` will return no data after upgrade. Use `authz_checks_total{result="ok"}` / `authz_checks_total{result="err"}` instead. Per-domain debug context remains available via the HTTP request URL path in standard access logs and via `logRequestErr` slog output on error paths.
 - **T40 / #55:** `access-types` list default sort changed from `bit` to `title` for consistency with other entities. Clients relying on bit-order should sort client-side.

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -123,8 +123,8 @@ func (s *Server) Router(reg prometheus.Registerer, gather prometheus.Gatherer) c
 	return r
 }
 
-func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+func (s *Server) health(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, r, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 type titleBody struct {
@@ -190,18 +190,18 @@ func (s *Server) domainCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Audit(r.Context(), "domain_create", slog.String("domain_id", d.ID))
-	writeJSON(w, http.StatusCreated, d)
+	writeJSON(w, r, http.StatusCreated, d)
 }
 
 func (s *Server) domainList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.DomainSortFields)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	list, total, err := s.Store.DomainList(r.Context(), opts)
@@ -212,7 +212,7 @@ func (s *Server) domainList(w http.ResponseWriter, r *http.Request) {
 	if list == nil {
 		list = []store.Domain{}
 	}
-	writeList(w, list, total, opts)
+	writeList(w, r, list, total, opts)
 }
 
 func (s *Server) domainGet(w http.ResponseWriter, r *http.Request) {
@@ -222,7 +222,7 @@ func (s *Server) domainGet(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, d)
+	writeJSON(w, r, http.StatusOK, d)
 }
 
 func (s *Server) domainPatch(w http.ResponseWriter, r *http.Request) {
@@ -232,7 +232,7 @@ func (s *Server) domainPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if b.Title == nil {
-		writeErr(w, http.StatusBadRequest, errors.New("title is required for patch"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
 		return
 	}
 	d, err := s.Store.DomainPatch(r.Context(), id, b.Title)
@@ -241,7 +241,7 @@ func (s *Server) domainPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Audit(r.Context(), "domain_patch", slog.String("domain_id", id))
-	writeJSON(w, http.StatusOK, d)
+	writeJSON(w, r, http.StatusOK, d)
 }
 
 func (s *Server) domainDelete(w http.ResponseWriter, r *http.Request) {
@@ -266,18 +266,18 @@ func (s *Server) userCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Audit(r.Context(), "user_create", slog.String("domain_id", domainID), slog.String("user_id", u.ID))
-	writeJSON(w, http.StatusCreated, u)
+	writeJSON(w, r, http.StatusCreated, u)
 }
 
 func (s *Server) userList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.UserSortFields)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
@@ -289,7 +289,7 @@ func (s *Server) userList(w http.ResponseWriter, r *http.Request) {
 	if list == nil {
 		list = []store.User{}
 	}
-	writeList(w, list, total, opts)
+	writeList(w, r, list, total, opts)
 }
 
 func (s *Server) userGet(w http.ResponseWriter, r *http.Request) {
@@ -300,7 +300,7 @@ func (s *Server) userGet(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, u)
+	writeJSON(w, r, http.StatusOK, u)
 }
 
 func (s *Server) userPatch(w http.ResponseWriter, r *http.Request) {
@@ -311,7 +311,7 @@ func (s *Server) userPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if b.Title == nil {
-		writeErr(w, http.StatusBadRequest, errors.New("title is required for patch"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
 		return
 	}
 	u, err := s.Store.UserPatch(r.Context(), domainID, id, b.Title)
@@ -320,7 +320,7 @@ func (s *Server) userPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Audit(r.Context(), "user_patch", slog.String("domain_id", domainID), slog.String("user_id", id))
-	writeJSON(w, http.StatusOK, u)
+	writeJSON(w, r, http.StatusOK, u)
 }
 
 func (s *Server) userDelete(w http.ResponseWriter, r *http.Request) {
@@ -351,18 +351,18 @@ func (s *Server) groupCreate(w http.ResponseWriter, r *http.Request) {
 	gaudit := []slog.Attr{slog.String("domain_id", domainID), slog.String("group_id", g.ID)}
 	gaudit = append(gaudit, parentGroupAuditAttrs(b.ParentGroupID, false)...)
 	logger.Audit(r.Context(), "group_create", gaudit...)
-	writeJSON(w, http.StatusCreated, g)
+	writeJSON(w, r, http.StatusCreated, g)
 }
 
 func (s *Server) groupList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseGroupListOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.GroupSortFields)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
@@ -374,7 +374,7 @@ func (s *Server) groupList(w http.ResponseWriter, r *http.Request) {
 	if list == nil {
 		list = []store.Group{}
 	}
-	writeList(w, list, total, opts.ListOpts)
+	writeList(w, r, list, total, opts.ListOpts)
 }
 
 func (s *Server) groupGet(w http.ResponseWriter, r *http.Request) {
@@ -385,7 +385,7 @@ func (s *Server) groupGet(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, g)
+	writeJSON(w, r, http.StatusOK, g)
 }
 
 func (s *Server) groupPatch(w http.ResponseWriter, r *http.Request) {
@@ -405,14 +405,14 @@ func (s *Server) groupPatch(w http.ResponseWriter, r *http.Request) {
 		default:
 			var pid string
 			if err := json.Unmarshal(trimmed, &pid); err != nil {
-				writeErr(w, http.StatusBadRequest, errors.New("parent_group_id must be a UUID string or null"))
+				writeErr(w, r, http.StatusBadRequest, errors.New("parent_group_id must be a UUID string or null"))
 				return
 			}
 			params.ParentGroupID = &pid
 		}
 	}
 	if params.Title == nil && !params.UpdateParent {
-		writeErr(w, http.StatusBadRequest, errors.New("at least one of title, parent_group_id is required"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, parent_group_id is required"))
 		return
 	}
 	g, err := s.Store.GroupPatch(r.Context(), domainID, groupID, params)
@@ -428,7 +428,7 @@ func (s *Server) groupPatch(w http.ResponseWriter, r *http.Request) {
 		gaudit = append(gaudit, parentGroupAuditAttrs(params.ParentGroupID, true)...)
 	}
 	logger.Audit(r.Context(), "group_patch", gaudit...)
-	writeJSON(w, http.StatusOK, g)
+	writeJSON(w, r, http.StatusOK, g)
 }
 
 func (s *Server) groupDelete(w http.ResponseWriter, r *http.Request) {
@@ -471,18 +471,18 @@ func (s *Server) resourceCreate(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Audit(r.Context(), "resource_create", slog.String("domain_id", domainID), slog.String("resource_id", res.ID))
-	writeJSON(w, http.StatusCreated, res)
+	writeJSON(w, r, http.StatusCreated, res)
 }
 
 func (s *Server) resourceList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.ResourceSortFields)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
@@ -494,7 +494,7 @@ func (s *Server) resourceList(w http.ResponseWriter, r *http.Request) {
 	if list == nil {
 		list = []store.Resource{}
 	}
-	writeList(w, list, total, opts)
+	writeList(w, r, list, total, opts)
 }
 
 func (s *Server) resourceGet(w http.ResponseWriter, r *http.Request) {
@@ -505,7 +505,7 @@ func (s *Server) resourceGet(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, res)
+	writeJSON(w, r, http.StatusOK, res)
 }
 
 func (s *Server) resourcePatch(w http.ResponseWriter, r *http.Request) {
@@ -516,7 +516,7 @@ func (s *Server) resourcePatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if b.Title == nil {
-		writeErr(w, http.StatusBadRequest, errors.New("title is required for patch"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
 		return
 	}
 	res, err := s.Store.ResourcePatch(r.Context(), domainID, id, b.Title)
@@ -525,7 +525,7 @@ func (s *Server) resourcePatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	logger.Audit(r.Context(), "resource_patch", slog.String("domain_id", domainID), slog.String("resource_id", id))
-	writeJSON(w, http.StatusOK, res)
+	writeJSON(w, r, http.StatusOK, res)
 }
 
 func (s *Server) resourceDelete(w http.ResponseWriter, r *http.Request) {
@@ -547,7 +547,7 @@ func (s *Server) accessTypeCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	bit, err := parseUint64Validated(b.Bit, maxAccessMask)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	a := &store.AccessType{ID: uuid.NewString(), DomainID: domainID, Title: b.Title, Bit: bit}
@@ -560,18 +560,18 @@ func (s *Server) accessTypeCreate(w http.ResponseWriter, r *http.Request) {
 		slog.String("access_type_id", a.ID),
 		slog.Uint64("bit", a.Bit),
 	)
-	writeJSON(w, http.StatusCreated, a)
+	writeJSON(w, r, http.StatusCreated, a)
 }
 
 func (s *Server) accessTypeList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.AccessTypeSortFields)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
@@ -583,7 +583,7 @@ func (s *Server) accessTypeList(w http.ResponseWriter, r *http.Request) {
 	if list == nil {
 		list = []store.AccessType{}
 	}
-	writeList(w, list, total, opts)
+	writeList(w, r, list, total, opts)
 }
 
 func (s *Server) accessTypeGet(w http.ResponseWriter, r *http.Request) {
@@ -594,7 +594,7 @@ func (s *Server) accessTypeGet(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, a)
+	writeJSON(w, r, http.StatusOK, a)
 }
 
 func (s *Server) accessTypePatch(w http.ResponseWriter, r *http.Request) {
@@ -605,14 +605,14 @@ func (s *Server) accessTypePatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if b.Title == nil && b.Bit == nil {
-		writeErr(w, http.StatusBadRequest, errors.New("at least one of title, bit is required"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, bit is required"))
 		return
 	}
 	params := store.AccessTypePatchParams{Title: b.Title}
 	if b.Bit != nil {
 		bit, err := parseUint64Validated(*b.Bit, maxAccessMask)
 		if err != nil {
-			writeErr(w, http.StatusBadRequest, err)
+			writeErr(w, r, http.StatusBadRequest, err)
 			return
 		}
 		params.Bit = &bit
@@ -627,7 +627,7 @@ func (s *Server) accessTypePatch(w http.ResponseWriter, r *http.Request) {
 		slog.String("access_type_id", id),
 		slog.Uint64("bit", a.Bit),
 	)
-	writeJSON(w, http.StatusOK, a)
+	writeJSON(w, r, http.StatusOK, a)
 }
 
 func (s *Server) accessTypeDelete(w http.ResponseWriter, r *http.Request) {
@@ -649,7 +649,7 @@ func (s *Server) permissionCreate(w http.ResponseWriter, r *http.Request) {
 	}
 	mask, err := parseUint64Validated(b.AccessMask, maxAccessMask)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	p := &store.Permission{
@@ -666,18 +666,18 @@ func (s *Server) permissionCreate(w http.ResponseWriter, r *http.Request) {
 		slog.String("resource_id", p.ResourceID),
 		slog.Uint64("access_mask", p.AccessMask),
 	)
-	writeJSON(w, http.StatusCreated, p)
+	writeJSON(w, r, http.StatusCreated, p)
 }
 
 func (s *Server) permissionList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parsePermissionListOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.PermissionSortFields)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
@@ -689,7 +689,7 @@ func (s *Server) permissionList(w http.ResponseWriter, r *http.Request) {
 	if list == nil {
 		list = []store.Permission{}
 	}
-	writeList(w, list, total, opts.ListOpts)
+	writeList(w, r, list, total, opts.ListOpts)
 }
 
 func (s *Server) permissionGet(w http.ResponseWriter, r *http.Request) {
@@ -700,7 +700,7 @@ func (s *Server) permissionGet(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, http.StatusOK, p)
+	writeJSON(w, r, http.StatusOK, p)
 }
 
 func (s *Server) permissionPatch(w http.ResponseWriter, r *http.Request) {
@@ -711,14 +711,14 @@ func (s *Server) permissionPatch(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if b.Title == nil && b.ResourceID == nil && b.AccessMask == nil {
-		writeErr(w, http.StatusBadRequest, errors.New("at least one of title, resource_id, access_mask is required"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, resource_id, access_mask is required"))
 		return
 	}
 	params := store.PermissionPatchParams{Title: b.Title, ResourceID: b.ResourceID}
 	if b.AccessMask != nil {
 		mask, err := parseUint64Validated(*b.AccessMask, maxAccessMask)
 		if err != nil {
-			writeErr(w, http.StatusBadRequest, err)
+			writeErr(w, r, http.StatusBadRequest, err)
 			return
 		}
 		params.AccessMask = &mask
@@ -734,7 +734,7 @@ func (s *Server) permissionPatch(w http.ResponseWriter, r *http.Request) {
 		slog.String("resource_id", p.ResourceID),
 		slog.Uint64("access_mask", p.AccessMask),
 	)
-	writeJSON(w, http.StatusOK, p)
+	writeJSON(w, r, http.StatusOK, p)
 }
 
 func (s *Server) permissionDelete(w http.ResponseWriter, r *http.Request) {
@@ -801,7 +801,7 @@ const userAuthzResourcesSortField = "resource_id"
 func (s *Server) userAuthzResources(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	// This endpoint only exposes pagination and uses a fixed stable ordering.
@@ -815,7 +815,7 @@ func (s *Server) userAuthzResources(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, userAuthzResourceDTOs(list), total, opts)
+	writeList(w, r, userAuthzResourceDTOs(list), total, opts)
 }
 
 const groupAuthzResourcesSortField = "resource_id"
@@ -823,7 +823,7 @@ const groupAuthzResourcesSortField = "resource_id"
 func (s *Server) groupAuthzResources(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort = groupAuthzResourcesSortField
@@ -836,7 +836,7 @@ func (s *Server) groupAuthzResources(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, groupAuthzResourceDTOs(list), total, opts)
+	writeList(w, r, groupAuthzResourceDTOs(list), total, opts)
 }
 
 // resourceAuthzUsersSortField is the meta.sort label returned to clients.
@@ -851,7 +851,7 @@ const resourceAuthzUsersSortField = "user_id"
 func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	// Populated for meta only; the store enforces fixed ORDER BY users.id ASC.
@@ -865,7 +865,7 @@ func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, resourceAuthzUserDTOs(list), total, opts)
+	writeList(w, r, resourceAuthzUserDTOs(list), total, opts)
 }
 
 const resourceAuthzGroupsSortField = "group_id"
@@ -873,7 +873,7 @@ const resourceAuthzGroupsSortField = "group_id"
 func (s *Server) resourceAuthzGroups(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	// Populated for meta only; the store enforces fixed ORDER BY group_permissions.group_id ASC.
@@ -887,7 +887,7 @@ func (s *Server) resourceAuthzGroups(w http.ResponseWriter, r *http.Request) {
 		writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, resourceAuthzGroupDTOs(list), total, opts)
+	writeList(w, r, resourceAuthzGroupDTOs(list), total, opts)
 }
 
 func (s *Server) grantGroupPermission(w http.ResponseWriter, r *http.Request) {
@@ -940,7 +940,7 @@ func (s *Server) authzCheck(w http.ResponseWriter, r *http.Request) {
 	}
 	bit, err := parseUint64Validated(bitStr, maxAccessMask)
 	if err != nil {
-		writeErr(w, http.StatusBadRequest, err)
+		writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	mask, err := s.Store.EffectiveMask(r.Context(), domainID, userID, resourceID)
@@ -950,7 +950,7 @@ func (s *Server) authzCheck(w http.ResponseWriter, r *http.Request) {
 	}
 	allowed := access.HasBit(mask, bit)
 	result = authzResultOK
-	writeJSON(w, http.StatusOK, map[string]any{
+	writeJSON(w, r, http.StatusOK, map[string]any{
 		"allowed":        allowed,
 		"effective_mask": strconv.FormatUint(mask, 10),
 	})
@@ -974,24 +974,26 @@ func (s *Server) authzMasks(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	result = authzResultOK
-	writeJSON(w, http.StatusOK, map[string]any{"masks": masks})
+	writeJSON(w, r, http.StatusOK, map[string]any{"masks": masks})
 }
 
-// TODO(T54): inject *slog.Logger via Server.Log so tests can capture logs without
-// mutating the package-level global (enables t.Parallel()).
-// TODO(T55): pass *http.Request to this function so encode-failure logs include
-// method and path (depends on T54).
-func writeJSON(w http.ResponseWriter, status int, v any) {
+// TODO(T54): replace r-threading with logWith(r) once T54 injectable logger lands.
+func writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
-		// The response header is already committed; log for operator visibility.
-		logger.Error("response encode failed", slog.String("err", err.Error()))
+		// The response header is already committed; log with request context for
+		// operator visibility so the failing endpoint can be identified.
+		logger.Error("response encode failed",
+			slog.String("err", err.Error()),
+			slog.String("method", r.Method),
+			slog.String("path", r.URL.Path),
+		)
 	}
 }
 
-func writeErr(w http.ResponseWriter, status int, err error) {
-	writeJSON(w, status, map[string]string{"error": err.Error()})
+func writeErr(w http.ResponseWriter, r *http.Request, status int, err error) {
+	writeJSON(w, r, status, map[string]string{"error": err.Error()})
 }
 
 // writeStoreErr classifies a store-layer error into the correct HTTP status
@@ -1018,7 +1020,7 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 		msg = "internal server error"
 	}
 	logRequestErr(r, status, err)
-	writeJSON(w, status, map[string]string{"error": msg})
+	writeJSON(w, r, status, map[string]string{"error": msg})
 }
 
 // writeInternalErr logs the full error and returns a generic 500 to the client.
@@ -1041,7 +1043,7 @@ func writeInternalErr(w http.ResponseWriter, r *http.Request, err error) {
 		)
 	}
 	logRequestErr(r, http.StatusInternalServerError, err)
-	writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	writeJSON(w, r, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 }
 
 // logRequestErr logs the error with request context. 5xx errors are logged at
@@ -1223,8 +1225,8 @@ func parseSortOrder(q url.Values, allowed []string) (string, store.SortOrder, er
 	return sortField, order, nil
 }
 
-func writeList(w http.ResponseWriter, data any, total int64, opts store.ListOpts) {
-	writeJSON(w, http.StatusOK, listEnvelope{
+func writeList(w http.ResponseWriter, r *http.Request, data any, total int64, opts store.ListOpts) {
+	writeJSON(w, r, http.StatusOK, listEnvelope{
 		Data: data,
 		Meta: listMeta{
 			Total:  total,
@@ -1244,12 +1246,12 @@ func readJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
 			logReadJSONErr(r, "body_too_large", "request body too large")
-			writeErr(w, http.StatusRequestEntityTooLarge, errors.New("request body too large"))
+			writeErr(w, r, http.StatusRequestEntityTooLarge, errors.New("request body too large"))
 			return false
 		}
 		cls := classifyDecodeErr(err)
 		logReadJSONErr(r, cls.kind, cls.logMsg)
-		writeErr(w, http.StatusBadRequest, errors.New(cls.clientMsg))
+		writeErr(w, r, http.StatusBadRequest, errors.New(cls.clientMsg))
 		return false
 	}
 	// Decode a second value to verify the stream is exhausted. io.EOF means
@@ -1261,7 +1263,7 @@ func readJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	var extra json.RawMessage
 	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
 		logReadJSONErr(r, "trailing_data", "trailing data after first JSON value")
-		writeErr(w, http.StatusBadRequest, errors.New("request body must contain exactly one JSON value"))
+		writeErr(w, r, http.StatusBadRequest, errors.New("request body must contain exactly one JSON value"))
 		return false
 	}
 	return true

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -984,11 +984,14 @@ func writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		// The response header is already committed; log with request context for
 		// operator visibility so the failing endpoint can be identified.
-		logger.Error("response encode failed",
-			slog.String("err", err.Error()),
-			slog.String("method", r.Method),
-			slog.String("path", r.URL.Path),
-		)
+		attrs := []slog.Attr{slog.String("err", err.Error())}
+		if r != nil {
+			attrs = append(attrs,
+				slog.String("method", r.Method),
+				slog.String("path", r.URL.Path),
+			)
+		}
+		logger.Error("response encode failed", attrs...)
 	}
 }
 

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -4749,15 +4749,26 @@ func TestWriteJSON_encodeErrorLogged(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("want status 200 (header already committed), got %d", w.Code)
 	}
-	logged := buf.String()
-	if !strings.Contains(logged, "response encode failed") {
-		t.Fatalf("expected 'response encode failed' in server log, got: %s", logged)
+
+	logged := strings.TrimSpace(buf.String())
+	if logged == "" {
+		t.Fatal("expected encode-failure log entry, got empty log output")
 	}
-	if !strings.Contains(logged, `"method":"GET"`) {
-		t.Fatalf("expected method=GET key-value in encode-failure log, got: %s", logged)
+
+	lines := strings.Split(logged, "\n")
+	var entry map[string]any
+	if err := json.Unmarshal([]byte(lines[0]), &entry); err != nil {
+		t.Fatalf("unmarshal log entry: %v; raw log: %s", err, logged)
 	}
-	if !strings.Contains(logged, `"path":"/api/v1/domains"`) {
-		t.Fatalf("expected path=/api/v1/domains key-value in encode-failure log, got: %s", logged)
+
+	if got := entry["msg"]; got != "response encode failed" {
+		t.Fatalf(`log field "msg" = %v, want %q; raw log: %s`, got, "response encode failed", logged)
+	}
+	if got := entry["method"]; got != http.MethodGet {
+		t.Fatalf(`log field "method" = %v, want %q; raw log: %s`, got, http.MethodGet, logged)
+	}
+	if got := entry["path"]; got != "/api/v1/domains" {
+		t.Fatalf(`log field "path" = %v, want %q; raw log: %s`, got, "/api/v1/domains", logged)
 	}
 }
 

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -4732,6 +4732,10 @@ func TestAPI_authzCheck_accessBitOutOfRange(t *testing.T) {
 // logged at ERROR level with method and path so operators can identify the
 // failing endpoint. Because the status header is already committed, the only
 // observable signal is the log entry.
+//
+// NOTE: This test mutates the package-level logger via logger.Init.
+// t.Parallel() is intentionally omitted until T54 (injectable logger) lands.
+// See TODO(T54) in writeJSON.
 func TestWriteJSON_encodeErrorLogged(t *testing.T) {
 	var buf bytes.Buffer
 	logger.Init(slog.LevelError, &buf)
@@ -4749,11 +4753,11 @@ func TestWriteJSON_encodeErrorLogged(t *testing.T) {
 	if !strings.Contains(logged, "response encode failed") {
 		t.Fatalf("expected 'response encode failed' in server log, got: %s", logged)
 	}
-	if !strings.Contains(logged, "GET") {
-		t.Fatalf("expected method=GET in encode-failure log, got: %s", logged)
+	if !strings.Contains(logged, `"method":"GET"`) {
+		t.Fatalf("expected method=GET key-value in encode-failure log, got: %s", logged)
 	}
-	if !strings.Contains(logged, "/api/v1/domains") {
-		t.Fatalf("expected path=/api/v1/domains in encode-failure log, got: %s", logged)
+	if !strings.Contains(logged, `"path":"/api/v1/domains"`) {
+		t.Fatalf("expected path=/api/v1/domains key-value in encode-failure log, got: %s", logged)
 	}
 }
 

--- a/go/internal/api/server_test.go
+++ b/go/internal/api/server_test.go
@@ -4729,22 +4729,31 @@ func TestAPI_authzCheck_accessBitOutOfRange(t *testing.T) {
 // --- T52: request/response error hardening tests ---
 
 // TestWriteJSON_encodeErrorLogged asserts that a response encoding failure is
-// logged at ERROR level rather than silently swallowed. Because the status
-// header is already committed, the only observable signal is the log entry.
+// logged at ERROR level with method and path so operators can identify the
+// failing endpoint. Because the status header is already committed, the only
+// observable signal is the log entry.
 func TestWriteJSON_encodeErrorLogged(t *testing.T) {
 	var buf bytes.Buffer
 	logger.Init(slog.LevelError, &buf)
 	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
 
 	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/api/v1/domains", nil)
 	// A channel is not JSON-serializable and will cause Encode to fail.
-	writeJSON(w, http.StatusOK, map[string]any{"v": make(chan int)})
+	writeJSON(w, r, http.StatusOK, map[string]any{"v": make(chan int)})
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("want status 200 (header already committed), got %d", w.Code)
 	}
-	if !strings.Contains(buf.String(), "response encode failed") {
-		t.Fatalf("expected 'response encode failed' in server log, got: %s", buf.String())
+	logged := buf.String()
+	if !strings.Contains(logged, "response encode failed") {
+		t.Fatalf("expected 'response encode failed' in server log, got: %s", logged)
+	}
+	if !strings.Contains(logged, "GET") {
+		t.Fatalf("expected method=GET in encode-failure log, got: %s", logged)
+	}
+	if !strings.Contains(logged, "/api/v1/domains") {
+		t.Fatalf("expected path=/api/v1/domains in encode-failure log, got: %s", logged)
 	}
 }
 

--- a/plan/phase-6/T55-writejson-request-context.md
+++ b/plan/phase-6/T55-writejson-request-context.md
@@ -55,6 +55,15 @@ server log so operators can identify which endpoint triggered the error.
 - New test: assert that an unserializable value passed to a handler produces an
   ERROR log entry that includes both `method` and `path` fields.
 
+## Implementation (shipped in PR #88)
+
+The **alternative (`*http.Request`) approach** was used because T54 (#76) is
+still open. `*http.Request` was added as the second parameter to `writeJSON`,
+`writeErr`, and `writeList`; all ~60 handler call sites in `server.go` updated.
+The `health` handler's blank `_` identifier was changed to `r` so it can be
+passed through. `TestWriteJSON_encodeErrorLogged` was extended to assert that
+both `method` and `path` appear in the ERROR log entry.
+
 ## Steps
 
 1. Decide approach (preferred: T54 logger injection, or standalone parameter).

--- a/plan/phase-6/T55-writejson-request-context.md
+++ b/plan/phase-6/T55-writejson-request-context.md
@@ -64,13 +64,13 @@ The `health` handler's blank `_` identifier was changed to `r` so it can be
 passed through. `TestWriteJSON_encodeErrorLogged` was extended to assert that
 both `method` and `path` appear in the ERROR log entry.
 
-## Steps
+## Steps (all completed — see Implementation above)
 
-1. Decide approach (preferred: T54 logger injection, or standalone parameter).
-2. Update `writeJSON` signature and all call sites in `server.go`.
-3. Update unit test helpers that call `writeJSON` directly.
-4. Add test asserting method+path appear in the encode-failure log entry.
-5. Verify `make test` and `make lint` pass.
+1. ✓ Decided approach — alternative (`*http.Request`) chosen; T54 still open.
+2. ✓ Updated `writeJSON` signature and all call sites in `server.go`.
+3. ✓ Updated unit test helpers that call `writeJSON` directly.
+4. ✓ Added test asserting method+path key-value pairs appear in the ERROR log entry.
+5. ✓ `make test` and `make lint` pass.
 
 ## Dependencies
 

--- a/plan/phase-6/T55-writejson-request-context.md
+++ b/plan/phase-6/T55-writejson-request-context.md
@@ -55,7 +55,7 @@ server log so operators can identify which endpoint triggered the error.
 - New test: assert that an unserializable value passed to a handler produces an
   ERROR log entry that includes both `method` and `path` fields.
 
-## Implementation (shipped in PR #88)
+## Implementation (shipped in PR #90)
 
 The **alternative (`*http.Request`) approach** was used because T54 (#76) is
 still open. `*http.Request` was added as the second parameter to `writeJSON`,


### PR DESCRIPTION
## Summary

`writeJSON` logged response encode failures with only the error string — no `method` or `path`. Every other error helper (`logRequestErr`, `logReadJSONErr`) includes request context. This PR resolves the gap flagged as CML-T52-3 in PR #86.

**Approach:** `*http.Request` parameter (alternative described in #88, chosen because T54 / #76 is still open). When `json.Encoder.Encode` returns an error the log entry now carries `method` and `path` alongside `err`. No behaviour change on the happy path.

### Changes

- `writeJSON(w, r, status, v)` — adds `r *http.Request`; logs method+path on encode failure.
- `writeErr(w, r, status, err)` and `writeList(w, r, data, total, opts)` — propagate `r`.
- `writeStoreErr`, `writeInternalErr`, `readJSON` — pass `r` to the updated helpers.
- `health` handler: `_ *http.Request` → `r *http.Request`.
- All ~60 handler call sites in `server.go` updated (mechanical).
- `TestWriteJSON_encodeErrorLogged` extended to assert method and path in the ERROR log.
- CHANGELOG / plan file updated.

## Ticket

Closes #88
Refs #76 (T54 injectable logger — preferred future migration path)

## Checklist

- [x] `make test` passes (all packages, -race)
- [x] `make lint` passes (0 issues)
- [x] No secrets or real `.env` values in the diff
- [x] CHANGELOG updated
- [x] Plan file updated