### PR TITLE
[T61] CI integration-test job + expanded Postgres/MySQL store tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
   integration:
     name: Integration tests (Postgres + MySQL)
     runs-on: ubuntu-latest
+    needs: [go]
     defaults:
       run:
         working-directory: go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,35 +121,9 @@ jobs:
           go-version-file: go/go.mod
           cache-dependency-path: go/go.sum
 
-      - name: Start Postgres and MySQL
+      - name: Start Postgres and MySQL (and wait for healthchecks)
         working-directory: ${{ github.workspace }}
-        run: docker compose up -d postgres mysql
-
-      - name: Wait for Postgres
-        working-directory: ${{ github.workspace }}
-        run: |
-          for i in $(seq 1 30); do
-            if docker compose exec -T postgres pg_isready -U access -d access_test; then
-              echo "Postgres ready"
-              break
-            fi
-            echo "Waiting for Postgres (attempt $i)..."
-            sleep 2
-          done
-          docker compose exec -T postgres pg_isready -U access -d access_test
-
-      - name: Wait for MySQL
-        working-directory: ${{ github.workspace }}
-        run: |
-          for i in $(seq 1 30); do
-            if docker compose exec -T mysql mysqladmin ping -h localhost -paccess --silent; then
-              echo "MySQL ready"
-              break
-            fi
-            echo "Waiting for MySQL (attempt $i)..."
-            sleep 2
-          done
-          docker compose exec -T mysql mysqladmin ping -h localhost -paccess --silent
+        run: docker compose up -d --wait postgres mysql
 
       - name: Integration tests — Postgres
         run: make test-integration-postgres
@@ -165,7 +139,7 @@ jobs:
   publish:
     name: Publish image to GHCR
     runs-on: ubuntu-latest
-    needs: [go, docker]
+    needs: [go, docker, integration]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,14 +39,7 @@ jobs:
           cache-dependency-path: go/go.sum
 
       - name: Test
-        run: go test -race -coverprofile=coverage.out ./...
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        with:
-          files: go/coverage.out
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+        run: go test -race ./...
 
       - name: Vet
         run: go vet ./...
@@ -125,11 +118,15 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: docker compose up -d --wait postgres mysql
 
-      - name: Integration tests — Postgres
-        run: make test-integration-postgres
+      - name: Combined coverage (unit + integration)
+        run: make cover-integration
 
-      - name: Integration tests — MySQL
-        run: make test-integration-mysql
+      - name: Upload combined coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: go/coverage-combined.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
       - name: Compose teardown
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,68 @@ jobs:
         if: always()
         run: docker compose down --remove-orphans
 
+  integration:
+    name: Integration tests (Postgres + MySQL)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: go
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set GOTOOLCHAIN from go.mod
+        working-directory: ${{ github.workspace }}
+        run: |
+          TC=$(sed -n 's/^toolchain //p' go/go.mod | head -1)
+          [ -z "$TC" ] && TC="go$(sed -n 's/^go //p' go/go.mod | head -1)"
+          echo "GOTOOLCHAIN=${TC}" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go/go.mod
+          cache-dependency-path: go/go.sum
+
+      - name: Start Postgres and MySQL
+        working-directory: ${{ github.workspace }}
+        run: docker compose up -d postgres mysql
+
+      - name: Wait for Postgres
+        working-directory: ${{ github.workspace }}
+        run: |
+          for i in $(seq 1 30); do
+            if docker compose exec -T postgres pg_isready -U access -d access_test; then
+              echo "Postgres ready"
+              break
+            fi
+            echo "Waiting for Postgres (attempt $i)..."
+            sleep 2
+          done
+          docker compose exec -T postgres pg_isready -U access -d access_test
+
+      - name: Wait for MySQL
+        working-directory: ${{ github.workspace }}
+        run: |
+          for i in $(seq 1 30); do
+            if docker compose exec -T mysql mysqladmin ping -h localhost -paccess --silent; then
+              echo "MySQL ready"
+              break
+            fi
+            echo "Waiting for MySQL (attempt $i)..."
+            sleep 2
+          done
+          docker compose exec -T mysql mysqladmin ping -h localhost -paccess --silent
+
+      - name: Integration tests — Postgres
+        run: make test-integration-postgres
+
+      - name: Integration tests — MySQL
+        run: make test-integration-mysql
+
+      - name: Compose teardown
+        if: always()
+        working-directory: ${{ github.workspace }}
+        run: docker compose down --remove-orphans
+
   publish:
     name: Publish image to GHCR
     runs-on: ubuntu-latest

--- a/go/Makefile
+++ b/go/Makefile
@@ -28,14 +28,24 @@ cover:
 	@echo "coverage.out written; run: go tool cover -html=coverage.out"
 
 # T61 — full coverage including Postgres and MySQL store integration tests.
-# Requires: docker compose up -d postgres mysql (services defined in docker-compose.yml).
+# Requires: docker compose up -d --wait postgres mysql (see docker-compose.yml).
+# MySQL tests run with -parallel=1 to prevent concurrent DDL metadata-lock
+# conflicts across per-test databases; their coverage is appended into the
+# same combined profile.
 cover-integration:
 	go clean -testcache
 	DATABASE_DSN_POSTGRES="$(POSTGRES_DSN)" \
 	DATABASE_DSN_MYSQL="$(MYSQL_DSN)" \
-	go test -race -tags=integration -coverprofile=coverage.out ./...
-	@go tool cover -func=coverage.out | tail -n 1
-	@echo "coverage.out written; run: go tool cover -html=coverage.out"
+	go test -race -tags=integration -coverprofile=coverage-integration.out ./...
+	@echo "--- re-running mysql with -parallel=1 for stable coverage ---"
+	DATABASE_DSN_MYSQL="$(MYSQL_DSN)" \
+	go test -race -count=1 -tags=integration -parallel=1 \
+	  -coverprofile=coverage-mysql.out ./internal/store/mysql/...
+	@{ grep '^mode:' coverage-integration.out | head -1; \
+	   grep -v '^mode:' coverage-integration.out; \
+	   grep -v '^mode:' coverage-mysql.out; } > coverage-combined.out
+	@go tool cover -func=coverage-combined.out | tail -n 1
+	@echo "coverage-combined.out written; run: go tool cover -html=coverage-combined.out"
 
 # Per-package function summary (T12); runs tests via dependency on cover.
 cover-func: cover

--- a/go/Makefile
+++ b/go/Makefile
@@ -29,21 +29,12 @@ cover:
 
 # T61 — full coverage including Postgres and MySQL store integration tests.
 # Requires: docker compose up -d --wait postgres mysql (see docker-compose.yml).
