### PR TITLE
[T56] Port SQLite migrations to PostgreSQL dialect

### DIFF
--- a/go/migrations/postgres/000001_init.down.sql
+++ b/go/migrations/postgres/000001_init.down.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS group_permissions;
+DROP TABLE IF EXISTS user_permissions;
+DROP TABLE IF EXISTS group_members;
+DROP TABLE IF EXISTS permissions;
+DROP TABLE IF EXISTS access_types;
+DROP TABLE IF EXISTS resources;
+DROP TABLE IF EXISTS groups;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS domains;

--- a/go/migrations/postgres/000001_init.up.sql
+++ b/go/migrations/postgres/000001_init.up.sql
@@ -1,0 +1,74 @@
+BEGIN;
+
+CREATE TABLE domains (
+    id   TEXT PRIMARY KEY,
+    title TEXT NOT NULL
+);
+
+CREATE TABLE users (
+    id        TEXT PRIMARY KEY,
+    domain_id TEXT NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
+    title     TEXT NOT NULL
+);
+
+CREATE TABLE groups (
+    id              TEXT PRIMARY KEY,
+    domain_id       TEXT NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
+    title           TEXT NOT NULL,
+    parent_group_id TEXT REFERENCES groups (id) ON DELETE RESTRICT
+);
+
+CREATE TABLE resources (
+    id        TEXT PRIMARY KEY,
+    domain_id TEXT NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
+    title     TEXT NOT NULL
+);
+
+CREATE TABLE access_types (
+    id        TEXT PRIMARY KEY,
+    domain_id TEXT NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
+    title     TEXT NOT NULL,
+    bit       BIGINT NOT NULL,
+    UNIQUE (domain_id, bit)
+);
+
+CREATE TABLE permissions (
+    id          TEXT PRIMARY KEY,
+    domain_id   TEXT NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
+    title       TEXT NOT NULL,
+    resource_id TEXT NOT NULL REFERENCES resources (id) ON DELETE CASCADE,
+    access_mask BIGINT NOT NULL
+);
+
+CREATE TABLE group_members (
+    domain_id TEXT NOT NULL REFERENCES domains (id) ON DELETE CASCADE,
+    user_id   TEXT NOT NULL REFERENCES users (id)   ON DELETE CASCADE,
+    group_id  TEXT NOT NULL REFERENCES groups (id)  ON DELETE CASCADE,
+    PRIMARY KEY (user_id, group_id)
+);
+
+CREATE TABLE user_permissions (
+    domain_id     TEXT NOT NULL REFERENCES domains (id)     ON DELETE CASCADE,
+    user_id       TEXT NOT NULL REFERENCES users (id)       ON DELETE CASCADE,
+    permission_id TEXT NOT NULL REFERENCES permissions (id) ON DELETE CASCADE,
+    PRIMARY KEY (user_id, permission_id)
+);
+
+CREATE TABLE group_permissions (
+    domain_id     TEXT NOT NULL REFERENCES domains (id)     ON DELETE CASCADE,
+    group_id      TEXT NOT NULL REFERENCES groups (id)      ON DELETE CASCADE,
+    permission_id TEXT NOT NULL REFERENCES permissions (id) ON DELETE CASCADE,
+    PRIMARY KEY (group_id, permission_id)
+);
+
+CREATE INDEX idx_users_domain                ON users       (domain_id);
+CREATE INDEX idx_groups_domain               ON groups      (domain_id);
+CREATE INDEX idx_resources_domain            ON resources   (domain_id);
+CREATE INDEX idx_access_types_domain_bit     ON access_types (domain_id, bit);
+CREATE INDEX idx_permissions_domain_resource ON permissions  (domain_id, resource_id);
+CREATE INDEX idx_group_members_domain_user   ON group_members   (domain_id, user_id);
+CREATE INDEX idx_group_members_domain_group  ON group_members   (domain_id, group_id);
+CREATE INDEX idx_user_permissions_domain_user   ON user_permissions  (domain_id, user_id);
+CREATE INDEX idx_group_permissions_domain_group ON group_permissions (domain_id, group_id);
+
+COMMIT;

