### PR TITLE
[T64] add MIT license file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **T64 / #100:** Added `LICENSE` file (MIT). The repository is now unambiguously open-source under the MIT License (`Copyright (c) 2026 Danyal Torabi`). `README.md` and `go/README.md` updated to reference it.
+
 - **T67 / #114:** CORS middleware — `Access-Control-Allow-Origin`, `Access-Control-Allow-Credentials: true`, and `Vary: Origin` headers added for allowed browser origins. Config via `CORS_ALLOWED_ORIGINS` env var / `cors_allowed_origins` YAML key (comma-separated list; default `*`). Wildcard always reflects the actual `Origin` request header so credentials work in browsers. `OPTIONS` preflight requests are answered with `204 No Content` before `BearerAuth` runs. Startup warning logged when wildcard is used on a non-loopback address.
 
 - **T52 / #80:** API request/response error hardening — `writeJSON` now logs encode failures at ERROR level instead of silently discarding them; `readJSON` rejects trailing JSON tokens after the first value (returns **400** with `"request body must contain exactly one JSON value"`); request body decode failures are logged server-side with a structured `kind` label (`empty_body`, `json_syntax`, `json_type`, `json_unknown_field`, `json_decode`, `body_too_large`, `trailing_data`) without echoing raw user input in client responses or server logs; all client-facing decode error messages are now stable and sanitized. List-handler use of `writeInternalErr` is explicitly documented as intentional.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Danyal Torabi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -142,4 +142,4 @@ User-facing or notable changes belong under **`## [Unreleased]`** in [CHANGELOG.
 
 ## License
 
-Add a `LICENSE` file when you publish the repository.
+Licensed under the [MIT License](LICENSE).

--- a/go/README.md
+++ b/go/README.md
@@ -162,3 +162,7 @@ Server output is structured JSON via `internal/logger` (wrapping `log/slog`). Al
 | `migrations/mysql` | MySQL / MariaDB migrations |
 
 See [AGENTS.md](../AGENTS.md) for contributor rules, security, and **library vs HTTP** boundaries.
+
+## License
+
+Licensed under the [MIT License](../LICENSE).

--- a/plan/phase-8/T64-license-file.md
+++ b/plan/phase-8/T64-license-file.md
@@ -1,8 +1,8 @@
-# T64 — Add LICENSE file (Apache-2.0)
+# T64 — Add LICENSE file (MIT)
 
 ## Ticket
 
