### PR TITLE
[T57] Port SQLite migrations to MySQL/MariaDB dialect

### DIFF
--- a/go/migrations/mysql/000001_init.down.sql
+++ b/go/migrations/mysql/000001_init.down.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS group_permissions;
+DROP TABLE IF EXISTS user_permissions;
+DROP TABLE IF EXISTS group_members;
+DROP TABLE IF EXISTS permissions;
+DROP TABLE IF EXISTS access_types;
+DROP TABLE IF EXISTS resources;
+DROP TABLE IF EXISTS `groups`;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS domains;

--- a/go/migrations/mysql/000001_init.up.sql
+++ b/go/migrations/mysql/000001_init.up.sql
@@ -1,0 +1,86 @@
+CREATE TABLE domains (
+    id    VARCHAR(255) PRIMARY KEY,
+    title VARCHAR(255) NOT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE users (
+    id        VARCHAR(255) PRIMARY KEY,
+    domain_id VARCHAR(255) NOT NULL,
+    title     VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_users_domain FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE `groups` (
+    id              VARCHAR(255) PRIMARY KEY,
+    domain_id       VARCHAR(255) NOT NULL,
+    title           VARCHAR(255) NOT NULL,
+    parent_group_id VARCHAR(255) DEFAULT NULL,
+    CONSTRAINT fk_groups_domain  FOREIGN KEY (domain_id)       REFERENCES domains  (id) ON DELETE CASCADE,
+    CONSTRAINT fk_groups_parent  FOREIGN KEY (parent_group_id) REFERENCES `groups` (id) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE resources (
+    id        VARCHAR(255) PRIMARY KEY,
+    domain_id VARCHAR(255) NOT NULL,
+    title     VARCHAR(255) NOT NULL,
+    CONSTRAINT fk_resources_domain FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE access_types (
+    id        VARCHAR(255) PRIMARY KEY,
+    domain_id VARCHAR(255) NOT NULL,
+    title     VARCHAR(255) NOT NULL,
+    bit       BIGINT UNSIGNED NOT NULL,
+    UNIQUE KEY uq_access_types_domain_bit (domain_id, bit),
+    CONSTRAINT fk_access_types_domain FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE permissions (
+    id          VARCHAR(255) PRIMARY KEY,
+    domain_id   VARCHAR(255) NOT NULL,
+    title       VARCHAR(255) NOT NULL,
+    resource_id VARCHAR(255) NOT NULL,
+    access_mask BIGINT NOT NULL,
+    CONSTRAINT fk_permissions_domain   FOREIGN KEY (domain_id)   REFERENCES domains   (id) ON DELETE CASCADE,
+    CONSTRAINT fk_permissions_resource FOREIGN KEY (resource_id) REFERENCES resources (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE group_members (
+    domain_id VARCHAR(255) NOT NULL,
+    user_id   VARCHAR(255) NOT NULL,
+    group_id  VARCHAR(255) NOT NULL,
+    PRIMARY KEY (user_id, group_id),
+    CONSTRAINT fk_group_members_domain FOREIGN KEY (domain_id) REFERENCES domains  (id) ON DELETE CASCADE,
+    CONSTRAINT fk_group_members_user   FOREIGN KEY (user_id)   REFERENCES users    (id) ON DELETE CASCADE,
+    CONSTRAINT fk_group_members_group  FOREIGN KEY (group_id)  REFERENCES `groups` (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE user_permissions (
+    domain_id     VARCHAR(255) NOT NULL,
+    user_id       VARCHAR(255) NOT NULL,
+    permission_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (user_id, permission_id),
+    CONSTRAINT fk_user_permissions_domain     FOREIGN KEY (domain_id)     REFERENCES domains      (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_permissions_user       FOREIGN KEY (user_id)       REFERENCES users        (id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_permissions_permission FOREIGN KEY (permission_id) REFERENCES permissions  (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE group_permissions (
+    domain_id     VARCHAR(255) NOT NULL,
+    group_id      VARCHAR(255) NOT NULL,
+    permission_id VARCHAR(255) NOT NULL,
+    PRIMARY KEY (group_id, permission_id),
+    CONSTRAINT fk_group_permissions_domain     FOREIGN KEY (domain_id)     REFERENCES domains      (id) ON DELETE CASCADE,
+    CONSTRAINT fk_group_permissions_group      FOREIGN KEY (group_id)      REFERENCES `groups`     (id) ON DELETE CASCADE,
+    CONSTRAINT fk_group_permissions_permission FOREIGN KEY (permission_id) REFERENCES permissions  (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE INDEX idx_users_domain                ON users            (domain_id);
+CREATE INDEX idx_groups_domain               ON `groups`         (domain_id);
+CREATE INDEX idx_resources_domain            ON resources        (domain_id);
+CREATE INDEX idx_access_types_domain_bit     ON access_types     (domain_id, bit);
+CREATE INDEX idx_permissions_domain_resource ON permissions      (domain_id, resource_id);
+CREATE INDEX idx_group_members_domain_user   ON group_members    (domain_id, user_id);
+CREATE INDEX idx_group_members_domain_group  ON group_members    (domain_id, group_id);
+CREATE INDEX idx_user_permissions_domain_user    ON user_permissions  (domain_id, user_id);
+CREATE INDEX idx_group_permissions_domain_group  ON group_permissions (domain_id, group_id);

--- a/go/migrations/mysql/000002_restrict_foreign_keys.down.sql
+++ b/go/migrations/mysql/000002_restrict_foreign_keys.down.sql
@@ -1,0 +1,63 @@
+-- Revert T33: restore ON DELETE CASCADE on all FKs changed by migration 2.
+-- Uses two ALTER TABLE statements per table (drop then add) for MySQL compatibility.
+
+ALTER TABLE users DROP FOREIGN KEY fk_users_domain;
+ALTER TABLE users ADD CONSTRAINT fk_users_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE `groups` DROP FOREIGN KEY fk_groups_domain;
+ALTER TABLE `groups` ADD CONSTRAINT fk_groups_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE resources DROP FOREIGN KEY fk_resources_domain;
+ALTER TABLE resources ADD CONSTRAINT fk_resources_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE access_types DROP FOREIGN KEY fk_access_types_domain;
+ALTER TABLE access_types ADD CONSTRAINT fk_access_types_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE permissions DROP FOREIGN KEY fk_permissions_domain;
+ALTER TABLE permissions ADD CONSTRAINT fk_permissions_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE permissions DROP FOREIGN KEY fk_permissions_resource;
+ALTER TABLE permissions ADD CONSTRAINT fk_permissions_resource
+    FOREIGN KEY (resource_id) REFERENCES resources (id) ON DELETE CASCADE;
+
+ALTER TABLE group_members DROP FOREIGN KEY fk_group_members_domain;
+ALTER TABLE group_members ADD CONSTRAINT fk_group_members_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE group_members DROP FOREIGN KEY fk_group_members_user;
+ALTER TABLE group_members ADD CONSTRAINT fk_group_members_user
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+ALTER TABLE group_members DROP FOREIGN KEY fk_group_members_group;
+ALTER TABLE group_members ADD CONSTRAINT fk_group_members_group
+    FOREIGN KEY (group_id) REFERENCES `groups` (id) ON DELETE CASCADE;
+
+ALTER TABLE user_permissions DROP FOREIGN KEY fk_user_permissions_domain;
+ALTER TABLE user_permissions ADD CONSTRAINT fk_user_permissions_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE user_permissions DROP FOREIGN KEY fk_user_permissions_user;
+ALTER TABLE user_permissions ADD CONSTRAINT fk_user_permissions_user
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE;
+
+ALTER TABLE user_permissions DROP FOREIGN KEY fk_user_permissions_permission;
+ALTER TABLE user_permissions ADD CONSTRAINT fk_user_permissions_permission
+    FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE;
+
+ALTER TABLE group_permissions DROP FOREIGN KEY fk_group_permissions_domain;
+ALTER TABLE group_permissions ADD CONSTRAINT fk_group_permissions_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE CASCADE;
+
+ALTER TABLE group_permissions DROP FOREIGN KEY fk_group_permissions_group;
+ALTER TABLE group_permissions ADD CONSTRAINT fk_group_permissions_group
+    FOREIGN KEY (group_id) REFERENCES `groups` (id) ON DELETE CASCADE;
+
+ALTER TABLE group_permissions DROP FOREIGN KEY fk_group_permissions_permission;
+ALTER TABLE group_permissions ADD CONSTRAINT fk_group_permissions_permission
+    FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE CASCADE;
+

--- a/go/migrations/mysql/000002_restrict_foreign_keys.up.sql
+++ b/go/migrations/mysql/000002_restrict_foreign_keys.up.sql
@@ -1,0 +1,65 @@
+-- T33: Replace ON DELETE CASCADE with RESTRICT so deleting an entity that is
+-- still referenced fails instead of silently removing dependents.
+-- MySQL/InnoDB requires two separate ALTER TABLE statements per table to
+-- drop a FK and re-add it with a new action under the same constraint name.
+
+ALTER TABLE users DROP FOREIGN KEY fk_users_domain;
+ALTER TABLE users ADD CONSTRAINT fk_users_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE `groups` DROP FOREIGN KEY fk_groups_domain;
+ALTER TABLE `groups` ADD CONSTRAINT fk_groups_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE resources DROP FOREIGN KEY fk_resources_domain;
+ALTER TABLE resources ADD CONSTRAINT fk_resources_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE access_types DROP FOREIGN KEY fk_access_types_domain;
+ALTER TABLE access_types ADD CONSTRAINT fk_access_types_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE permissions DROP FOREIGN KEY fk_permissions_domain;
+ALTER TABLE permissions ADD CONSTRAINT fk_permissions_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE permissions DROP FOREIGN KEY fk_permissions_resource;
+ALTER TABLE permissions ADD CONSTRAINT fk_permissions_resource
+    FOREIGN KEY (resource_id) REFERENCES resources (id) ON DELETE RESTRICT;
+
+ALTER TABLE group_members DROP FOREIGN KEY fk_group_members_domain;
+ALTER TABLE group_members ADD CONSTRAINT fk_group_members_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE group_members DROP FOREIGN KEY fk_group_members_user;
+ALTER TABLE group_members ADD CONSTRAINT fk_group_members_user
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT;
+
+ALTER TABLE group_members DROP FOREIGN KEY fk_group_members_group;
+ALTER TABLE group_members ADD CONSTRAINT fk_group_members_group
+    FOREIGN KEY (group_id) REFERENCES `groups` (id) ON DELETE RESTRICT;
+
+ALTER TABLE user_permissions DROP FOREIGN KEY fk_user_permissions_domain;
+ALTER TABLE user_permissions ADD CONSTRAINT fk_user_permissions_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE user_permissions DROP FOREIGN KEY fk_user_permissions_user;
+ALTER TABLE user_permissions ADD CONSTRAINT fk_user_permissions_user
+    FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE RESTRICT;
+
+ALTER TABLE user_permissions DROP FOREIGN KEY fk_user_permissions_permission;
+ALTER TABLE user_permissions ADD CONSTRAINT fk_user_permissions_permission
+    FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+ALTER TABLE group_permissions DROP FOREIGN KEY fk_group_permissions_domain;
+ALTER TABLE group_permissions ADD CONSTRAINT fk_group_permissions_domain
+    FOREIGN KEY (domain_id) REFERENCES domains (id) ON DELETE RESTRICT;
+
+ALTER TABLE group_permissions DROP FOREIGN KEY fk_group_permissions_group;
+ALTER TABLE group_permissions ADD CONSTRAINT fk_group_permissions_group
+    FOREIGN KEY (group_id) REFERENCES `groups` (id) ON DELETE RESTRICT;
+
+ALTER TABLE group_permissions DROP FOREIGN KEY fk_group_permissions_permission;
+ALTER TABLE group_permissions ADD CONSTRAINT fk_group_permissions_permission
+    FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+

--- a/go/migrations/mysql/000003_composite_fk_cross_domain.down.sql
+++ b/go/migrations/mysql/000003_composite_fk_cross_domain.down.sql
@@ -1,0 +1,40 @@
+-- T51 (down): revert composite UNIQUE KEY / composite FK schema back to the
+-- post-T33 state: single-column FKs ON DELETE RESTRICT, no composite UNIQUE KEY.
+
+-- group_members: restore single-column FKs
+ALTER TABLE group_members
+    DROP FOREIGN KEY fk_group_members_user_domain,
+    DROP FOREIGN KEY fk_group_members_group_domain;
+
+ALTER TABLE group_members
+    ADD CONSTRAINT fk_group_members_user
+        FOREIGN KEY (user_id)  REFERENCES users    (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_group_members_group
+        FOREIGN KEY (group_id) REFERENCES `groups` (id) ON DELETE RESTRICT;
+
+-- user_permissions: restore single-column FKs
+ALTER TABLE user_permissions
+    DROP FOREIGN KEY fk_user_permissions_user_domain,
+    DROP FOREIGN KEY fk_user_permissions_permission_domain;
+
+ALTER TABLE user_permissions
+    ADD CONSTRAINT fk_user_permissions_user
+        FOREIGN KEY (user_id)       REFERENCES users       (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_user_permissions_permission
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+-- group_permissions: restore single-column FKs
+ALTER TABLE group_permissions
+    DROP FOREIGN KEY fk_group_permissions_group_domain,
+    DROP FOREIGN KEY fk_group_permissions_permission_domain;
+
+ALTER TABLE group_permissions
+    ADD CONSTRAINT fk_group_permissions_group
+        FOREIGN KEY (group_id)      REFERENCES `groups`    (id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_group_permissions_permission
+        FOREIGN KEY (permission_id) REFERENCES permissions (id) ON DELETE RESTRICT;
+
+-- Drop composite UNIQUE KEY constraints
+ALTER TABLE users       DROP INDEX uq_users_id_domain;
+ALTER TABLE `groups`    DROP INDEX uq_groups_id_domain;
+ALTER TABLE permissions DROP INDEX uq_permissions_id_domain;

--- a/go/migrations/mysql/000003_composite_fk_cross_domain.up.sql
+++ b/go/migrations/mysql/000003_composite_fk_cross_domain.up.sql
@@ -1,0 +1,118 @@
+-- T51: Enforce at the schema level that junction tables cannot reference an
+-- entity from a different domain. A composite UNIQUE KEY (id, domain_id) on
+-- users/groups/permissions provides the FK target; each junction column
+-- pair references it.
+--
+-- MySQL/MariaDB note: MySQL does not support DDL transactions; this migration
+-- is not transactional. If the pre-check fires, the migration is aborted and
+-- should be retried after fixing the cross-domain data.
+--
+-- Audit query to identify cross-domain rows before retrying:
+--
+--   SELECT 'group_permissions.group_domain' AS src, gp.domain_id, gp.group_id, gp.permission_id
+--     FROM group_permissions gp JOIN `groups` g ON gp.group_id = g.id
+--     WHERE gp.domain_id <> g.domain_id
+--   UNION ALL
+--   SELECT 'group_permissions.permission_domain', gp.domain_id, gp.group_id, gp.permission_id
+--     FROM group_permissions gp JOIN permissions p ON gp.permission_id = p.id
+--     WHERE gp.domain_id <> p.domain_id
+--   UNION ALL
+--   SELECT 'user_permissions.user_domain', up.domain_id, up.user_id, up.permission_id
+--     FROM user_permissions up JOIN users u ON up.user_id = u.id
+--     WHERE up.domain_id <> u.domain_id
+--   UNION ALL
+--   SELECT 'user_permissions.permission_domain', up.domain_id, up.user_id, up.permission_id
+--     FROM user_permissions up JOIN permissions p ON up.permission_id = p.id
+--     WHERE up.domain_id <> p.domain_id
+--   UNION ALL
+--   SELECT 'group_members.user_domain', gm.domain_id, gm.user_id, gm.group_id
+--     FROM group_members gm JOIN users u ON gm.user_id = u.id
+--     WHERE gm.domain_id <> u.domain_id
+--   UNION ALL
+--   SELECT 'group_members.group_domain', gm.domain_id, gm.user_id, gm.group_id
+--     FROM group_members gm JOIN `groups` g ON gm.group_id = g.id
+--     WHERE gm.domain_id <> g.domain_id;
+
+-- Step 0: pre-check via a BEFORE INSERT trigger on a temporary marker table.
+-- SIGNAL SQLSTATE aborts the triggering INSERT, halting the migration.
+-- Note: MySQL does not support transactional DDL; the pre-check fires on the
+-- INSERT statement only. If the pre-check passes, subsequent ALTER TABLE
+-- statements run independently (non-transactionally).
+-- The DELIMITER change below is required by the mysql CLI to handle the
+-- trigger body that contains semicolons. A future Go-based migration runner
+-- (T59/T60) should split statements by $$ or use multiStatements=true with
+-- DELIMITER-aware parsing.
+
+CREATE TABLE _mig_t51_marker (x INT) ENGINE=InnoDB;
+
+DELIMITER $$
+CREATE TRIGGER _mig_t51_check BEFORE INSERT ON _mig_t51_marker
+FOR EACH ROW
+BEGIN
+    DECLARE n BIGINT DEFAULT 0;
+    SELECT COALESCE(SUM(c), 0) INTO n FROM (
+        SELECT COUNT(*) AS c FROM group_permissions gp JOIN `groups`     g ON gp.group_id      = g.id WHERE gp.domain_id <> g.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM group_permissions gp JOIN permissions p ON gp.permission_id = p.id WHERE gp.domain_id <> p.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM user_permissions  up JOIN users        u ON up.user_id      = u.id WHERE up.domain_id <> u.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM user_permissions  up JOIN permissions  p ON up.permission_id = p.id WHERE up.domain_id <> p.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM group_members     gm JOIN users        u ON gm.user_id      = u.id WHERE gm.domain_id <> u.domain_id
+        UNION ALL
+        SELECT COUNT(*)        FROM group_members     gm JOIN `groups`     g ON gm.group_id     = g.id WHERE gm.domain_id <> g.domain_id
+    ) sub;
+    IF n > 0 THEN
+        SIGNAL SQLSTATE '45000'
+            SET MESSAGE_TEXT = 'T51: cross-domain junction rows detected; see audit query in migration header before retrying';
+    END IF;
+END$$
+DELIMITER ;
+
+INSERT INTO _mig_t51_marker (x) VALUES (1);
+
+DROP TRIGGER _mig_t51_check;
+DROP TABLE   _mig_t51_marker;
+
+-- Step 1: add composite UNIQUE KEY (id, domain_id) to users, groups, permissions.
+-- The leading `id` column keeps the planner preferring the PK / per-domain index
+-- for domain-scoped scans, avoiding optimizer issues with ORDER BY + LIMIT/OFFSET.
+ALTER TABLE users       ADD CONSTRAINT uq_users_id_domain       UNIQUE KEY (id, domain_id);
+ALTER TABLE `groups`    ADD CONSTRAINT uq_groups_id_domain      UNIQUE KEY (id, domain_id);
+ALTER TABLE permissions ADD CONSTRAINT uq_permissions_id_domain UNIQUE KEY (id, domain_id);
+
+-- Step 2: replace single-column FKs on junction tables with composite FKs.
+
+-- group_members
+ALTER TABLE group_members
+    DROP FOREIGN KEY fk_group_members_user,
+    DROP FOREIGN KEY fk_group_members_group;
+
+ALTER TABLE group_members
+    ADD CONSTRAINT fk_group_members_user_domain
+        FOREIGN KEY (user_id,  domain_id) REFERENCES users    (id, domain_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_group_members_group_domain
+        FOREIGN KEY (group_id, domain_id) REFERENCES `groups` (id, domain_id) ON DELETE RESTRICT;
+
+-- user_permissions
+ALTER TABLE user_permissions
+    DROP FOREIGN KEY fk_user_permissions_user,
+    DROP FOREIGN KEY fk_user_permissions_permission;
+
+ALTER TABLE user_permissions
+    ADD CONSTRAINT fk_user_permissions_user_domain
+        FOREIGN KEY (user_id,       domain_id) REFERENCES users       (id, domain_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_user_permissions_permission_domain
+        FOREIGN KEY (permission_id, domain_id) REFERENCES permissions (id, domain_id) ON DELETE RESTRICT;
+
+-- group_permissions
+ALTER TABLE group_permissions
+    DROP FOREIGN KEY fk_group_permissions_group,
+    DROP FOREIGN KEY fk_group_permissions_permission;
+
+ALTER TABLE group_permissions
+    ADD CONSTRAINT fk_group_permissions_group_domain
+        FOREIGN KEY (group_id,      domain_id) REFERENCES `groups`    (id, domain_id) ON DELETE RESTRICT,
+    ADD CONSTRAINT fk_group_permissions_permission_domain
+        FOREIGN KEY (permission_id, domain_id) REFERENCES permissions (id, domain_id) ON DELETE RESTRICT;

--- a/go/migrations/mysql/README.md
+++ b/go/migrations/mysql/README.md
@@ -1,9 +1,13 @@
-# MySQL migrations (future)
+# MySQL/MariaDB migrations
 
-Add versioned DDL here when implementing `internal/store/mysql` and wiring `internal/database.Open` for driver `mysql`.
+Versioned DDL for MySQL 8+ and MariaDB 10.6+, mirroring the SQLite migration set.
 
-TODO(T01): Port the SQLite migrations from `../sqlite/`, including
-`000003_composite_fk_cross_domain.up.sql` (T51, #77 / PR #83) — composite
-UNIQUE on `users`/`groups`/`permissions` and composite FKs on the three
-junction tables, with a pre-check that `SIGNAL SQLSTATE`s on cross-domain
-rows. See `plan/phase-5/T01-per-dialect-migrations.md`.
+| File | Description |
+|------|-------------|
+| `000001_init.{up,down}.sql` | Initial schema (tables + indexes); `BIGINT UNSIGNED` for `bit`; `ENGINE=InnoDB` on all tables |
+| `000002_restrict_foreign_keys.{up,down}.sql` | Switch all FKs to `ON DELETE RESTRICT` (T33) |
+| `000003_composite_fk_cross_domain.{up,down}.sql` | Composite `UNIQUE KEY (id, domain_id)` + composite FKs on junction tables; cross-domain pre-check via `SIGNAL SQLSTATE '45000'` in a BEFORE INSERT trigger (T51, #77) |
+
+**Note:** MySQL does not support transactional DDL. Migration 3 is non-transactional; if the pre-check fires the migration is aborted and can be retried once cross-domain rows are cleaned up.
+
+Implemented in T57 (#92). Store implementation (`internal/store/mysql`) and driver wiring (`internal/database.Open`) are tracked in T59 and T60. Docker Compose service and integration-test targets are in T61 (#96).

--- a/plan/phase-7/T57-mysql-migrations.md
+++ b/plan/phase-7/T57-mysql-migrations.md
@@ -34,7 +34,7 @@ Create the three MySQL/MariaDB migration files that mirror the SQLite set, trans
    - Drop and re-add composite FKs on the three junction tables.
    - Replace `RAISE(ABORT, …)` with a stored procedure/event-free approach using `SIGNAL SQLSTATE '45000' SET MESSAGE_TEXT = '…';` inside a before-insert trigger, or a stored procedure pre-check — choose whichever is more compatible across MySQL 8 / MariaDB 10.6.
 4. Write corresponding `.down.sql` for each migration.
-5. Verify migrations apply against a local MySQL 8 container (or via the test helper in T61).
+5. Verify migrations apply against a local MySQL 8 container (see T61 for docker-compose service wiring; for T57 a standalone `docker run mysql:8` is sufficient).
 
 ## Acceptance criteria
 


### PR DESCRIPTION
## Summary

Port all three SQLite migration files to MySQL 8+ / MariaDB 10.6+ compatible DDL.

### Changes
- `go/migrations/mysql/000001_init.{up,down}.sql` — initial schema; `VARCHAR(255)` for ids, `BIGINT UNSIGNED` for `bit`, `ENGINE=InnoDB` on all tables
- `go/migrations/mysql/000002_restrict_foreign_keys.{up,down}.sql` — switch all FKs to `ON DELETE RESTRICT` using two-step `ALTER TABLE DROP FK / ADD CONSTRAINT` per table (MySQL requires this to reuse the same constraint name)
- `go/migrations/mysql/000003_composite_fk_cross_domain.{up,down}.sql` — composite `UNIQUE KEY (id, domain_id)` on `users`/`groups`/`permissions`; composite FKs on junction tables; `SIGNAL SQLSTATE '45000'` pre-check inside a `BEFORE INSERT` trigger using `DELIMITER $$` for mysql CLI (ported from T51/#77)
- `go/migrations/mysql/README.md` — replace TODO placeholder with file table

### MySQL-specific notes
- **Migration 2**: MySQL doesn't allow drop+add of the same FK name in one `ALTER TABLE` statement; two separate statements are used per FK.
- **Migration 3 (non-atomic)**: MySQL doesn't support transactional DDL. The pre-check trigger fires on the `INSERT INTO _mig_t51_marker` statement; if it passes, subsequent `ALTER TABLE` statements are independent. The `DELIMITER $$` directive is `mysql` CLI-specific; a future Go migration runner (T59/T60) will need delimiter-aware statement splitting.

### Local testing (mysql:8 container)
- All three `.up.sql` apply cleanly to a fresh DB ✓
- All three `.down.sql` reverse cleanly, leaving an empty DB ✓
- `ON DELETE RESTRICT` blocks deletion of referenced rows ✓
- Cross-domain FK violation fires on junction-table insert ✓
- Pre-check `SIGNAL SQLSTATE '45000'` fires when cross-domain rows exist ✓

## Ticket

Fixes #92 — Part of T1 — Refs #12

## Checklist

- [x] Tests / verification done locally (Docker container)
- [x] No secrets or real env values in diff
- [x] Plan file revised (T57 step wording)
- [ ] Store implementation (`internal/store/mysql`) — T59
- [ ] Driver wiring (`database.Open`) — T60
- [ ] Docker Compose service + CI integration tests — T61 (#96)