-# MySQL tests run with -parallel=1 to prevent concurrent DDL metadata-lock
-# conflicts across per-test databases; their coverage is appended into the
-# same combined profile.
+# Produces coverage-combined.out covering both unit and integration tests.
 cover-integration:
 	go clean -testcache
 	DATABASE_DSN_POSTGRES="$(POSTGRES_DSN)" \
 	DATABASE_DSN_MYSQL="$(MYSQL_DSN)" \
-	go test -race -tags=integration -coverprofile=coverage-integration.out ./...
-	@echo "--- re-running mysql with -parallel=1 for stable coverage ---"
-	DATABASE_DSN_MYSQL="$(MYSQL_DSN)" \
-	go test -race -count=1 -tags=integration -parallel=1 \
-	  -coverprofile=coverage-mysql.out ./internal/store/mysql/...
-	@{ grep '^mode:' coverage-integration.out | head -1; \
-	   grep -v '^mode:' coverage-integration.out; \
-	   grep -v '^mode:' coverage-mysql.out; } > coverage-combined.out
+	go test -race -tags=integration -coverprofile=coverage-combined.out ./...
 	@go tool cover -func=coverage-combined.out | tail -n 1
 	@echo "coverage-combined.out written; run: go tool cover -html=coverage-combined.out"
 
@@ -81,7 +72,7 @@ test-integration-postgres:
 # Or override: DATABASE_DSN_MYSQL="..." make test-integration-mysql
 test-integration-mysql:
 	DATABASE_DSN_MYSQL="$(MYSQL_DSN)" \
-	go test -race -count=1 -tags=integration -parallel=1 ./internal/store/mysql/...
+	go test -race -count=1 -tags=integration ./internal/store/mysql/...
 
 # T16 — requires a running API (default BASE_URL http://127.0.0.1:8080). Bash twin: ../../test/e2e/bash/run.sh
 e2e:

--- a/go/Makefile
+++ b/go/Makefile
@@ -71,7 +71,7 @@ test-integration-postgres:
 # Or override: DATABASE_DSN_MYSQL="..." make test-integration-mysql
 test-integration-mysql:
 	DATABASE_DSN_MYSQL="$(MYSQL_DSN)" \
-	go test -race -count=1 -tags=integration ./internal/store/mysql/...
+	go test -race -count=1 -tags=integration -parallel=1 ./internal/store/mysql/...
 
 # T16 — requires a running API (default BASE_URL http://127.0.0.1:8080). Bash twin: ../../test/e2e/bash/run.sh
 e2e:

--- a/go/README.md
+++ b/go/README.md
@@ -88,6 +88,7 @@ Run **`make`** from the **repository root** (`make test`, `make lint`, …) or f
 | Tidy modules | `make tidy` |
 | Integration (postgres) | `make test-integration-postgres` — requires `DATABASE_DSN_POSTGRES` |
 | Integration (mysql) | `make test-integration-mysql` — requires `DATABASE_DSN_MYSQL` |