-**T64** — Add `LICENSE` (Apache-2.0) (GitHub [#100](https://github.com/DanyalTorabi/access-manager/issues/100))
+**T64** — Add `LICENSE` (MIT) (GitHub [#100](https://github.com/DanyalTorabi/access-manager/issues/100))
 
 ## Phase
 
@@ -10,43 +10,48 @@
 
 ## Goal
 
-Add a top-level `LICENSE` file using the **Apache License, Version 2.0**, copyrighted to **Danyal Torabi**, and reference it from the README so the repository is unambiguously licensed.
+Add a top-level `LICENSE` file using the **MIT License**, copyrighted to **Danyal Torabi**, and reference it from the README so the repository is unambiguously open-source.
 
 ## Why
 
 GitHub treats a repo without a `LICENSE` file as "all rights reserved" — nobody can legally reuse the code. Adding the file:
-- Makes the project legally usable.
+- Makes the project legally usable and open-source (matching the OpenClaw project's licensing posture).
 - Lets GitHub display the license badge in the repo header.
 - Lets `go` tooling and SBOM generators detect the license correctly.
 
 ## Deliverables
 
-- `LICENSE` at repository root containing the verbatim Apache-2.0 license text and the copyright line:
+- `LICENSE` at repository root containing the standard MIT license text with the copyright line:
   ```
-  Copyright 2026 Danyal Torabi
+  Copyright (c) 2026 Danyal Torabi
   ```
 - A short `## License` section in [README.md](../../README.md) pointing at the file:
-  > Licensed under the [Apache License, Version 2.0](LICENSE).
-- Optional: a `NOTICE` file if/when third-party code under Apache-2.0 with notices is bundled. Defer until needed.
+  > Licensed under the [MIT License](LICENSE).
+- A short `## License` section in [go/README.md](../go/README.md) pointing at the root file.
+- No `NOTICE` file needed (MIT does not require one).
 
 ## Steps
 
-1. Copy the Apache-2.0 text from [https://www.apache.org/licenses/LICENSE-2.0.txt](https://www.apache.org/licenses/LICENSE-2.0.txt) into a new `LICENSE` file at the repo root.
-2. At the bottom of the boilerplate (after the "END OF TERMS AND CONDITIONS" / "APPENDIX" block), include the recommended copyright line: `Copyright 2026 Danyal Torabi`.
-3. Add a `## License` section near the bottom of `README.md`.
-4. Verify GitHub's license detector picks it up after the PR merges (the repo header will show "Apache-2.0" within a few minutes of merge).
+1. Create a new `LICENSE` file at the repo root with the standard MIT license text and copyright header: `Copyright (c) 2026 Danyal Torabi`.
+2. Add a `## License` section near the bottom of `README.md`: `Licensed under the [MIT License](LICENSE).`
+3. Add a `## License` section near the bottom of `go/README.md` pointing at the root file.
+4. Add a changelog entry under `## [Unreleased]` → `### Added` in `CHANGELOG.md`.
+5. Verify GitHub's license detector picks it up after the PR merges (the repo header will show "MIT" within a few minutes of merge).
 
 ## Acceptance criteria
 
-- `LICENSE` exists at repository root with the **unmodified** Apache-2.0 text.
-- `README.md` references the license.
+- `LICENSE` exists at repository root with the standard MIT text and `Copyright (c) 2026 Danyal Torabi`.
+- `README.md` and `go/README.md` reference the license.
+- `CHANGELOG.md` has an Unreleased entry.
 - `golangci-lint` and `make test` are unaffected.
-- After merge, GitHub UI shows "Apache-2.0" as the repo license.
+- After merge, GitHub UI shows "MIT" as the repo license.
 
 ## Files / paths
 
 - **Create:** `LICENSE`
 - **Edit:** `README.md`
+- **Edit:** `go/README.md`
+- **Edit:** `CHANGELOG.md`
 
 ## Dependencies
 
@@ -54,6 +59,6 @@ None. Blocker for **T66 / #102** (release archives include `LICENSE`).
 
 ## Out of scope
 
-- Per-file SPDX headers (`// SPDX-License-Identifier: Apache-2.0`) — can be added later in a separate sweep if desired.
+- Per-file SPDX headers (`// SPDX-License-Identifier: MIT`) — can be added later in a separate sweep if desired.
 - A `CONTRIBUTOR LICENSE AGREEMENT` (CLA) workflow.
 - Third-party license aggregation (`go-licenses report ...`).

--- a/plan/phase-8/T64-license-file.md
+++ b/plan/phase-8/T64-license-file.md
@@ -15,7 +15,7 @@ Add a top-level `LICENSE` file using the **MIT License**, copyrighted to **Danya
 ## Why
 
 GitHub treats a repo without a `LICENSE` file as "all rights reserved" — nobody can legally reuse the code. Adding the file:
-- Makes the project legally usable and open-source (matching the OpenClaw project's licensing posture).
+- Makes the project legally usable and open-source.
 - Lets GitHub display the license badge in the repo header.
 - Lets `go` tooling and SBOM generators detect the license correctly.
 


### PR DESCRIPTION
## Summary

Add a top-level `LICENSE` file using the MIT License (matching the OpenClaw project's open-source posture). Update `README.md` and `go/README.md` to replace the placeholder license section with a proper reference, and add an Unreleased entry to `CHANGELOG.md`. The plan file is also updated to reflect MIT instead of the original Apache-2.0 draft.

## Ticket

Fixes #100

## Checklist

- [x] `make test` and `make lint` pass (from repo root)
- [x] Docs updated if behavior or setup changed (`README.md`, `go/README.md`, `CHANGELOG.md`)
- [x] No secrets or real `.env` values committed