### PR TITLE
[T1] Break down per-dialect migrations into phase-7 sub-tickets; add 26Q2 milestone docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,14 @@ When starting work on a new ticket or task, **create a topic branch** from up-to
 
 By default, **do not** run `git commit`, `git push`, or `gh pr create`. Provide a **proposed commit message** and **PR body** (Summary, Ticket, Checklist per [`.github/pull_request_template.md`](.github/pull_request_template.md)) for the human to paste. Run those git/`gh` commands only when the human **explicitly** asks you to.
 
+### Milestone
+
+Every new issue must be assigned to the **current active milestone**. When creating an issue:
+- Via `gh issue create`: add `--milestone "<title>"` (e.g. `--milestone "26Q2"`).
+- Via GitHub UI: select the milestone from the **Milestone** dropdown before submitting.
+
+**Current milestone:** `26Q2` (April–June 2026, due 2026-06-30). Update this line and the matching line in [CONTRIBUTING.md](CONTRIBUTING.md#milestone) when a new milestone is activated.
+
 ## GitHub
 
 **Humans:** Prefer the **`gh`** CLI for issues, PRs, Actions, and API tasks when scripting. Requires [GitHub CLI](https://cli.github.com/) and `gh auth login`. Maintainer steps: [CONTRIBUTING.md](CONTRIBUTING.md) (**T6**). CI: [`.github/workflows/ci.yml`](.github/workflows/ci.yml) (**T13**); **`gh run list`** / **`gh pr checks`**.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,13 @@ Provide **proposed** commit message and PR description text only. Do **not** run
 - The `Tnn` identifier must match the corresponding plan file under `plan/phase-*/Tnn-...md` when applicable. Include a link to the plan file in the issue or PR body.
 - If no plan ticket applies, follow a short, imperative title (e.g. `ci: fix linting error`).
 
+### Milestone
+
+- Every new issue must be assigned to the **current active milestone** (e.g. `26Q2`).
+- When creating an issue via `gh issue create`, add `--milestone "<milestone title>"` (e.g. `--milestone "26Q2"`).
+- When creating via the GitHub UI, select the milestone from the **Milestone** dropdown before submitting.
+- The current milestone is **26Q2** (April–June 2026, due 2026-06-30). Update this line when a new milestone is created.
+
 
 ### Before you open a PR (self-review)
 

--- a/plan/README.md
+++ b/plan/README.md
@@ -12,7 +12,8 @@ This directory holds **executable mini-specs** for umbrella work. Filenames use 
 | 3 | GitHub, Docker, CI | T29, T14, T6, T19, T13 | [phase-3](phase-3/) |
 | 4 | API hardening | T7 | [phase-4](phase-4/) |
 | 5 | P2 polish and multi-DB | T15, T17, T16, T1, T33, T34, T35, T37, T38, T39, T40 | [phase-5](phase-5/) |
-| 6 | P3 scale, prod, product options | T23, T20, T31, T32, T22, T21, T2, T3, T4, T5, **T41–T45** (authz listing) | [phase-6](phase-6/) |
+| 6 | P3 scale, prod, product options | T23, T20, T31, T32, T22, T21, T2, T3, T4, T5, **T41–T55** | [phase-6](phase-6/) |
+| 7 | Multi-DB implementation (T1 sub-tasks) | T56, T57, T58, T59, T60, T61 | [phase-7](phase-7/) |
 
 **Within phase 3**, prefer ticket order **T29 → T14 → T6 → T19 → T13** (`go/` layout first; Docker/compose before CI integration tests that need it).
 

--- a/plan/phase-5/T01-per-dialect-migrations.md
+++ b/plan/phase-5/T01-per-dialect-migrations.md
@@ -12,6 +12,19 @@
 
 Extend [internal/database/open.go](../../go/internal/database/open.go) and add **Postgres** and/or **MySQL** drivers, **dialect-specific migrations**, and store implementations that satisfy [internal/store/store.go](../../go/internal/store/store.go).
 
+## Breakdown (Phase 7 sub-tickets)
+
+This umbrella ticket has been broken down into focused sub-tasks in [plan/phase-7/](../phase-7/):
+
+| Sub-ticket | Title | Issue |
+|------------|-------|-------|
+| T56 | Port SQLite migrations to PostgreSQL dialect | [#91](https://github.com/DanyalTorabi/access-manager/issues/91) |
+| T57 | Port SQLite migrations to MySQL/MariaDB dialect | [#92](https://github.com/DanyalTorabi/access-manager/issues/92) |
+| T58 | Implement `internal/store/postgres` (Store interface) | [#93](https://github.com/DanyalTorabi/access-manager/issues/93) |
+| T59 | Implement `internal/store/mysql` (Store interface) | [#94](https://github.com/DanyalTorabi/access-manager/issues/94) |
+| T60 | Wire Postgres & MySQL into `database.Open`; DSN config and README | [#95](https://github.com/DanyalTorabi/access-manager/issues/95) |
+| T61 | Docker Compose services + integration-test targets for Postgres and MySQL | [#96](https://github.com/DanyalTorabi/access-manager/issues/96) |
+
 ## Deliverables
 
 - `migrations/postgres/*.sql`, `migrations/mysql/*.sql` (or tool-based migrations).

--- a/plan/phase-7/T56-postgres-migrations.md
+++ b/plan/phase-7/T56-postgres-migrations.md
@@ -1,0 +1,70 @@
+# T56 — Port SQLite migrations to PostgreSQL dialect
+
+## Ticket
+
+**T56** — Port SQLite migrations to PostgreSQL dialect (GitHub [#91](https://github.com/DanyalTorabi/access-manager/issues/91))
+
+## Parent
+
+**T1** ([#12](https://github.com/DanyalTorabi/access-manager/issues/12)) — [plan/phase-5/T01-per-dialect-migrations.md](../phase-5/T01-per-dialect-migrations.md)
+
+## Phase
+
+**Phase 7** — Multi-DB implementation (sub-tasks of T1)
+
+## Goal
+
+Create the three PostgreSQL migration files that mirror the SQLite set, translating all dialect-specific DDL. The migration tool should remain the same file-based runner already used for SQLite (or a compatible postgres-aware variant).
+
+## Deliverables
+
+- `go/migrations/postgres/000001_init.up.sql` — initial schema
+- `go/migrations/postgres/000001_init.down.sql`
+- `go/migrations/postgres/000002_restrict_foreign_keys.up.sql` — ALTER TABLE / recreate tables with RESTRICT
+- `go/migrations/postgres/000002_restrict_foreign_keys.down.sql`
+- `go/migrations/postgres/000003_composite_fk_cross_domain.up.sql` — composite UNIQUE + composite FKs, with `DO $$...RAISE EXCEPTION` pre-check (T51/#77)
+- `go/migrations/postgres/000003_composite_fk_cross_domain.down.sql`
+
+## Steps
+
+1. **Translate `000001_init`**: Replace SQLite-ism `TEXT PRIMARY KEY` with `TEXT PRIMARY KEY` (same, fine), ensure `INTEGER` → `BIGINT` for `bit` column on `access_types`, keep the nine indexes.
+2. **Translate `000002_restrict_foreign_keys`**: PostgreSQL allows `ALTER TABLE … ALTER CONSTRAINT` or `DROP CONSTRAINT … ADD CONSTRAINT … ON DELETE RESTRICT`. Use `ALTER TABLE` rather than the SQLite rebuild-and-copy pattern (SQLite cannot `ALTER` FKs, PostgreSQL can).
+3. **Translate `000003_composite_fk_cross_domain`** (ported from T51/#77 PR #83):
+   - Add composite `UNIQUE (domain_id, id)` to `users`, `groups`, `permissions` via `ALTER TABLE`.
+   - Drop and re-add composite FKs on the three junction tables referencing `(domain_id, user_id/group_id/permission_id)`.
+   - Replace `RAISE(ABORT, …)` SQLite trigger with a PostgreSQL `DO $$ BEGIN … IF EXISTS(…) THEN RAISE EXCEPTION '…'; END IF; END $$;` pre-check block.
+4. Write a corresponding `.down.sql` for each migration that reverses the changes cleanly.
+5. Verify migrations apply in order with `psql` against a local Postgres container (or via the test helper in T61).
+
+## Acceptance criteria
+
+- `psql` can apply all three `.up.sql` files against a fresh PostgreSQL 15+ database without error.
+- Running them twice (idempotent via `IF NOT EXISTS` guards where applicable) does not fail.
+- Running `.down.sql` files in reverse order leaves an empty database without error.
+- The composite cross-domain pre-check fires as expected (insert a cross-domain row → error).
+
+## Files / paths
+
+- **Create:** `go/migrations/postgres/000001_init.{up,down}.sql`, `000002_restrict_foreign_keys.{up,down}.sql`, `000003_composite_fk_cross_domain.{up,down}.sql`
+- **Remove/Update:** `go/migrations/postgres/README.md` — replace TODO with a reference to this ticket being done.
+
+## Out of scope
+
+- The store implementation (`internal/store/postgres`) — that is T58.
+- Wiring `database.Open` — that is T60.
+
+## Dependencies
+
+- **T51 (#77)** — composite FK migration already done for SQLite; this ticket ports it.
+- **T61** — docker-compose postgres service used for manual and automated verification.
+
+## Notes on Postgres vs SQLite DDL differences
+
+| Concern | SQLite | PostgreSQL |
+|-----|-----|-----|
+| Auto-increment PK | `INTEGER PRIMARY KEY` | `BIGSERIAL PRIMARY KEY` or `GENERATED ALWAYS AS IDENTITY` |
+| `bit` column type | `INTEGER` | `BIGINT` |
+| Boolean | `INTEGER` (0/1) | `BOOLEAN` |
+| ADD FK to existing table | Rebuild table (no ALTER) | `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` |
+| Trigger-like pre-check | `RAISE(ABORT, …)` in trigger | `DO $$ BEGIN RAISE EXCEPTION '…'; END $$` |
+| FK `RESTRICT` | Default with pragma | Explicit `ON DELETE RESTRICT` |

--- a/plan/phase-7/T57-mysql-migrations.md
+++ b/plan/phase-7/T57-mysql-migrations.md
@@ -1,0 +1,70 @@
+# T57 — Port SQLite migrations to MySQL/MariaDB dialect
+
+## Ticket
+
+**T57** — Port SQLite migrations to MySQL/MariaDB dialect (GitHub [#92](https://github.com/DanyalTorabi/access-manager/issues/92))
+
+## Parent
+
+**T1** ([#12](https://github.com/DanyalTorabi/access-manager/issues/12)) — [plan/phase-5/T01-per-dialect-migrations.md](../phase-5/T01-per-dialect-migrations.md)
+
+## Phase
+
+**Phase 7** — Multi-DB implementation (sub-tasks of T1)
+
+## Goal
+
+Create the three MySQL/MariaDB migration files that mirror the SQLite set, translating all dialect-specific DDL. Primary targets: MySQL 8+ and MariaDB 10.6+.
+
+## Deliverables
+
+- `go/migrations/mysql/000001_init.up.sql` — initial schema
+- `go/migrations/mysql/000001_init.down.sql`
+- `go/migrations/mysql/000002_restrict_foreign_keys.up.sql` — `RESTRICT` FK behaviour (MySQL's default, verify and make explicit)
+- `go/migrations/mysql/000002_restrict_foreign_keys.down.sql`
+- `go/migrations/mysql/000003_composite_fk_cross_domain.up.sql` — composite UNIQUE + composite FKs, with `SIGNAL SQLSTATE` pre-check (T51/#77)
+- `go/migrations/mysql/000003_composite_fk_cross_domain.down.sql`
+
+## Steps
+
+1. **Translate `000001_init`**: Use `VARCHAR(255)` or `CHAR(36)` for `id` columns (UUIDs are TEXT in SQLite). Use `BIGINT UNSIGNED` for the `bit` column on `access_types`. Add `ENGINE=InnoDB` to all tables to enable FK support. Use backtick quoting.
+2. **Translate `000002_restrict_foreign_keys`**: MySQL FK behaviour is `RESTRICT` by default but it must be `ON DELETE RESTRICT` explicitly for clarity. Use `ALTER TABLE … DROP FOREIGN KEY …; ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY … ON DELETE RESTRICT;` per table.
+3. **Translate `000003_composite_fk_cross_domain`** (ported from T51/#77 PR #83):
+   - Add composite `UNIQUE KEY uq_domain_id (domain_id, id)` to `users`, `groups`, `permissions`.
+   - Drop and re-add composite FKs on the three junction tables.
+   - Replace `RAISE(ABORT, …)` with a stored procedure/event-free approach using `SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = '…';` inside a before-insert trigger, or a stored procedure pre-check — choose whichever is more compatible across MySQL 8 / MariaDB 10.6.
+4. Write corresponding `.down.sql` for each migration.
+5. Verify migrations apply against a local MySQL 8 container (or via the test helper in T61).
+
+## Acceptance criteria
+
+- `mysql` CLI can apply all three `.up.sql` files against a fresh MySQL 8 database without error.
+- Running `.down.sql` files in reverse order leaves a clean database.
+- The composite cross-domain pre-check fires as expected.
+
+## Files / paths
+
+- **Create:** `go/migrations/mysql/000001_init.{up,down}.sql`, `000002_restrict_foreign_keys.{up,down}.sql`, `000003_composite_fk_cross_domain.{up,down}.sql`
+- **Remove/Update:** `go/migrations/mysql/README.md` — replace TODO with a reference to this ticket being done.
+
+## Out of scope
+
+- The store implementation (`internal/store/mysql`) — that is T59.
+- Wiring `database.Open` — that is T60.
+
+## Dependencies
+
+- **T51 (#77)** — composite FK migration already done for SQLite; this ticket ports it.
+- **T61** — docker-compose mysql service used for manual and automated verification.
+
+## Notes on MySQL vs SQLite DDL differences
+
+| Concern | SQLite | MySQL |
+|-----|-----|-----|
+| String type | `TEXT` | `VARCHAR(255)` or `TEXT` |
+| `bit` column type | `INTEGER` | `BIGINT UNSIGNED` |
+| Boolean | `INTEGER` (0/1) | `TINYINT(1)` or `BOOLEAN` |
+| FK support | Requires `PRAGMA foreign_keys = ON` | Requires `ENGINE=InnoDB`; on by default with InnoDB |
+| ADD FK to existing table | Rebuild table | `ALTER TABLE … ADD CONSTRAINT … FOREIGN KEY` |
+| Trigger pre-check | `RAISE(ABORT, …)` | `SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = '…'` in BEFORE INSERT trigger |
+| Identifier quoting | `"…"` or backtick | Backtick |

--- a/plan/phase-7/T58-postgres-store.md
+++ b/plan/phase-7/T58-postgres-store.md
@@ -1,0 +1,66 @@
+# T58 — Implement `internal/store/postgres` (Store interface)
+
+## Ticket
+
+**T58** — Implement `internal/store/postgres` satisfying `store.Store` (GitHub [#93](https://github.com/DanyalTorabi/access-manager/issues/93))
+
+## Parent
+
+**T1** ([#12](https://github.com/DanyalTorabi/access-manager/issues/12)) — [plan/phase-5/T01-per-dialect-migrations.md](../phase-5/T01-per-dialect-migrations.md)
+
+## Phase
+
+**Phase 7** — Multi-DB implementation (sub-tasks of T1)
+
+## Goal
+
+Implement a PostgreSQL-backed `store.Store` in `go/internal/store/postgres/`, following exactly the same interface contract (signatures, error sentinel values, pagination behaviour) as `go/internal/store/sqlite/`.
+
+## Deliverables
+
+- `go/internal/store/postgres/db.go` — `Open(dsn string) (*sql.DB, error)` using `lib/pq` or `pgx/stdlib`
+- `go/internal/store/postgres/migrate.go` — `MigrateUp(db *sql.DB, dir string) error` (may reuse the same file-based runner from sqlite or a postgres-aware variant)
+- `go/internal/store/postgres/store.go` — full `Store` implementation (~1400 lines, mirroring `sqlite/store.go`)
+- `go/internal/store/postgres/store_test.go` — integration tests using a real Postgres DB (via `DATABASE_DSN_POSTGRES` env or `postgres://localhost/access_test`)
+
+## Steps
+
+1. **Dependency**: Add the PostgreSQL driver to `go/go.mod`. Prefer `github.com/lib/pq` (pure Go) unless the team has a preference for `pgx`. Avoid adding both.
+2. **Open + migrate**: Port `sqlite/db.go` → `postgres/db.go`. The `Open` function sets sensible connection pool parameters (`SetMaxOpenConns`, `SetConnMaxLifetime`). Port `sqlite/migrate.go` → `postgres/migrate.go`; if the existing runner works with postgres (`pq`), reuse it, otherwise write a minimal file-scanning loop.
+3. **Store implementation**: Port all methods from `sqlite/store.go`. Key translation points:
+   - `$1, $2, …` placeholders instead of `?`.
+   - `INSERT INTO … RETURNING id` for cases where SQLite uses `LastInsertId` (not available in postgres).
+   - `SERIAL` / `GENERATED ALWAYS AS IDENTITY` is not used here (IDs are UUIDs/TEXT).
+   - Error mapping: `pq.Error` codes → `store.ErrConflict` (code `23505`), `store.ErrFKViolation` (code `23503`), `store.ErrNotFound` (sql.ErrNoRows).
+   - `sql.NullString` for nullable `parent_group_id`.
+   - Cycle detection in `GroupSetParent`: same bounded loop, dialect-agnostic Go code.
+4. **Tests**: Mirror `sqlite/store_test.go` with `newTestStore(t)` that spins up a temporary Postgres schema (use `t.Cleanup` to drop). Skip if `DATABASE_DSN_POSTGRES` env is not set (so unit-only CI still passes). Tag them `//go:build integration` or guard with env skip.
+5. Update `go/internal/store/postgres/README.md` (or create one) with a quick "setup for dev" note.
+
+## Acceptance criteria
+
+- `go test -race -tags=integration ./internal/store/postgres/...` passes against a running Postgres 15 instance.
+- All `store.Store` methods are implemented (no method stubs returning `ErrNotFound` unconditionally).
+- Error sentinels (`ErrConflict`, `ErrFKViolation`, `ErrNotFound`, `ErrInvalidInput`) are correctly mapped from postgres driver errors — confirmed by test assertions.
+- `make test` (non-integration) still passes without a running Postgres.
+
+## Files / paths
+
+- **Create:** `go/internal/store/postgres/db.go`, `migrate.go`, `store.go`, `store_test.go`
+- **Edit:** `go/go.mod`, `go/go.sum` (add postgres driver)
+
+## Out of scope
+
+- Wiring `database.Open` — that is T60.
+- Migration files — that is T56.
+
+## Dependencies
+
+- **T56** — migrations must exist before integration tests can run.
+- **T61** — docker-compose postgres service for automated integration-test runs.
+
+## Test strategy
+
+- Use `//go:build integration` build tag so the CI unit job skips these.
+- Add a separate `make test-integration-postgres` target in `go/Makefile` (see T61).
+- Use `t.TempDir()` is not applicable here; instead create/drop a unique schema per test run using `uuid.New()` or `t.Name()`.

--- a/plan/phase-7/T59-mysql-store.md
+++ b/plan/phase-7/T59-mysql-store.md
@@ -1,0 +1,67 @@
+# T59 — Implement `internal/store/mysql` (Store interface)
+
+## Ticket
+
+**T59** — Implement `internal/store/mysql` satisfying `store.Store` (GitHub [#94](https://github.com/DanyalTorabi/access-manager/issues/94))
+
+## Parent
+
+**T1** ([#12](https://github.com/DanyalTorabi/access-manager/issues/12)) — [plan/phase-5/T01-per-dialect-migrations.md](../phase-5/T01-per-dialect-migrations.md)
+
+## Phase
+
+**Phase 7** — Multi-DB implementation (sub-tasks of T1)
+
+## Goal
+
+Implement a MySQL-backed `store.Store` in `go/internal/store/mysql/`, following exactly the same interface contract (signatures, error sentinel values, pagination behaviour) as `go/internal/store/sqlite/`.
+
+## Deliverables
+
+- `go/internal/store/mysql/db.go` — `Open(dsn string) (*sql.DB, error)` using `github.com/go-sql-driver/mysql`
+- `go/internal/store/mysql/migrate.go` — `MigrateUp(db *sql.DB, dir string) error`
+- `go/internal/store/mysql/store.go` — full `Store` implementation mirroring `sqlite/store.go`
+- `go/internal/store/mysql/store_test.go` — integration tests guarded by `DATABASE_DSN_MYSQL` env
+
+## Steps
+
+1. **Dependency**: Add `github.com/go-sql-driver/mysql` to `go/go.mod`.
+2. **Open + migrate**: Port `sqlite/db.go` → `mysql/db.go`. The DSN format is `user:password@tcp(host:port)/dbname?parseTime=true&multiStatements=true`. Set sensible pool parameters. Port the file-based migrator; MySQL supports multi-statement execution if `multiStatements=true` is in the DSN.
+3. **Store implementation**: Port all methods from `sqlite/store.go`. Key translation points:
+   - `?` placeholders are the same as SQLite — no change needed.
+   - `INSERT … ON DUPLICATE KEY UPDATE id=id` is a common no-op upsert guard; prefer returning `store.ErrConflict` via error mapping.
+   - Error mapping: `mysql.MySQLError` number `1062` → `store.ErrConflict`, number `1451`/`1452` → `store.ErrFKViolation`, `sql.ErrNoRows` → `store.ErrNotFound`.
+   - `LAST_INSERT_ID()` is available but IDs are TEXT (UUIDs), so `LastInsertId` is not used — IDs are generated in Go before insertion (same as SQLite).
+   - `sql.NullString` for nullable `parent_group_id`.
+   - Cycle detection in `GroupSetParent`: same bounded loop, dialect-agnostic.
+   - `BIGINT UNSIGNED` for the `bit` column — map to `uint64` in Go (same as SQLite `INTEGER` → `uint64`).
+4. **Tests**: Mirror `sqlite/store_test.go` with `newTestStore(t)` that creates a fresh database per run (drop + recreate using a unique name from `t.Name()`). Skip if `DATABASE_DSN_MYSQL` env is not set. Tag with `//go:build integration`.
+5. Enable FK checks explicitly: `SET FOREIGN_KEY_CHECKS=1` in the `Open` connection setup (InnoDB has FKs enabled by default, but be explicit for clarity).
+
+## Acceptance criteria
+
+- `go test -race -tags=integration ./internal/store/mysql/...` passes against a running MySQL 8 instance.
+- All `store.Store` methods are implemented.
+- Error sentinels are correctly mapped and verified by test assertions (conflict, FK violation, not-found, invalid-input).
+- `make test` (non-integration) still passes without a running MySQL.
+
+## Files / paths
+
+- **Create:** `go/internal/store/mysql/db.go`, `migrate.go`, `store.go`, `store_test.go`
+- **Edit:** `go/go.mod`, `go/go.sum` (add MySQL driver)
+
+## Out of scope
+
+- Wiring `database.Open` — that is T60.
+- Migration files — that is T57.
+
+## Dependencies
+
+- **T57** — migrations must exist before integration tests can run.
+- **T61** — docker-compose mysql service for automated integration-test runs.
+
+## Test strategy
+
+- Use `//go:build integration` build tag so the CI unit job skips these.
+- Add a `make test-integration-mysql` target in `go/Makefile` (see T61).
+- Create a unique database per test suite; drop it in `t.Cleanup`.

--- a/plan/phase-7/T60-wire-drivers.md
+++ b/plan/phase-7/T60-wire-drivers.md
@@ -1,0 +1,66 @@
+# T60 — Wire Postgres & MySQL into `database.Open`; DSN config and README
+
+## Ticket
+
+**T60** — Wire Postgres & MySQL into `database.Open`; update DSN config and docs (GitHub [#95](https://github.com/DanyalTorabi/access-manager/issues/95))
+
+## Parent
+
+**T1** ([#12](https://github.com/DanyalTorabi/access-manager/issues/12)) — [plan/phase-5/T01-per-dialect-migrations.md](../phase-5/T01-per-dialect-migrations.md)
+
+## Phase
+
+**Phase 7** — Multi-DB implementation (sub-tasks of T1)
+
+## Goal
+
+Extend `go/internal/database/open.go` to dispatch to `internal/store/postgres` and `internal/store/mysql` when those drivers are selected via `DATABASE_DRIVER`, and update all DSN configuration docs and `.env.example` so users can start either backend.
+
+## Deliverables
+
+- `go/internal/database/open.go` — add `"postgres"` and `"mysql"` cases to the `Open` switch
+- `go/internal/database/open.go` — `MigrateUp` must dispatch to the correct dialect-specific migrator when called
+- `go/.env.example` — add commented-out Postgres and MySQL DSN examples
+- `go/config.example.yaml` — add commented DSN options for each driver
+- `go/README.md` — document the supported drivers and sample DSN format
+- Root `README.md` — update the Database section if it mentions only SQLite
+
+## Steps
+
+1. **Extend `Open`**: Add `"postgres"` and `"mysql"` cases that call `pgstore.Open(dsn)` and `mysqlstore.Open(dsn)` respectively, returning the appropriate `*sql.DB` and migrations directory path (`"migrations/postgres"` / `"migrations/mysql"`).
+2. **`MigrateUp` dispatch**: The current `MigrateUp` calls `sqlstore.MigrateUp`. Either:
+   - Accept the `*sql.DB` and dialect string and route to the correct package's `MigrateUp`, or
+   - Unify migration logic into a single file-based runner that works across dialects (preferred, since all three dialects now share the same runner contract — see T58/T59 for notes on multi-statement MySQL support).
+3. **Error messages**: Extend the "unsupported driver" error message to list all three now-supported drivers.
+4. **Config docs**: Update `go/.env.example` with:
+   ```
+   # DATABASE_DRIVER=postgres
+   # DATABASE_DSN=postgres://localhost:5432/access_manager?sslmode=disable
+   # DATABASE_DRIVER=mysql
+   # DATABASE_DSN=root:@tcp(localhost:3306)/access_manager?parseTime=true
+   ```
+5. **README**: Add a "Supported databases" section or update the existing one with driver names and minimum version requirements (PostgreSQL 15+, MySQL 8+ / MariaDB 10.6+).
+6. **Tests**: Add a unit test in `go/internal/database/` that verifies `Open` returns a non-nil error for `"baddriver"` and a different branch test that exercises `Open` with `"sqlite"` still works (existing test should be extended, not replaced).
+
+## Acceptance criteria
+
+- `DATABASE_DRIVER=postgres DATABASE_DSN=…` starts the server, runs migrations, and responds to `GET /domains` with `[]`.
+- `DATABASE_DRIVER=mysql DATABASE_DSN=…` does the same.
+- `DATABASE_DRIVER=unknown` returns a clear error listing all supported drivers.
+- `make test` passes (the `database` package unit test does not require running DB instances).
+
+## Files / paths
+
+- **Edit:** `go/internal/database/open.go`
+- **Edit:** `go/.env.example`, `go/config.example.yaml`, `go/README.md`, `README.md`
+
+## Out of scope
+
+- Store implementations — T58, T59.
+- Migration SQL files — T56, T57.
+- CI integration test targets — T61.
+
+## Dependencies
+
+- **T56, T57** — Postgres/MySQL migration dirs must exist.
+- **T58, T59** — Store packages must exist for `Open` to import.

--- a/plan/phase-7/T61-ci-integration-tests.md
+++ b/plan/phase-7/T61-ci-integration-tests.md
@@ -1,0 +1,96 @@
+# T61 — Docker Compose services + integration-test targets for Postgres and MySQL
+
+## Ticket
+
+**T61** — Docker Compose services + integration-test targets for Postgres and MySQL (GitHub [#96](https://github.com/DanyalTorabi/access-manager/issues/96))
+
+## Parent
+
+**T1** ([#12](https://github.com/DanyalTorabi/access-manager/issues/12)) — [plan/phase-5/T01-per-dialect-migrations.md](../phase-5/T01-per-dialect-migrations.md)
+
+## Phase
+
+**Phase 7** — Multi-DB implementation (sub-tasks of T1)
+
+## Goal
+
+Add docker-compose services for Postgres and MySQL, Makefile targets to run integration tests against each, and extend the CI workflow to run those integration tests on every PR.
+
+## Deliverables
+
+- `docker-compose.yml` — add `postgres` and `mysql` services with health checks
+- `go/Makefile` — `test-integration-postgres` and `test-integration-mysql` targets
+- Root `Makefile` — delegate `test-integration-postgres` / `test-integration-mysql` from root
+- `.github/workflows/ci.yml` — new job (or step) running integration tests against postgres and mysql using compose services
+- `go/.env.example` — DSN env vars used by the integration-test Makefile targets
+
+## Steps
+
+1. **docker-compose services**: Add to `docker-compose.yml`:
+   ```yaml
+   postgres:
+     image: postgres:15-alpine
+     environment:
+       POSTGRES_DB: access_test
+       POSTGRES_USER: access
+       POSTGRES_PASSWORD: access
+     ports:
+       - "5432:5432"
+     healthcheck:
+       test: ["CMD-SHELL", "pg_isready -U access"]
+       interval: 5s
+       retries: 10
+
+   mysql:
+     image: mysql:8
+     environment:
+       MYSQL_DATABASE: access_test
+       MYSQL_ROOT_PASSWORD: access
+     ports:
+       - "3306:3306"
+     healthcheck:
+       test: ["CMD", "mysqladmin", "ping", "-h", "localhost", "-paccess"]
+       interval: 5s
+       retries: 10
+   ```
+2. **Makefile targets** (in `go/Makefile`):
+   ```makefile
+   test-integration-postgres:
+       DATABASE_DSN_POSTGRES="postgres://access:access@localhost:5432/access_test?sslmode=disable" \
+       go test -race -tags=integration -count=1 ./internal/store/postgres/...
+
+   test-integration-mysql:
+       DATABASE_DSN_MYSQL="root:access@tcp(localhost:3306)/access_test?parseTime=true&multiStatements=true" \
+       go test -race -tags=integration -count=1 ./internal/store/mysql/...
+   ```
+3. **CI workflow**: Add an integration-test job that:
+   - Uses `docker-compose up -d postgres mysql`
+   - Waits for healthchecks (`docker-compose ps` or `--wait` flag)
+   - Runs `make test-integration-postgres` and `make test-integration-mysql`
+   - Tears down with `docker-compose down` in a `post` step
+4. **Polling over sleep**: In any test helpers that wait for DB readiness (e.g. retry connection), use a deadline loop (`time.Now().Add(30 * time.Second)` + retry) rather than `time.Sleep`.
+
+## Acceptance criteria
+
+- `docker-compose up postgres mysql` starts both services and they pass healthchecks.
+- `make test-integration-postgres` passes with a running postgres container.
+- `make test-integration-mysql` passes with a running mysql container.
+- CI passes with the new integration-test job on every push to `main` and on PRs.
+- `make test` (unit only) still passes without any running containers.
+
+## Files / paths
+
+- **Edit:** `docker-compose.yml`
+- **Edit:** `go/Makefile`, root `Makefile`
+- **Edit:** `.github/workflows/ci.yml`
+- **Edit:** `go/.env.example` (document DSN vars used by integration targets)
+
+## Out of scope
+
+- E2E tests against Postgres/MySQL backend (that is future T62+ work). This ticket focuses on store integration tests only.
+
+## Dependencies
+
+- **T56, T57** — migration SQL files.
+- **T58, T59** — store packages under test.
+- **T60** — driver wiring (for a combined end-to-end smoke option in CI, optional here).


### PR DESCRIPTION
## Summary

Breaks the per-dialect migrations umbrella (T1/#12) into six focused, independently-mergeable sub-tickets in a new `plan/phase-7/` directory. Also documents the 26Q2 milestone requirement in AGENTS.md and CONTRIBUTING.md.

### Sub-tickets created

| Ticket | GitHub | Description |
|--------|--------|-------------|
| T56 | #91 | Port SQLite migrations → PostgreSQL DDL |
| T57 | #92 | Port SQLite migrations → MySQL/MariaDB DDL |
| T58 | #93 | Implement `internal/store/postgres` (Store interface) |
| T59 | #94 | Implement `internal/store/mysql` (Store interface) |
| T60 | #95 | Wire Postgres & MySQL into `database.Open`; DSN config + README |
| T61 | #96 | Docker Compose services + integration-test CI targets |

### Milestone / instructions changes

- **AGENTS.md** — added Milestone section under Commits and pull requests: new issues must be assigned to `26Q2`; current milestone noted with due date.
- **CONTRIBUTING.md** — added Milestone section under Issue / PR title format with same guidance and `gh issue create --milestone` example.
- **plan/README.md** — added phase-7 row to the phase table.
- **plan/phase-5/T01** — added Breakdown table linking all six sub-tickets.

## Ticket
Refs #12

## Checklist
- [x] `make test` passes (all packages green via `go test -race ./...`)
- [x] No code changes — documentation and plan files only
- [x] All 55 existing issues assigned to milestone 26Q2
- [x] Six new sub-issues (#91–#96) created and assigned to 26Q2