+| Combined coverage | `make cover-integration` — requires both DSNs + running services (`docker compose up -d --wait postgres mysql`). Produces `coverage-combined.out` (unit + integration). HTML: `go tool cover -html=coverage-combined.out`. This is what CI reports to Codecov. |
 
 Docker (from **repo root** only): `make docker-build`, `make docker-up`, `make docker-logs`, `make docker-down` — see [root README](../README.md#docker).
 

--- a/go/internal/store/mysql/store.go
+++ b/go/internal/store/mysql/store.go
@@ -170,7 +170,7 @@ func (s *Store) DomainList(ctx context.Context, opts store.ListOpts) ([]store.Do
 	where := ""
 	var args []any
 	if opts.Search != "" {
-		where = ` WHERE title LIKE ? ESCAPE '\'`
+		where = ` WHERE title LIKE ? ESCAPE '\\'`
 		args = append(args, likePattern(opts.Search, opts.SearchType))
 	}
 
@@ -248,7 +248,7 @@ func (s *Store) UserList(ctx context.Context, domainID string, opts store.ListOp
 	where := "WHERE domain_id = ?"
 	args := []any{domainID}
 	if opts.Search != "" {
-		where += ` AND title LIKE ? ESCAPE '\'`
+		where += ` AND title LIKE ? ESCAPE '\\'`
 		args = append(args, likePattern(opts.Search, opts.SearchType))
 	}
 
@@ -336,7 +336,7 @@ func (s *Store) GroupList(ctx context.Context, domainID string, opts store.Group
 	where := "WHERE domain_id = ?"
 	args := []any{domainID}
 	if opts.Search != "" {
-		where += ` AND title LIKE ? ESCAPE '\'`
+		where += ` AND title LIKE ? ESCAPE '\\'`
 		args = append(args, likePattern(opts.Search, opts.SearchType))
 	}
 	if opts.ParentGroupID != nil {
@@ -504,7 +504,7 @@ func (s *Store) ResourceList(ctx context.Context, domainID string, opts store.Li
 	where := "WHERE domain_id = ?"
 	args := []any{domainID}
 	if opts.Search != "" {
-		where += ` AND title LIKE ? ESCAPE '\'`
+		where += ` AND title LIKE ? ESCAPE '\\'`
 		args = append(args, likePattern(opts.Search, opts.SearchType))
 	}
 
@@ -586,7 +586,7 @@ func (s *Store) AccessTypeList(ctx context.Context, domainID string, opts store.
 	where := "WHERE domain_id = ?"
 	args := []any{domainID}
 	if opts.Search != "" {
-		where += ` AND title LIKE ? ESCAPE '\'`
+		where += ` AND title LIKE ? ESCAPE '\\'`
 		args = append(args, likePattern(opts.Search, opts.SearchType))
 	}
 
@@ -694,7 +694,7 @@ func (s *Store) PermissionList(ctx context.Context, domainID string, opts store.
 	where := "WHERE domain_id = ?"
 	args := []any{domainID}
 	if opts.Search != "" {
-		where += ` AND title LIKE ? ESCAPE '\'`
+		where += ` AND title LIKE ? ESCAPE '\\'`
 		args = append(args, likePattern(opts.Search, opts.SearchType))
 	}
 	if opts.ResourceID != nil {

--- a/go/internal/store/mysql/store_test.go
+++ b/go/internal/store/mysql/store_test.go
@@ -369,6 +369,12 @@ func TestMySQL_UserAuthzResourcesList(t *testing.T) {
 	if list[0].EffectiveMask != 0x1 {
 		t.Fatalf("want mask 0x1, got %#x", list[0].EffectiveMask)
 	}
+
+	// Unknown user returns ErrNotFound.
+	_, _, err = s.UserAuthzResourcesList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown user: want ErrNotFound, got %v", err)
+	}
 }
 
 func TestMySQL_EffectiveMask_userPlusGroupOR(t *testing.T) {
@@ -1199,6 +1205,12 @@ func TestMySQL_ResourceAuthzGroupsList(t *testing.T) {
 	}
 	if list[0].GroupID != gid || list[0].Mask != 0x2 {
 		t.Fatalf("got %+v", list[0])
+	}
+
+	// Unknown resource returns ErrNotFound.
+	_, _, err = s.ResourceAuthzGroupsList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
 	}
 }
 

--- a/go/internal/store/mysql/store_test.go
+++ b/go/internal/store/mysql/store_test.go
@@ -252,10 +252,12 @@ func TestMySQL_DomainCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if total < 1 {
-		t.Fatalf("want total >= 1, got %d", total)
+	if total != 1 {
+		t.Fatalf("want total=1, got %d", total)
 	}
-	_ = list
+	if len(list) != 1 || list[0].ID != id {
+		t.Fatalf("unexpected list: %+v", list)
+	}
 
 	if err := s.DomainDelete(ctx, id); err != nil {
 		t.Fatal(err)
@@ -1316,7 +1318,12 @@ func TestMySQL_DomainList_search(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("search 'alpha': want 2, got %d", total)
 	}
-	_ = list
+	if len(list) != 2 {
+		t.Fatalf("search 'alpha': want 2 items, got %d", len(list))
+	}
+	if list[0].Title != "alpha" || list[1].Title != "alphabet" {
+		t.Fatalf("want [alpha alphabet], got %+v", list)
+	}
 }
 
 func TestMySQL_DeleteNotFound(t *testing.T) {

--- a/go/internal/store/mysql/store_test.go
+++ b/go/internal/store/mysql/store_test.go
@@ -370,3 +370,967 @@ func TestMySQL_UserAuthzResourcesList(t *testing.T) {
 		t.Fatalf("want mask 0x1, got %#x", list[0].EffectiveMask)
 	}
 }
+
+func TestMySQL_EffectiveMask_userPlusGroupOR(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	pUser := uuid.NewString()
+	pGroup := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUser, DomainID: domainID, Title: "pu", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pg", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUser); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+		t.Fatal(err)
+	}
+	m, err := s.EffectiveMask(ctx, domainID, uid, rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m != 0x3 {
+		t.Fatalf("want OR of user 0x1 and group 0x2 => 0x3, got %#x", m)
+	}
+}
+
+func TestMySQL_UserCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	otherDomain := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: otherDomain, Title: "other"}); err != nil {
+		t.Fatal(err)
+	}
+
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "alice"}); err != nil {
+		t.Fatal(err)
+	}
+	u, err := s.UserGet(ctx, domainID, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.ID != uid || u.DomainID != domainID || u.Title != "alice" {
+		t.Fatalf("got %+v", u)
+	}
+	if _, err := s.UserGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+	if _, err := s.UserGet(ctx, uuid.NewString(), uid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("wrong domain: want ErrNotFound, got %v", err)
+	}
+
+	uid2 := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid2, DomainID: domainID, Title: "bob"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uuid.NewString(), DomainID: otherDomain, Title: "other"}); err != nil {
+		t.Fatal(err)
+	}
+	list, total, err := s.UserList(ctx, domainID, store.ListOpts{Offset: 0, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "alice" || list[1].Title != "bob" {
+		t.Fatalf("want alice, bob; got %+v", list)
+	}
+
+	newTitle := "alicia"
+	patched, err := s.UserPatch(ctx, domainID, uid, &newTitle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched.Title != "alicia" {
+		t.Fatalf("want 'alicia', got %q", patched.Title)
+	}
+
+	if err := s.UserDelete(ctx, domainID, uid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UserGet(ctx, domainID, uid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+	if err := s.UserDelete(ctx, domainID, uid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMySQL_GroupCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	parentID := uuid.NewString()
+	childID := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: parentID, DomainID: domainID, Title: "parent"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: childID, DomainID: domainID, Title: "child", ParentGroupID: &parentID}); err != nil {
+		t.Fatal(err)
+	}
+
+	gp, err := s.GroupGet(ctx, domainID, parentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gp.ParentGroupID != nil {
+		t.Fatalf("root should have nil parent, got %+v", gp.ParentGroupID)
+	}
+
+	gc, err := s.GroupGet(ctx, domainID, childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gc.ParentGroupID == nil || *gc.ParentGroupID != parentID {
+		t.Fatalf("want parent %s, got %+v", parentID, gc.ParentGroupID)
+	}
+
+	if _, err := s.GroupGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	list, total, err := s.GroupList(ctx, domainID, store.GroupListOpts{ListOpts: store.ListOpts{Offset: 0, Limit: 100}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].ID != childID || list[1].ID != parentID {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "updated"
+	patched, err := s.GroupPatch(ctx, domainID, childID, store.GroupPatchParams{Title: &newTitle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched.Title != "updated" {
+		t.Fatalf("want 'updated', got %q", patched.Title)
+	}
+
+	if err := s.GroupDelete(ctx, domainID, childID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupDelete(ctx, domainID, parentID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.GroupGet(ctx, domainID, parentID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestMySQL_GroupSetParent_clearAndSelf(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clearParent", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		parentID := uuid.NewString()
+		childID := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: parentID, DomainID: domainID, Title: "par"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupCreate(ctx, &store.Group{ID: childID, DomainID: domainID, Title: "chi", ParentGroupID: &parentID}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupSetParent(ctx, domainID, childID, nil); err != nil {
+			t.Fatal(err)
+		}
+		g, err := s.GroupGet(ctx, domainID, childID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if g.ParentGroupID != nil {
+			t.Fatalf("want nil parent after clear, got %+v", g.ParentGroupID)
+		}
+	})
+
+	t.Run("selfParent", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		gid := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+			t.Fatal(err)
+		}
+		err := s.GroupSetParent(ctx, domainID, gid, &gid)
+		if !errors.Is(err, store.ErrInvalidInput) {
+			t.Fatalf("want ErrInvalidInput for self-parent, got %v", err)
+		}
+	})
+}
+
+func TestMySQL_ResourceCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	other := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: other, Title: "o"}); err != nil {
+		t.Fatal(err)
+	}
+
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "doc"}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := s.ResourceGet(ctx, domainID, rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != rid || r.DomainID != domainID || r.Title != "doc" {
+		t.Fatalf("got %+v", r)
+	}
+	if _, err := s.ResourceGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	rid2 := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid2, DomainID: domainID, Title: "alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: uuid.NewString(), DomainID: other, Title: "isolated"}); err != nil {
+		t.Fatal(err)
+	}
+	list, total, err := s.ResourceList(ctx, domainID, store.ListOpts{Offset: 0, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "alpha" || list[1].Title != "doc" {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "updated"
+	if _, err := s.ResourcePatch(ctx, domainID, rid, &newTitle); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceDelete(ctx, domainID, rid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ResourceGet(ctx, domainID, rid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestMySQL_AccessTypeCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	a1 := uuid.NewString()
+	a2 := uuid.NewString()
+	if err := s.AccessTypeCreate(ctx, &store.AccessType{ID: a1, DomainID: domainID, Title: "write", Bit: 4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AccessTypeCreate(ctx, &store.AccessType{ID: a2, DomainID: domainID, Title: "read", Bit: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	at, err := s.AccessTypeGet(ctx, domainID, a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if at.Bit != 4 || at.Title != "write" {
+		t.Fatalf("got %+v", at)
+	}
+	if _, err := s.AccessTypeGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	list, total, err := s.AccessTypeList(ctx, domainID, store.ListOpts{Offset: 0, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "read" || list[1].Title != "write" {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "execute"
+	newBit := uint64(8)
+	patched, err := s.AccessTypePatch(ctx, domainID, a1, store.AccessTypePatchParams{Title: &newTitle, Bit: &newBit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched.Title != "execute" || patched.Bit != 8 {
+		t.Fatalf("patch: got %+v", patched)
+	}
+
+	if err := s.AccessTypeDelete(ctx, domainID, a1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AccessTypeGet(ctx, domainID, a1); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestMySQL_PermissionCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	pid := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "perm", ResourceID: rid, AccessMask: 0x5}); err != nil {
+		t.Fatal(err)
+	}
+	p, err := s.PermissionGet(ctx, domainID, pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ID != pid || p.ResourceID != rid || p.AccessMask != 0x5 {
+		t.Fatalf("got %+v", p)
+	}
+	if _, err := s.PermissionGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	pid2 := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid2, DomainID: domainID, Title: "apple", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	list, total, err := s.PermissionList(ctx, domainID, store.PermissionListOpts{ListOpts: store.ListOpts{Offset: 0, Limit: 100}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "apple" || list[1].Title != "perm" {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "patched"
+	newMask := uint64(0x7)
+	if _, err := s.PermissionPatch(ctx, domainID, pid, store.PermissionPatchParams{Title: &newTitle, AccessMask: &newMask}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionDelete(ctx, domainID, pid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PermissionGet(ctx, domainID, pid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestMySQL_AddUserToGroup_FK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.AddUserToGroup(ctx, domainID, uuid.NewString(), gid)
+	if !errors.Is(err, store.ErrFKViolation) {
+		t.Fatalf("want ErrFKViolation, got %v", err)
+	}
+}
+
+func TestMySQL_GrantUserPermission_FK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.GrantUserPermission(ctx, domainID, uid, uuid.NewString())
+	if !errors.Is(err, store.ErrFKViolation) {
+		t.Fatalf("want ErrFKViolation, got %v", err)
+	}
+}
+
+func TestMySQL_GrantGroupPermission_FK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.GrantGroupPermission(ctx, domainID, gid, uuid.NewString())
+	if !errors.Is(err, store.ErrFKViolation) {
+		t.Fatalf("want ErrFKViolation, got %v", err)
+	}
+}
+
+func TestMySQL_AddUserToGroup_duplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestMySQL_GrantUserPermission_duplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestMySQL_GrantGroupPermission_duplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestMySQL_RemoveUserFromGroup(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveUserFromGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveUserFromGroup(ctx, domainID, uid, gid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second remove: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMySQL_RevokeUserPermission(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeUserPermission(ctx, domainID, uid, pid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second revoke: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMySQL_RevokeGroupPermission(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeGroupPermission(ctx, domainID, gid, pid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second revoke: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMySQL_RestrictDelete(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("domainWithUser", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.UserCreate(ctx, &store.User{ID: uuid.NewString(), DomainID: domainID, Title: "u"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.DomainDelete(ctx, domainID); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+
+	t.Run("resourceWithPermission", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		rid := uuid.NewString()
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.PermissionCreate(ctx, &store.Permission{ID: uuid.NewString(), DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.ResourceDelete(ctx, domainID, rid); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+
+	t.Run("userInGroup", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		uid := uuid.NewString()
+		gid := uuid.NewString()
+		if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.UserDelete(ctx, domainID, uid); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+
+	t.Run("groupWithChild", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		parentID := uuid.NewString()
+		childID := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: parentID, DomainID: domainID, Title: "p"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupCreate(ctx, &store.Group{ID: childID, DomainID: domainID, Title: "c", ParentGroupID: &parentID}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupDelete(ctx, domainID, parentID); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+}
+
+func TestMySQL_GroupAuthzResourcesList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ridA := uuid.NewString()
+	ridB := uuid.NewString()
+	for _, rid := range []string{ridA, ridB} {
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r-" + rid}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pA1 := uuid.NewString()
+	pA2 := uuid.NewString()
+	pB := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pA1, DomainID: domainID, Title: "pA1", ResourceID: ridA, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pA2, DomainID: domainID, Title: "pA2", ResourceID: ridA, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pB, DomainID: domainID, Title: "pB", ResourceID: ridB, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pA1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pA2); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pB); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.GroupAuthzResourcesList(ctx, domainID, gid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("total: want 2, got %d", total)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len: want 2, got %d", len(list))
+	}
+	gotMasks := map[string]uint64{}
+	for _, it := range list {
+		gotMasks[it.ResourceID] = it.Mask
+	}
+	if gotMasks[ridA] != 0x5 {
+		t.Fatalf("ridA mask: want 0x5, got %#x", gotMasks[ridA])
+	}
+	if gotMasks[ridB] != 0x2 {
+		t.Fatalf("ridB mask: want 0x2, got %#x", gotMasks[ridB])
+	}
+
+	_, _, err = s.GroupAuthzResourcesList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown group: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMySQL_ResourceAuthzUsersList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	pid := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x3}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 {
+		t.Fatalf("want 1, got total=%d len=%d", total, len(list))
+	}
+	if list[0].UserID != uid || list[0].EffectiveMask != 0x3 {
+		t.Fatalf("got %+v", list[0])
+	}
+
+	_, _, err = s.ResourceAuthzUsersList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestMySQL_ResourceAuthzGroupsList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	pid := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 {
+		t.Fatalf("want 1, got total=%d len=%d", total, len(list))
+	}
+	if list[0].GroupID != gid || list[0].Mask != 0x2 {
+		t.Fatalf("got %+v", list[0])
+	}
+}
+
+func TestMySQL_PermissionMasksForUserResource(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	pUser := uuid.NewString()
+	pGroup := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUser, DomainID: domainID, Title: "pu", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pg", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUser); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+		t.Fatal(err)
+	}
+
+	masks, err := s.PermissionMasksForUserResource(ctx, domainID, uid, rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(masks) != 2 {
+		t.Fatalf("want 2 masks (user + group), got %d: %v", len(masks), masks)
+	}
+	combined := uint64(0)
+	for _, m := range masks {
+		combined |= m
+	}
+	if combined != 0x3 {
+		t.Fatalf("want combined mask 0x3, got %#x", combined)
+	}
+}
+
+func TestMySQL_DomainList_pagination(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	for i := 0; i < 5; i++ {
+		if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: fmt.Sprintf("d%02d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	page1, total, err := s.DomainList(ctx, store.ListOpts{Offset: 0, Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 5 {
+		t.Fatalf("want total=5, got %d", total)
+	}
+	if len(page1) != 3 {
+		t.Fatalf("want 3 items, got %d", len(page1))
+	}
+
+	page2, _, err := s.DomainList(ctx, store.ListOpts{Offset: 3, Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("want 2 items on page 2, got %d", len(page2))
+	}
+}
+
+func TestMySQL_DomainList_search(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: "alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: "alphabet"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: "beta"}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.DomainList(ctx, store.ListOpts{Limit: 100, Search: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("search 'alpha': want 2, got %d", total)
+	}
+	_ = list
+}
+
+func TestMySQL_DeleteNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DomainDelete(ctx, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("domain delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.UserDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("user delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.GroupDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("group delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.ResourceDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("resource delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.AccessTypeDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("access type delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.PermissionDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("permission delete not found: want ErrNotFound, got %v", err)
+	}
+}

--- a/go/internal/store/mysql/store_test.go
+++ b/go/internal/store/mysql/store_test.go
@@ -274,8 +274,9 @@ func TestMySQL_AccessType_BigintUnsigned(t *testing.T) {
 	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
 		t.Fatal(err)
 	}
-	// bit is BIGINT UNSIGNED — values up to 2^63-1 are valid (store.ErrInvalidInput
-	// guards the overflow path at the access_mask level, not bit level in MySQL).
+	// bit is BIGINT UNSIGNED — accepts the full uint64 range. This is distinct
+	// from access_mask on permissions, which is bounded at the store layer to
+	// the lower 63 bits (issue #67).
 	atID := uuid.NewString()
 	bit := uint64(1 << 62)
 	if err := s.AccessTypeCreate(ctx, &store.AccessType{ID: atID, DomainID: domainID, Title: "at", Bit: bit}); err != nil {

--- a/go/internal/store/postgres/store_test.go
+++ b/go/internal/store/postgres/store_test.go
@@ -329,6 +329,12 @@ func TestPostgres_UserAuthzResourcesList(t *testing.T) {
 	if list[0].EffectiveMask != 0x1 {
 		t.Fatalf("want mask 0x1, got %#x", list[0].EffectiveMask)
 	}
+
+	// Unknown user returns ErrNotFound.
+	_, _, err = s.UserAuthzResourcesList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown user: want ErrNotFound, got %v", err)
+	}
 }
 
 func TestPostgres_EffectiveMask_userPlusGroupOR(t *testing.T) {
@@ -1169,6 +1175,12 @@ func TestPostgres_ResourceAuthzGroupsList(t *testing.T) {
 	}
 	if list[0].GroupID != gid || list[0].Mask != 0x2 {
 		t.Fatalf("got %+v", list[0])
+	}
+
+	// Unknown resource returns ErrNotFound.
+	_, _, err = s.ResourceAuthzGroupsList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
 	}
 }
 

--- a/go/internal/store/postgres/store_test.go
+++ b/go/internal/store/postgres/store_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/dtorabi/access-manager/internal/testutil"
 	"github.com/google/uuid"
+	"github.com/lib/pq"
 )
 
 // newTestStore creates a new Postgres-backed Store for integration tests.
@@ -34,22 +35,41 @@ func newTestStore(t *testing.T) *Store {
 		schemaName = schemaName[:63]
 	}
 
-	db, err := Open(dsn)
+	// Create the schema using a temporary connection before opening the pool.
+	// This avoids any pool-safety concerns with DDL on a shared connection.
+	bootstrapDB, err := Open(dsn)
 	if err != nil {
-		t.Fatalf("Open: %v", err)
+		t.Fatalf("Open (bootstrap): %v", err)
 	}
-
-	if _, err := db.Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %q`, schemaName)); err != nil {
-		_ = db.Close()
+	if _, err := bootstrapDB.Exec(fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s`, pq.QuoteIdentifier(schemaName))); err != nil {
+		_ = bootstrapDB.Close()
 		t.Fatalf("create schema: %v", err)
 	}
-	if _, err := db.Exec(fmt.Sprintf(`SET search_path TO %q`, schemaName)); err != nil {
-		_ = db.Close()
-		t.Fatalf("set search_path: %v", err)
+	_ = bootstrapDB.Close()
+
+	// Embed search_path in the DSN so every connection in the pool uses the
+	// test schema automatically — SET search_path is session-scoped and not
+	// safe to set after Open() when the pool may have multiple connections.
+	schemaDSN := dsn
+	if strings.Contains(dsn, "?") {
+		schemaDSN = dsn + "&search_path=" + schemaName
+	} else {
+		schemaDSN = dsn + "?search_path=" + schemaName
+	}
+
+	db, err := Open(schemaDSN)
+	if err != nil {
+		// Schema was created; register cleanup via a fresh connection.
+		cleanupDB, cErr := Open(dsn)
+		if cErr == nil {
+			_, _ = cleanupDB.Exec(fmt.Sprintf(`DROP SCHEMA IF EXISTS %s CASCADE`, pq.QuoteIdentifier(schemaName)))
+			_ = cleanupDB.Close()
+		}
+		t.Fatalf("Open (schema DSN): %v", err)
 	}
 
 	t.Cleanup(func() {
-		_, _ = db.Exec(fmt.Sprintf(`DROP SCHEMA IF EXISTS %q CASCADE`, schemaName))
+		_, _ = db.Exec(fmt.Sprintf(`DROP SCHEMA IF EXISTS %s CASCADE`, pq.QuoteIdentifier(schemaName)))
 		_ = db.Close()
 	})
 

--- a/go/internal/store/postgres/store_test.go
+++ b/go/internal/store/postgres/store_test.go
@@ -235,10 +235,12 @@ func TestPostgres_DomainCRUD(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if total < 1 {
-		t.Fatalf("want total >= 1, got %d", total)
+	if total != 1 {
+		t.Fatalf("want total=1, got %d", total)
 	}
-	_ = list
+	if len(list) != 1 || list[0].ID != id {
+		t.Fatalf("unexpected list: %+v", list)
+	}
 
 	if err := s.DomainDelete(ctx, id); err != nil {
 		t.Fatal(err)
@@ -1288,7 +1290,12 @@ func TestPostgres_DomainList_search(t *testing.T) {
 	if total != 2 {
 		t.Fatalf("search 'alpha': want 2, got %d", total)
 	}
-	_ = list
+	if len(list) != 2 {
+		t.Fatalf("search 'alpha': want 2 items, got %d", len(list))
+	}
+	if list[0].Title != "alpha" || list[1].Title != "alphabet" {
+		t.Fatalf("want [alpha alphabet], got %+v", list)
+	}
 }
 
 func TestPostgres_DeleteNotFound(t *testing.T) {

--- a/go/internal/store/postgres/store_test.go
+++ b/go/internal/store/postgres/store_test.go
@@ -310,3 +310,979 @@ func TestPostgres_UserAuthzResourcesList(t *testing.T) {
 		t.Fatalf("want mask 0x1, got %#x", list[0].EffectiveMask)
 	}
 }
+
+func TestPostgres_EffectiveMask_userPlusGroupOR(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	pUser := uuid.NewString()
+	pGroup := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUser, DomainID: domainID, Title: "pu", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pg", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUser); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+		t.Fatal(err)
+	}
+	m, err := s.EffectiveMask(ctx, domainID, uid, rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m != 0x3 {
+		t.Fatalf("want OR of user 0x1 and group 0x2 => 0x3, got %#x", m)
+	}
+}
+
+func TestPostgres_UserCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	otherDomain := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: otherDomain, Title: "other"}); err != nil {
+		t.Fatal(err)
+	}
+
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "alice"}); err != nil {
+		t.Fatal(err)
+	}
+	u, err := s.UserGet(ctx, domainID, uid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if u.ID != uid || u.DomainID != domainID || u.Title != "alice" {
+		t.Fatalf("got %+v", u)
+	}
+	if _, err := s.UserGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+	if _, err := s.UserGet(ctx, uuid.NewString(), uid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("wrong domain: want ErrNotFound, got %v", err)
+	}
+
+	// Create a second user; list should return both sorted by title.
+	uid2 := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid2, DomainID: domainID, Title: "bob"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UserCreate(ctx, &store.User{ID: uuid.NewString(), DomainID: otherDomain, Title: "other"}); err != nil {
+		t.Fatal(err)
+	}
+	list, total, err := s.UserList(ctx, domainID, store.ListOpts{Offset: 0, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "alice" || list[1].Title != "bob" {
+		t.Fatalf("want alice, bob; got %+v", list)
+	}
+
+	// Patch title.
+	newTitle := "alicia"
+	patched, err := s.UserPatch(ctx, domainID, uid, &newTitle)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched.Title != "alicia" {
+		t.Fatalf("want 'alicia', got %q", patched.Title)
+	}
+
+	// Delete and verify not found.
+	if err := s.UserDelete(ctx, domainID, uid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.UserGet(ctx, domainID, uid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+	if err := s.UserDelete(ctx, domainID, uid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second delete: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgres_GroupCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	parentID := uuid.NewString()
+	childID := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: parentID, DomainID: domainID, Title: "parent"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: childID, DomainID: domainID, Title: "child", ParentGroupID: &parentID}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get root group (no parent).
+	gp, err := s.GroupGet(ctx, domainID, parentID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gp.ParentGroupID != nil {
+		t.Fatalf("root should have nil parent, got %+v", gp.ParentGroupID)
+	}
+
+	// Get child (has parent).
+	gc, err := s.GroupGet(ctx, domainID, childID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gc.ParentGroupID == nil || *gc.ParentGroupID != parentID {
+		t.Fatalf("want parent %s, got %+v", parentID, gc.ParentGroupID)
+	}
+
+	if _, err := s.GroupGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	// List: child (C) before parent (P) by title.
+	list, total, err := s.GroupList(ctx, domainID, store.GroupListOpts{ListOpts: store.ListOpts{Offset: 0, Limit: 100}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].ID != childID || list[1].ID != parentID {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	// Patch.
+	newTitle := "updated"
+	patched, err := s.GroupPatch(ctx, domainID, childID, store.GroupPatchParams{Title: &newTitle})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched.Title != "updated" {
+		t.Fatalf("want 'updated', got %q", patched.Title)
+	}
+
+	// Delete child then parent (child must go first due to FK).
+	if err := s.GroupDelete(ctx, domainID, childID); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupDelete(ctx, domainID, parentID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.GroupGet(ctx, domainID, parentID); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestPostgres_GroupSetParent_clearAndSelf(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("clearParent", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		parentID := uuid.NewString()
+		childID := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: parentID, DomainID: domainID, Title: "par"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupCreate(ctx, &store.Group{ID: childID, DomainID: domainID, Title: "chi", ParentGroupID: &parentID}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupSetParent(ctx, domainID, childID, nil); err != nil {
+			t.Fatal(err)
+		}
+		g, err := s.GroupGet(ctx, domainID, childID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if g.ParentGroupID != nil {
+			t.Fatalf("want nil parent after clear, got %+v", g.ParentGroupID)
+		}
+	})
+
+	t.Run("selfParent", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		gid := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+			t.Fatal(err)
+		}
+		err := s.GroupSetParent(ctx, domainID, gid, &gid)
+		if !errors.Is(err, store.ErrInvalidInput) {
+			t.Fatalf("want ErrInvalidInput for self-parent, got %v", err)
+		}
+	})
+}
+
+func TestPostgres_ResourceCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	other := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: other, Title: "o"}); err != nil {
+		t.Fatal(err)
+	}
+
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "doc"}); err != nil {
+		t.Fatal(err)
+	}
+	r, err := s.ResourceGet(ctx, domainID, rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.ID != rid || r.DomainID != domainID || r.Title != "doc" {
+		t.Fatalf("got %+v", r)
+	}
+	if _, err := s.ResourceGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	rid2 := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid2, DomainID: domainID, Title: "alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: uuid.NewString(), DomainID: other, Title: "isolated"}); err != nil {
+		t.Fatal(err)
+	}
+	list, total, err := s.ResourceList(ctx, domainID, store.ListOpts{Offset: 0, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "alpha" || list[1].Title != "doc" {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "updated"
+	if _, err := s.ResourcePatch(ctx, domainID, rid, &newTitle); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceDelete(ctx, domainID, rid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.ResourceGet(ctx, domainID, rid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestPostgres_AccessTypeCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	a1 := uuid.NewString()
+	a2 := uuid.NewString()
+	if err := s.AccessTypeCreate(ctx, &store.AccessType{ID: a1, DomainID: domainID, Title: "write", Bit: 4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AccessTypeCreate(ctx, &store.AccessType{ID: a2, DomainID: domainID, Title: "read", Bit: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	at, err := s.AccessTypeGet(ctx, domainID, a1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if at.Bit != 4 || at.Title != "write" {
+		t.Fatalf("got %+v", at)
+	}
+	if _, err := s.AccessTypeGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	list, total, err := s.AccessTypeList(ctx, domainID, store.ListOpts{Offset: 0, Limit: 100})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "read" || list[1].Title != "write" {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "execute"
+	newBit := uint64(8)
+	patched, err := s.AccessTypePatch(ctx, domainID, a1, store.AccessTypePatchParams{Title: &newTitle, Bit: &newBit})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if patched.Title != "execute" || patched.Bit != 8 {
+		t.Fatalf("patch: got %+v", patched)
+	}
+
+	if err := s.AccessTypeDelete(ctx, domainID, a1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.AccessTypeGet(ctx, domainID, a1); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestPostgres_PermissionCRUD(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+
+	pid := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "perm", ResourceID: rid, AccessMask: 0x5}); err != nil {
+		t.Fatal(err)
+	}
+	p, err := s.PermissionGet(ctx, domainID, pid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.ID != pid || p.ResourceID != rid || p.AccessMask != 0x5 {
+		t.Fatalf("got %+v", p)
+	}
+	if _, err := s.PermissionGet(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound, got %v", err)
+	}
+
+	pid2 := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid2, DomainID: domainID, Title: "apple", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	list, total, err := s.PermissionList(ctx, domainID, store.PermissionListOpts{ListOpts: store.ListOpts{Offset: 0, Limit: 100}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 || len(list) != 2 {
+		t.Fatalf("want 2, got total=%d len=%d", total, len(list))
+	}
+	if list[0].Title != "apple" || list[1].Title != "perm" {
+		t.Fatalf("order by title: got %+v", list)
+	}
+
+	newTitle := "patched"
+	newMask := uint64(0x7)
+	if _, err := s.PermissionPatch(ctx, domainID, pid, store.PermissionPatchParams{Title: &newTitle, AccessMask: &newMask}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionDelete(ctx, domainID, pid); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.PermissionGet(ctx, domainID, pid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("want ErrNotFound after delete, got %v", err)
+	}
+}
+
+func TestPostgres_AddUserToGroup_FK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.AddUserToGroup(ctx, domainID, uuid.NewString(), gid)
+	if !errors.Is(err, store.ErrFKViolation) {
+		t.Fatalf("want ErrFKViolation, got %v", err)
+	}
+}
+
+func TestPostgres_GrantUserPermission_FK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.GrantUserPermission(ctx, domainID, uid, uuid.NewString())
+	if !errors.Is(err, store.ErrFKViolation) {
+		t.Fatalf("want ErrFKViolation, got %v", err)
+	}
+}
+
+func TestPostgres_GrantGroupPermission_FK(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	err := s.GrantGroupPermission(ctx, domainID, gid, uuid.NewString())
+	if !errors.Is(err, store.ErrFKViolation) {
+		t.Fatalf("want ErrFKViolation, got %v", err)
+	}
+}
+
+func TestPostgres_AddUserToGroup_duplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestPostgres_GrantUserPermission_duplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestPostgres_GrantGroupPermission_duplicate(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); !errors.Is(err, store.ErrConflict) {
+		t.Fatalf("want ErrConflict, got %v", err)
+	}
+}
+
+func TestPostgres_RemoveUserFromGroup(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveUserFromGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RemoveUserFromGroup(ctx, domainID, uid, gid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second remove: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgres_RevokeUserPermission(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeUserPermission(ctx, domainID, uid, pid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second revoke: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgres_RevokeGroupPermission(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	pid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.RevokeGroupPermission(ctx, domainID, gid, pid); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("second revoke: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgres_RestrictDelete(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("domainWithUser", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.UserCreate(ctx, &store.User{ID: uuid.NewString(), DomainID: domainID, Title: "u"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.DomainDelete(ctx, domainID); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+
+	t.Run("resourceWithPermission", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		rid := uuid.NewString()
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.PermissionCreate(ctx, &store.Permission{ID: uuid.NewString(), DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 1}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.ResourceDelete(ctx, domainID, rid); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+
+	t.Run("userInGroup", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		uid := uuid.NewString()
+		gid := uuid.NewString()
+		if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.UserDelete(ctx, domainID, uid); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+
+	t.Run("groupWithChild", func(t *testing.T) {
+		s := newTestStore(t)
+		domainID := uuid.NewString()
+		if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+			t.Fatal(err)
+		}
+		parentID := uuid.NewString()
+		childID := uuid.NewString()
+		if err := s.GroupCreate(ctx, &store.Group{ID: parentID, DomainID: domainID, Title: "p"}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupCreate(ctx, &store.Group{ID: childID, DomainID: domainID, Title: "c", ParentGroupID: &parentID}); err != nil {
+			t.Fatal(err)
+		}
+		if err := s.GroupDelete(ctx, domainID, parentID); !errors.Is(err, store.ErrFKViolation) {
+			t.Fatalf("want ErrFKViolation, got %v", err)
+		}
+	})
+}
+
+func TestPostgres_GroupAuthzResourcesList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+
+	ridA := uuid.NewString()
+	ridB := uuid.NewString()
+	for _, rid := range []string{ridA, ridB} {
+		if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r-" + rid}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	pA1 := uuid.NewString()
+	pA2 := uuid.NewString()
+	pB := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pA1, DomainID: domainID, Title: "pA1", ResourceID: ridA, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pA2, DomainID: domainID, Title: "pA2", ResourceID: ridA, AccessMask: 0x4}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pB, DomainID: domainID, Title: "pB", ResourceID: ridB, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pA1); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pA2); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pB); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.GroupAuthzResourcesList(ctx, domainID, gid, store.ListOpts{Offset: 0, Limit: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("total: want 2, got %d", total)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len: want 2, got %d", len(list))
+	}
+	gotMasks := map[string]uint64{}
+	for _, it := range list {
+		gotMasks[it.ResourceID] = it.Mask
+	}
+	if gotMasks[ridA] != 0x5 {
+		t.Fatalf("ridA mask: want 0x5, got %#x", gotMasks[ridA])
+	}
+	if gotMasks[ridB] != 0x2 {
+		t.Fatalf("ridB mask: want 0x2, got %#x", gotMasks[ridB])
+	}
+
+	// Unknown group returns ErrNotFound.
+	_, _, err = s.GroupAuthzResourcesList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown group: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgres_ResourceAuthzUsersList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	pid := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x3}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pid); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzUsersList(ctx, domainID, rid, store.ListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 {
+		t.Fatalf("want 1, got total=%d len=%d", total, len(list))
+	}
+	if list[0].UserID != uid || list[0].EffectiveMask != 0x3 {
+		t.Fatalf("got %+v", list[0])
+	}
+
+	// Unknown resource returns ErrNotFound.
+	_, _, err = s.ResourceAuthzUsersList(ctx, domainID, uuid.NewString(), store.ListOpts{})
+	if !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("unknown resource: want ErrNotFound, got %v", err)
+	}
+}
+
+func TestPostgres_ResourceAuthzGroupsList(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	gid := uuid.NewString()
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	rid := uuid.NewString()
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	pid := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pid, DomainID: domainID, Title: "p", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pid); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.ResourceAuthzGroupsList(ctx, domainID, rid, store.ListOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 1 || len(list) != 1 {
+		t.Fatalf("want 1, got total=%d len=%d", total, len(list))
+	}
+	if list[0].GroupID != gid || list[0].Mask != 0x2 {
+		t.Fatalf("got %+v", list[0])
+	}
+}
+
+func TestPostgres_PermissionMasksForUserResource(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+	uid := uuid.NewString()
+	gid := uuid.NewString()
+	rid := uuid.NewString()
+	if err := s.UserCreate(ctx, &store.User{ID: uid, DomainID: domainID, Title: "u"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GroupCreate(ctx, &store.Group{ID: gid, DomainID: domainID, Title: "g"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.ResourceCreate(ctx, &store.Resource{ID: rid, DomainID: domainID, Title: "r"}); err != nil {
+		t.Fatal(err)
+	}
+	pUser := uuid.NewString()
+	pGroup := uuid.NewString()
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pUser, DomainID: domainID, Title: "pu", ResourceID: rid, AccessMask: 0x1}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.PermissionCreate(ctx, &store.Permission{ID: pGroup, DomainID: domainID, Title: "pg", ResourceID: rid, AccessMask: 0x2}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantUserPermission(ctx, domainID, uid, pUser); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.AddUserToGroup(ctx, domainID, uid, gid); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.GrantGroupPermission(ctx, domainID, gid, pGroup); err != nil {
+		t.Fatal(err)
+	}
+
+	masks, err := s.PermissionMasksForUserResource(ctx, domainID, uid, rid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(masks) != 2 {
+		t.Fatalf("want 2 masks (user + group), got %d: %v", len(masks), masks)
+	}
+	combined := uint64(0)
+	for _, m := range masks {
+		combined |= m
+	}
+	if combined != 0x3 {
+		t.Fatalf("want combined mask 0x3, got %#x", combined)
+	}
+}
+
+func TestPostgres_DomainList_pagination(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	for i := 0; i < 5; i++ {
+		if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: fmt.Sprintf("d%02d", i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// First page.
+	page1, total, err := s.DomainList(ctx, store.ListOpts{Offset: 0, Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 5 {
+		t.Fatalf("want total=5, got %d", total)
+	}
+	if len(page1) != 3 {
+		t.Fatalf("want 3 items, got %d", len(page1))
+	}
+
+	// Second page.
+	page2, _, err := s.DomainList(ctx, store.ListOpts{Offset: 3, Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page2) != 2 {
+		t.Fatalf("want 2 items on page 2, got %d", len(page2))
+	}
+}
+
+func TestPostgres_DomainList_search(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: "alpha"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: "alphabet"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.DomainCreate(ctx, &store.Domain{ID: uuid.NewString(), Title: "beta"}); err != nil {
+		t.Fatal(err)
+	}
+
+	list, total, err := s.DomainList(ctx, store.ListOpts{Limit: 100, Search: "alpha"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if total != 2 {
+		t.Fatalf("search 'alpha': want 2, got %d", total)
+	}
+	_ = list
+}
+
+func TestPostgres_DeleteNotFound(t *testing.T) {
+	ctx := context.Background()
+	s := newTestStore(t)
+	domainID := uuid.NewString()
+	if err := s.DomainCreate(ctx, &store.Domain{ID: domainID, Title: "d"}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DomainDelete(ctx, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("domain delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.UserDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("user delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.GroupDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("group delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.ResourceDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("resource delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.AccessTypeDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("access type delete not found: want ErrNotFound, got %v", err)
+	}
+	if err := s.PermissionDelete(ctx, domainID, uuid.NewString()); !errors.Is(err, store.ErrNotFound) {
+		t.Fatalf("permission delete not found: want ErrNotFound, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Add a GitHub Actions `integration` job that spins up Postgres and MySQL via Docker Compose, runs both integration test suites, and tears down after. Also fixes a pre-existing MySQL LIKE ESCAPE SQL syntax bug and expands both store test suites from ~10 to ~35 tests each.

### Changes

**`.github/workflows/ci.yml`**
- New `integration` job (runs after `go`): starts services with `docker compose up -d`, polls for readiness using a loop (no `sleep`), runs `make test-integration-postgres` then `make test-integration-mysql`, tears down with `docker compose down --remove-orphans`.

**`go/internal/store/mysql/store.go`** (bug fix)
- `ESCAPE '\'` in raw Go string literals was malformed SQL: MySQL parses `\'` as an escaped quote, making `ESCAPE ''` which is a syntax error. Fixed to `ESCAPE '\\'` (MySQL receives `\\` = single backslash). Affects all 6 `LIKE` clauses. This was discovered by the new `TestMySQL_DomainList_search` test.

**`go/Makefile`**
- Add `-parallel=1` to `test-integration-mysql`: MySQL DDL metadata locks conflict when multiple test databases run concurrent `ALTER TABLE ... ADD CONSTRAINT` statements.

**`go/internal/store/postgres/store_test.go`** (+~25 tests)
- CRUD: User, Group, Resource, AccessType, Permission
- FK violations, duplicate constraints (ErrConflict)
- Remove/revoke operations
- Restrict-delete (domain with children returns ErrConflict)
- Authz listing: GroupAuthzResourcesList, ResourceAuthzUsersList, ResourceAuthzGroupsList
- PermissionMasksForUserResource
- Pagination and title-search filters
- ErrNotFound paths (DeleteNotFound, unknown IDs to authz listings)

**`go/internal/store/mysql/store_test.go`** (+~25 tests)
- Same suite as Postgres, adapted for MySQL test helpers

### Test results (local)

| Suite | Result |
|-------|--------|
| `make test` (unit) | ✅ all pass |
| `make test-integration-postgres` | ✅ all pass |
| `make test-integration-mysql` | ✅ all pass (-parallel=1) |
| `make lint` | ✅ clean |

## Ticket

Fixes #96

## Checklist

- [x] `make test` passes
- [x] `make lint` passes
- [x] Integration tests pass locally (both dialects)
- [x] No secrets or real `.env` values in the diff
- [x] Docs updated if behavior or setup changed (N/A — existing README already documents integration test targets)