--- a/go/migrations/postgres/000002_restrict_foreign_keys.down.sql
+++ b/go/migrations/postgres/000002_restrict_foreign_keys.down.sql
@@ -1,0 +1,91 @@
+-- Revert T33: restore ON DELETE CASCADE on all FKs changed by migration 2.
+
+-- users.domain_id
+ALTER TABLE users
+    DROP CONSTRAINT users_domain_id_fkey,
+    ADD  CONSTRAINT users_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- groups.domain_id
+ALTER TABLE groups
+    DROP CONSTRAINT groups_domain_id_fkey,
+    ADD  CONSTRAINT groups_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- resources.domain_id
+ALTER TABLE resources
+    DROP CONSTRAINT resources_domain_id_fkey,
+    ADD  CONSTRAINT resources_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- access_types.domain_id
+ALTER TABLE access_types
+    DROP CONSTRAINT access_types_domain_id_fkey,
+    ADD  CONSTRAINT access_types_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- permissions.domain_id
+ALTER TABLE permissions
+    DROP CONSTRAINT permissions_domain_id_fkey,
+    ADD  CONSTRAINT permissions_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- permissions.resource_id
+ALTER TABLE permissions
+    DROP CONSTRAINT permissions_resource_id_fkey,
+    ADD  CONSTRAINT permissions_resource_id_fkey
+        FOREIGN KEY (resource_id) REFERENCES resources (id) ON DELETE CASCADE;
+
+-- group_members.domain_id
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_domain_id_fkey,
+    ADD  CONSTRAINT group_members_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- group_members.user_id
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_user_id_fkey,
+    ADD  CONSTRAINT group_members_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+-- group_members.group_id
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_group_id_fkey,
+    ADD  CONSTRAINT group_members_group_id_fkey
+        FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE;
+
+-- user_permissions.domain_id
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_domain_id_fkey,
+    ADD  CONSTRAINT user_permissions_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- user_permissions.user_id
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_user_id_fkey,
+    ADD  CONSTRAINT user_permissions_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+-- user_permissions.permission_id
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_permission_id_fkey,
+    ADD  CONSTRAINT user_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE;
+
+-- group_permissions.domain_id
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_domain_id_fkey,
+    ADD  CONSTRAINT group_permissions_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+-- group_permissions.group_id
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_group_id_fkey,
+    ADD  CONSTRAINT group_permissions_group_id_fkey
+        FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE CASCADE;
+
+-- group_permissions.permission_id
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_permission_id_fkey,
+    ADD  CONSTRAINT group_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE;

--- a/go/migrations/postgres/000002_restrict_foreign_keys.up.sql
+++ b/go/migrations/postgres/000002_restrict_foreign_keys.up.sql
@@ -1,0 +1,98 @@
+-- T33: Replace ON DELETE CASCADE with RESTRICT so deleting an entity that is
+-- still referenced fails instead of silently removing dependents.
+-- PostgreSQL supports ALTER TABLE … DROP CONSTRAINT … ADD CONSTRAINT …, so
+-- no table-rebuild dance is required (unlike SQLite).
+
+BEGIN;
+
+-- users.domain_id
+ALTER TABLE users
+    DROP CONSTRAINT users_domain_id_fkey,
+    ADD  CONSTRAINT users_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- groups.domain_id
+ALTER TABLE groups
+    DROP CONSTRAINT groups_domain_id_fkey,
+    ADD  CONSTRAINT groups_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- resources.domain_id
+ALTER TABLE resources
+    DROP CONSTRAINT resources_domain_id_fkey,
+    ADD  CONSTRAINT resources_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- access_types.domain_id
+ALTER TABLE access_types
+    DROP CONSTRAINT access_types_domain_id_fkey,
+    ADD  CONSTRAINT access_types_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- permissions.domain_id
+ALTER TABLE permissions
+    DROP CONSTRAINT permissions_domain_id_fkey,
+    ADD  CONSTRAINT permissions_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- permissions.resource_id
+ALTER TABLE permissions
+    DROP CONSTRAINT permissions_resource_id_fkey,
+    ADD  CONSTRAINT permissions_resource_id_fkey
+        FOREIGN KEY (resource_id) REFERENCES resources (id) ON DELETE RESTRICT;
+
+-- group_members.domain_id
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_domain_id_fkey,
+    ADD  CONSTRAINT group_members_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- group_members.user_id
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_user_id_fkey,
+    ADD  CONSTRAINT group_members_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT;
+
+-- group_members.group_id
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_group_id_fkey,
+    ADD  CONSTRAINT group_members_group_id_fkey
+        FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE RESTRICT;
+
+-- user_permissions.domain_id
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_domain_id_fkey,
+    ADD  CONSTRAINT user_permissions_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- user_permissions.user_id
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_user_id_fkey,
+    ADD  CONSTRAINT user_permissions_user_id_fkey
+        FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT;
+
+-- user_permissions.permission_id
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_permission_id_fkey,
+    ADD  CONSTRAINT user_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+-- group_permissions.domain_id
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_domain_id_fkey,
+    ADD  CONSTRAINT group_permissions_domain_id_fkey
+        FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+-- group_permissions.group_id
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_group_id_fkey,
+    ADD  CONSTRAINT group_permissions_group_id_fkey
+        FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE RESTRICT;
+
+-- group_permissions.permission_id
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_permission_id_fkey,
+    ADD  CONSTRAINT group_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+COMMIT;

--- a/go/migrations/postgres/000003_composite_fk_cross_domain.down.sql
+++ b/go/migrations/postgres/000003_composite_fk_cross_domain.down.sql
@@ -1,0 +1,40 @@
+-- T51 (down): revert composite UNIQUE / composite FK schema back to the
+-- post-T33 state: single-column FKs ON DELETE RESTRICT, no UNIQUE (id, domain_id).
+
+-- group_members: restore single-column FKs
+ALTER TABLE group_members
+    DROP CONSTRAINT fk_group_members_user,
+    DROP CONSTRAINT fk_group_members_group;
+
+ALTER TABLE group_members
+    ADD CONSTRAINT group_members_user_id_fkey
+        FOREIGN KEY (user_id)  REFERENCES users  (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT group_members_group_id_fkey
+        FOREIGN KEY (group_id) REFERENCES groups (id) ON DELETE RESTRICT;
+
+-- user_permissions: restore single-column FKs
+ALTER TABLE user_permissions
+    DROP CONSTRAINT fk_user_permissions_user,
+    DROP CONSTRAINT fk_user_permissions_permission;
+
+ALTER TABLE user_permissions
+    ADD CONSTRAINT user_permissions_user_id_fkey
+        FOREIGN KEY (user_id)       REFERENCES users       (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT user_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+-- group_permissions: restore single-column FKs
+ALTER TABLE group_permissions
+    DROP CONSTRAINT fk_group_permissions_group,
+    DROP CONSTRAINT fk_group_permissions_permission;
+
+ALTER TABLE group_permissions
+    ADD CONSTRAINT group_permissions_group_id_fkey
+        FOREIGN KEY (group_id)      REFERENCES groups      (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT group_permissions_permission_id_fkey
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+-- Drop composite UNIQUE constraints
+ALTER TABLE users       DROP CONSTRAINT uq_users_id_domain;
+ALTER TABLE groups      DROP CONSTRAINT uq_groups_id_domain;
+ALTER TABLE permissions DROP CONSTRAINT uq_permissions_id_domain;

--- a/go/migrations/postgres/000003_composite_fk_cross_domain.up.sql
+++ b/go/migrations/postgres/000003_composite_fk_cross_domain.up.sql
@@ -1,0 +1,100 @@
+-- T51: Enforce at the schema level that junction tables cannot reference an
+-- entity from a different domain. A composite UNIQUE (id, domain_id) on
+-- users/groups/permissions provides the FK target; each junction column
+-- pair references it.
+--
+-- Audit query to identify cross-domain rows before retrying:
+--
+--   SELECT 'group_permissions.group_domain' AS src, gp.domain_id, gp.group_id, gp.permission_id
+--     FROM group_permissions gp JOIN groups g ON gp.group_id = g.id
+--     WHERE gp.domain_id <> g.domain_id
+--   UNION ALL
+--   SELECT 'group_permissions.permission_domain', gp.domain_id, gp.group_id, gp.permission_id
+--     FROM group_permissions gp JOIN permissions p ON gp.permission_id = p.id
+--     WHERE gp.domain_id <> p.domain_id
+--   UNION ALL
+--   SELECT 'user_permissions.user_domain', up.domain_id, up.user_id, up.permission_id
+--     FROM user_permissions up JOIN users u ON up.user_id = u.id
+--     WHERE up.domain_id <> u.domain_id
+--   UNION ALL
+--   SELECT 'user_permissions.permission_domain', up.domain_id, up.user_id, up.permission_id
+--     FROM user_permissions up JOIN permissions p ON up.permission_id = p.id
+--     WHERE up.domain_id <> p.domain_id
+--   UNION ALL
+--   SELECT 'group_members.user_domain', gm.domain_id, gm.user_id, gm.group_id
+--     FROM group_members gm JOIN users u ON gm.user_id = u.id
+--     WHERE gm.domain_id <> u.domain_id
+--   UNION ALL
+--   SELECT 'group_members.group_domain', gm.domain_id, gm.user_id, gm.group_id
+--     FROM group_members gm JOIN groups g ON gm.group_id = g.id
+--     WHERE gm.domain_id <> g.domain_id;
+
+BEGIN;
+
+-- Step 0: pre-check. Abort if any cross-domain rows exist.
+DO $$
+DECLARE
+    n BIGINT;
+BEGIN
+    SELECT COALESCE(SUM(c), 0) INTO n FROM (
+        SELECT COUNT(*) AS c FROM group_permissions gp JOIN groups g       ON gp.group_id       = g.id WHERE gp.domain_id <> g.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM group_permissions gp JOIN permissions p ON gp.permission_id  = p.id WHERE gp.domain_id <> p.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM user_permissions  up JOIN users u       ON up.user_id        = u.id WHERE up.domain_id <> u.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM user_permissions  up JOIN permissions p ON up.permission_id  = p.id WHERE up.domain_id <> p.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM group_members     gm JOIN users u       ON gm.user_id        = u.id WHERE gm.domain_id <> u.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM group_members     gm JOIN groups g      ON gm.group_id       = g.id WHERE gm.domain_id <> g.domain_id
+    ) sub;
+    IF n > 0 THEN
+        RAISE EXCEPTION 'T51: cross-domain junction rows detected; see audit query in migration header before retrying';
+    END IF;
+END $$;
+
+-- Step 1: add composite UNIQUE (id, domain_id) to users, groups, permissions.
+-- The leading `id` column keeps the planner preferring the existing PK / per-domain
+-- index for domain-scoped scans (avoids optimizer issues with ORDER BY + LIMIT/OFFSET).
+ALTER TABLE users       ADD CONSTRAINT uq_users_id_domain       UNIQUE (id, domain_id);
+ALTER TABLE groups      ADD CONSTRAINT uq_groups_id_domain      UNIQUE (id, domain_id);
+ALTER TABLE permissions ADD CONSTRAINT uq_permissions_id_domain UNIQUE (id, domain_id);
+
+-- Step 2: drop the existing single-column FKs on the three junction tables
+-- and re-add them as composite FKs referencing (id, domain_id).
+
+-- group_members
+ALTER TABLE group_members
+    DROP CONSTRAINT group_members_user_id_fkey,
+    DROP CONSTRAINT group_members_group_id_fkey;
+
+ALTER TABLE group_members
+    ADD CONSTRAINT fk_group_members_user
+        FOREIGN KEY (user_id,  domain_id) REFERENCES users  (id, domain_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_group_members_group
+        FOREIGN KEY (group_id, domain_id) REFERENCES groups (id, domain_id) ON DELETE RESTRICT;
+
+-- user_permissions
+ALTER TABLE user_permissions
+    DROP CONSTRAINT user_permissions_user_id_fkey,
+    DROP CONSTRAINT user_permissions_permission_id_fkey;
+
+ALTER TABLE user_permissions
+    ADD CONSTRAINT fk_user_permissions_user
+        FOREIGN KEY (user_id,       domain_id) REFERENCES users       (id, domain_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_user_permissions_permission
+        FOREIGN KEY (permission_id, domain_id) REFERENCES permissions (id, domain_id) ON DELETE RESTRICT;
+
+-- group_permissions
+ALTER TABLE group_permissions
+    DROP CONSTRAINT group_permissions_group_id_fkey,
+    DROP CONSTRAINT group_permissions_permission_id_fkey;
+
+ALTER TABLE group_permissions
+    ADD CONSTRAINT fk_group_permissions_group
+        FOREIGN KEY (group_id,      domain_id) REFERENCES groups      (id, domain_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_group_permissions_permission
+        FOREIGN KEY (permission_id, domain_id) REFERENCES permissions (id, domain_id) ON DELETE RESTRICT;
+
+COMMIT;

--- a/go/migrations/postgres/README.md
+++ b/go/migrations/postgres/README.md
@@ -1,10 +1,11 @@
-# PostgreSQL migrations (future)
+# PostgreSQL migrations
 
-Add versioned DDL here when implementing `internal/store/postgres` and wiring `internal/database.Open` for driver `postgres`.
+Versioned DDL for PostgreSQL 15+, mirroring the SQLite migration set.
 
-TODO(T01): Port the SQLite migrations from `../sqlite/`, including
-`000003_composite_fk_cross_domain.up.sql` (T51, #77 / PR #83) — composite
-UNIQUE on `users`/`groups`/`permissions` and composite FKs on the three
-junction tables, with a pre-check that `RAISE EXCEPTION`s on cross-domain
-rows (typically inside a `DO` block). See
-`plan/phase-5/T01-per-dialect-migrations.md`.
+| File | Description |
+|------|-------------|
+| `000001_init.{up,down}.sql` | Initial schema (tables + indexes) |
+| `000002_restrict_foreign_keys.{up,down}.sql` | Switch all FKs to `ON DELETE RESTRICT` (T33) |
+| `000003_composite_fk_cross_domain.{up,down}.sql` | Composite `UNIQUE (id, domain_id)` + composite FKs on junction tables; cross-domain pre-check via `DO $$ RAISE EXCEPTION $$` (T51, #77) |
+
+Implemented in T56 (#91). Store implementation (`internal/store/postgres`) and driver wiring (`internal/database.Open`) are tracked in T58 and T60. Docker Compose service and integration-test targets are in T61 (#96).

--- a/plan/phase-7/T56-postgres-migrations.md
+++ b/plan/phase-7/T56-postgres-migrations.md
@@ -27,14 +27,14 @@ Create the three PostgreSQL migration files that mirror the SQLite set, translat
 
 ## Steps
 
-1. **Translate `000001_init`**: Replace SQLite-ism `TEXT PRIMARY KEY` with `TEXT PRIMARY KEY` (same, fine), ensure `INTEGER` → `BIGINT` for `bit` column on `access_types`, keep the nine indexes.
+1. **Translate `000001_init`**: Keep `TEXT PRIMARY KEY` for all `id` columns (UUIDs stored as text). Translate `INTEGER` → `BIGINT` for the `bit` column on `access_types`. Add explicit `ON DELETE CASCADE` / `ON DELETE RESTRICT` where needed. Keep all nine indexes.
 2. **Translate `000002_restrict_foreign_keys`**: PostgreSQL allows `ALTER TABLE … ALTER CONSTRAINT` or `DROP CONSTRAINT … ADD CONSTRAINT … ON DELETE RESTRICT`. Use `ALTER TABLE` rather than the SQLite rebuild-and-copy pattern (SQLite cannot `ALTER` FKs, PostgreSQL can).
 3. **Translate `000003_composite_fk_cross_domain`** (ported from T51/#77 PR #83):
    - Add composite `UNIQUE (domain_id, id)` to `users`, `groups`, `permissions` via `ALTER TABLE`.
    - Drop and re-add composite FKs on the three junction tables referencing `(domain_id, user_id/group_id/permission_id)`.
    - Replace `RAISE(ABORT, …)` SQLite trigger with a PostgreSQL `DO $$ BEGIN … IF EXISTS(…) THEN RAISE EXCEPTION '…'; END IF; END $$;` pre-check block.
 4. Write a corresponding `.down.sql` for each migration that reverses the changes cleanly.
-5. Verify migrations apply in order with `psql` against a local Postgres container (or via the test helper in T61).
+5. Verify migrations apply in order with `psql` against a local Postgres container (see T61 for docker-compose service wiring; for T56 a standalone `docker run postgres:15-alpine` is sufficient).
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Summary

Port all three SQLite migration files to PostgreSQL-compatible DDL.

### Changes
- `go/migrations/postgres/000001_init.{up,down}.sql` — initial schema with 9 tables and indexes; `INTEGER` → `BIGINT` for the `bit` column
- `go/migrations/postgres/000002_restrict_foreign_keys.{up,down}.sql` — switch all FKs to `ON DELETE RESTRICT` using `ALTER TABLE … DROP/ADD CONSTRAINT` (no table-rebuild needed in PG)
- `go/migrations/postgres/000003_composite_fk_cross_domain.{up,down}.sql` — composite `UNIQUE (id, domain_id)` on `users`/`groups`/`permissions`; composite FKs on junction tables; `DO $$ RAISE EXCEPTION` pre-check aborts the whole transaction if cross-domain rows exist (ported from T51/#77)
- All `.up.sql` files are wrapped in `BEGIN`/`COMMIT` for atomic application
- `go/migrations/postgres/README.md` — replace TODO placeholder with file table

### Local testing (postgres:15-alpine container)
- All three `.up.sql` apply cleanly to a fresh DB ✓
- All three `.down.sql` reverse cleanly, leaving an empty DB ✓
- `ON DELETE RESTRICT` blocks deletion of referenced rows ✓
- Cross-domain FK violation fires on junction-table insert ✓
- Pre-check `RAISE EXCEPTION` aborts entire transaction when cross-domain rows exist, with no partial changes applied ✓

## Ticket

Fixes #91 — Part of T1 — Refs #12

## Checklist

- [x] Tests / verification done locally (Docker container)
- [x] No secrets or real env values in diff
- [x] Plan file revised (T56 step wording)
- [ ] Store implementation (`internal/store/postgres`) — T58
- [ ] Driver wiring (`database.Open`) — T60
- [ ] Docker Compose service + CI integration tests — T61 (#96)