### PR TITLE
[T21] Kubernetes manifests + Helm chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ dist/
 .idea/
 .vscode/
 comments-PR*.md
+
+# Kubernetes: prevent real secret files from being committed.
+# Use secret.example.yaml as a reference and create secrets with kubectl.
+deploy/k8s/*.secret.yaml
+deploy/k8s/**/*.secret.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 comments-PR*.md
 
 # Kubernetes: prevent real secret files from being committed.
-# Use secret.example.yaml as a reference and create secrets with kubectl.
+# Use secret.example (no .yaml extension) as a reference and create secrets with kubectl.
+# If you create a local copy with .yaml extension, it will be ignored:
 deploy/k8s/*.secret.yaml
 deploy/k8s/**/*.secret.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,8 @@ comments-PR*.md
 # If you create a local copy with .yaml extension, it will be ignored:
 deploy/k8s/*.secret.yaml
 deploy/k8s/**/*.secret.yaml
+# Explicit catch for the most obvious copy-paste names:
+deploy/k8s/secret.yaml
+deploy/k8s/secrets.yaml
+deploy/k8s/postgres/secret.yaml
+deploy/k8s/postgres/secrets.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **T21 / #32:** Kubernetes deployment — raw manifests (`deploy/k8s/`) and Helm chart (`charts/access-manager/`) for deploying access-manager to any Kubernetes cluster. Includes: Namespace, ConfigMap, Deployment (2 replicas, RollingUpdate, `/health` liveness + readiness probes, non-root `securityContext` matching the distroless image UID 65532, `readOnlyRootFilesystem`), ClusterIP Service, nginx Ingress, and an optional in-cluster Postgres StatefulSet + PVC for Minikube/dev. Secret names align with `docs/environments.md` (`access-manager-db` / `access-manager-auth`). `docs/kubernetes.md` added with prerequisites, secret creation, `kubectl apply`, Helm install/upgrade, rolling-update, and Minikube smoke-test instructions.
+
 ### Security
 
 - **T68 / #119:** `go 1.25.10` resolves GO-2026-4971 — Windows-only panic in `net.Dial`/`LookupPort` on NUL byte. Does not affect this Linux server binary; bumped proactively. Primary motivation is toolchain alignment (see `### Changed`).

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,12 @@ RUN go mod download
 COPY go/ ./
 # Image platform matches target (linux/amd64 or linux/arm64); no CGO for modernc.org/sqlite.
 RUN CGO_ENABLED=0 GOOS=linux go build -trimpath -ldflags="-s -w" -o /out/server ./cmd/server
-RUN mkdir -p /out/migrations && cp -r migrations/sqlite /out/migrations/sqlite
+# Bundle all migration dialects so the same image works with any supported database.
+# MIGRATIONS_DIR (default: migrations/sqlite) selects which directory to run at startup.
+RUN mkdir -p /out/migrations && \
+    cp -r migrations/sqlite /out/migrations/sqlite && \
+    cp -r migrations/postgres /out/migrations/postgres && \
+    cp -r migrations/mysql /out/migrations/mysql
 
 FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /home/nonroot

--- a/README.md
+++ b/README.md
@@ -68,6 +68,20 @@ make docker-down
 - **[docker-compose.yml](docker-compose.yml)** — `app` service  
 - **[.dockerignore](.dockerignore)**
 
+## Kubernetes
+
+Raw manifests and a Helm chart are provided under **[`deploy/k8s/`](deploy/k8s/)** and **[`charts/access-manager/`](charts/access-manager/)**. Both include liveness/readiness probes on `/health`, non-root pod security (distroless `nonroot` UID 65532), resource limits, and an optional in-cluster Postgres StatefulSet for dev/Minikube. Production deployments should use a managed database and supply the DSN via a K8s Secret.
+
+**Full guide:** [docs/kubernetes.md](docs/kubernetes.md)
+
+```bash
+# Quick dry-run
+kubectl apply --dry-run=client -f deploy/k8s/
+
+# Helm lint
+helm lint charts/access-manager/
+```
+
 ## Observability
 
 Prometheus metrics are exported at **`/metrics`** (outside bearer auth, like `/health`). Compose includes **Prometheus** and **Grafana** services bound to loopback:
@@ -143,4 +157,4 @@ User-facing or notable changes belong under **`## [Unreleased]`** in [CHANGELOG.
 
 ## License
 
-Licensed under the [MIT License](LICENSE).
+Add a `LICENSE` file when you publish the repository.

--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ User-facing or notable changes belong under **`## [Unreleased]`** in [CHANGELOG.
 
 ## License
 
-Add a `LICENSE` file when you publish the repository.
+Licensed under the [MIT License](LICENSE).

--- a/charts/access-manager/.helmignore
+++ b/charts/access-manager/.helmignore
@@ -1,0 +1,7 @@
+# Patterns to ignore when packaging the chart.
+# Same format as .gitignore
+.DS_Store
+.git
+.gitignore
+*.orig
+*.bak

--- a/charts/access-manager/Chart.yaml
+++ b/charts/access-manager/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: access-manager
+description: Helm chart for the access-manager service
+type: application
+version: 0.1.0
+appVersion: "latest"
+keywords:
+  - access-manager
+  - authorization
+  - rbac
+home: https://github.com/DanyalTorabi/access-manager
+sources:
+  - https://github.com/DanyalTorabi/access-manager
+maintainers:
+  - name: Danyal Torabi
+    url: https://github.com/DanyalTorabi

--- a/charts/access-manager/Chart.yaml
+++ b/charts/access-manager/Chart.yaml
@@ -3,7 +3,10 @@ name: access-manager
 description: Helm chart for the access-manager service
 type: application
 version: 0.1.0
-appVersion: "latest"
+# appVersion tracks the deployed image tag. Override at release time:
+#   helm upgrade access-manager charts/access-manager/ --set image.tag=sha-abc1234
+# CI can also stamp it: helm upgrade ... --set appVersion=$GIT_SHA
+appVersion: "0.0.0"
 keywords:
   - access-manager
   - authorization

--- a/charts/access-manager/templates/NOTES.txt
+++ b/charts/access-manager/templates/NOTES.txt
@@ -1,0 +1,27 @@
+access-manager has been deployed.
+
+Service: {{ include "access-manager.fullname" . }}
+Namespace: {{ .Release.Namespace }}
+
+{{- if .Values.ingress.enabled }}
+URL: http://{{ .Values.ingress.host }}/health
+{{- else }}
+Run the following to forward the service locally:
+  kubectl port-forward svc/{{ include "access-manager.fullname" . }} 8080:{{ .Values.service.port }} -n {{ .Release.Namespace }}
+Then: curl http://127.0.0.1:8080/health
+{{- end }}
+
+{{- if eq .Values.image.tag "latest" }}
+
+WARNING: image.tag is set to "latest". This is suitable for local development only.
+For staging/production, pin to a specific SHA:
+  helm upgrade {{ .Release.Name }} charts/access-manager/ --set image.tag=sha-<your-sha>
+Using :latest in production can cause uncontrolled upgrades on pod restarts.
+{{- end }}
+
+{{- if .Values.postgres.enabled }}
+
+NOTE: In-cluster Postgres is enabled. This is for dev/Minikube only.
+For production, disable it (postgres.enabled=false) and supply a
+managed Postgres URL via the access-manager-db Secret.
+{{- end }}

--- a/charts/access-manager/templates/_helpers.tpl
+++ b/charts/access-manager/templates/_helpers.tpl
@@ -7,13 +7,19 @@ Expand the name of the chart.
 
 {{/*
 Create a default fully qualified app name.
-Truncates at 63 chars to stay within Kubernetes label length limits.
+Follows the standard Helm convention: <release-name>-<chart-name>, truncated to 63 chars.
+Override with .Values.fullnameOverride or .Values.nameOverride.
 */}}
 {{- define "access-manager.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
-{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/access-manager/templates/_helpers.tpl
+++ b/charts/access-manager/templates/_helpers.tpl
@@ -1,0 +1,44 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "access-manager.name" -}}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+Truncates at 63 chars to stay within Kubernetes label length limits.
+*/}}
+{{- define "access-manager.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Common labels applied to all resources.
+*/}}
+{{- define "access-manager.labels" -}}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{ include "access-manager.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Values.image.tag | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels (stable subset used in matchLabels — do not change after initial deploy).
+*/}}
+{{- define "access-manager.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "access-manager.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Postgres selector labels.
+*/}}
+{{- define "access-manager.postgresSelectorLabels" -}}
+app.kubernetes.io/name: {{ include "access-manager.name" . }}-postgres
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/access-manager/templates/configmap.yaml
+++ b/charts/access-manager/templates/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "access-manager.fullname" . }}
-  namespace: access-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: config

--- a/charts/access-manager/templates/configmap.yaml
+++ b/charts/access-manager/templates/configmap.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: config
 data:
   DATABASE_DRIVER: {{ .Values.config.databaseDriver | quote }}
-  HTTP_ADDR: "0.0.0.0:8080"
+  HTTP_ADDR: {{ .Values.config.httpAddr | quote }}
   MIGRATIONS_DIR: {{ .Values.config.migrationsDir | quote }}
   CORS_ALLOWED_ORIGINS: {{ .Values.config.corsAllowedOrigins | quote }}
   SHUTDOWN_TIMEOUT_SECONDS: {{ .Values.config.shutdownTimeoutSeconds | quote }}

--- a/charts/access-manager/templates/configmap.yaml
+++ b/charts/access-manager/templates/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "access-manager.fullname" . }}
+  namespace: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: config
+data:
+  DATABASE_DRIVER: {{ .Values.config.databaseDriver | quote }}
+  HTTP_ADDR: "0.0.0.0:8080"
+  MIGRATIONS_DIR: {{ .Values.config.migrationsDir | quote }}
+  CORS_ALLOWED_ORIGINS: {{ .Values.config.corsAllowedOrigins | quote }}
+  SHUTDOWN_TIMEOUT_SECONDS: {{ .Values.config.shutdownTimeoutSeconds | quote }}

--- a/charts/access-manager/templates/deployment.yaml
+++ b/charts/access-manager/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "access-manager.fullname" . }}
-  namespace: access-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/charts/access-manager/templates/deployment.yaml
+++ b/charts/access-manager/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         fsGroup: 65532
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
       containers:
         - name: server
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/access-manager/templates/deployment.yaml
+++ b/charts/access-manager/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "access-manager.fullname" . }}
+  namespace: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "access-manager.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        {{- include "access-manager.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: server
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "access-manager.fullname" . }}
+          env:
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.db.name }}
+                  key: {{ .Values.secrets.db.key }}
+            - name: API_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.secrets.auth.name }}
+                  key: {{ .Values.secrets.auth.key }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      automountServiceAccountToken: false

--- a/charts/access-manager/templates/ingress.yaml
+++ b/charts/access-manager/templates/ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "access-manager.fullname" . }}
-  namespace: access-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingress

--- a/charts/access-manager/templates/ingress.yaml
+++ b/charts/access-manager/templates/ingress.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "access-manager.fullname" . }}
+  namespace: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: ingress
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "access-manager.fullname" . }}
+                port:
+                  name: http
+{{- end }}

--- a/charts/access-manager/templates/namespace.yaml
+++ b/charts/access-manager/templates/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}

--- a/charts/access-manager/templates/postgres/service.yaml
+++ b/charts/access-manager/templates/postgres/service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: postgres
-  namespace: access-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres

--- a/charts/access-manager/templates/postgres/service.yaml
+++ b/charts/access-manager/templates/postgres/service.yaml
@@ -16,4 +16,24 @@ spec:
       port: 5432
       targetPort: postgres
       protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-headless
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  # Headless service required by the StatefulSet governing service.
+  # Gives each pod a stable DNS entry: postgres-0.postgres-headless.<namespace>.svc.cluster.local
+  clusterIP: None
+  selector:
+    {{- include "access-manager.postgresSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP
 {{- end }}

--- a/charts/access-manager/templates/postgres/service.yaml
+++ b/charts/access-manager/templates/postgres/service.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "access-manager.postgresSelectorLabels" . | nindent 4 }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP
+{{- end }}

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -18,10 +18,9 @@ spec:
       labels:
         {{- include "access-manager.postgresSelectorLabels" . | nindent 8 }}
     spec:
+      # The official postgres image starts as root to initialise the data directory
+      # then drops to UID 999 internally via su-exec. Do not set runAsNonRoot here.
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 999
-        runAsGroup: 999
         fsGroup: 999
       containers:
         - name: postgres

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -36,11 +36,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $(POSTGRES_USER)
-                - -d
-                - $(POSTGRES_DB)
+                - sh
+                - -c
+                - 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 5
@@ -48,11 +46,9 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $(POSTGRES_USER)
-                - -d
-                - $(POSTGRES_DB)
+                - sh
+                - -c
+                - 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
             initialDelaySeconds: 15
             periodSeconds: 20
             failureThreshold: 3

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -8,7 +8,8 @@ metadata:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres
 spec:
-  serviceName: postgres
+  # Must reference the headless Service (clusterIP: None) for stable per-pod DNS.
+  serviceName: postgres-headless
   replicas: 1
   selector:
     matchLabels:

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -73,6 +73,11 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        {{- if .Values.postgres.storageClassName }}
+        storageClassName: {{ .Values.postgres.storageClassName | quote }}
+        {{- else if (hasKey .Values.postgres "storageClassName") }}
+        storageClassName: ""
+        {{- end }}
         resources:
           requests:
             storage: {{ .Values.postgres.storage }}

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -56,6 +56,13 @@ spec:
             timeoutSeconds: 5
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
+          # postgres writes to its data directory so readOnlyRootFilesystem cannot be set.
+          # Drop all capabilities and disallow privilege escalation at the container level.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: postgres
-  namespace: access-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres

--- a/charts/access-manager/templates/postgres/statefulset.yaml
+++ b/charts/access-manager/templates/postgres/statefulset.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.postgres.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "access-manager.postgresSelectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "access-manager.postgresSelectorLabels" . | nindent 8 }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999
+        runAsGroup: 999
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: {{ .Values.postgres.image }}
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ .Values.postgres.secretName }}
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 5
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 5
+          resources:
+            {{- toYaml .Values.postgres.resources | nindent 12 }}
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+              subPath: pgdata
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: {{ .Values.postgres.storage }}
+{{- end }}

--- a/charts/access-manager/templates/service.yaml
+++ b/charts/access-manager/templates/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "access-manager.fullname" . }}
+  namespace: access-manager
+  labels:
+    {{- include "access-manager.labels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+spec:
+  type: {{ .Values.service.type }}
+  selector:
+    {{- include "access-manager.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP

--- a/charts/access-manager/templates/service.yaml
+++ b/charts/access-manager/templates/service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "access-manager.fullname" . }}
-  namespace: access-manager
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "access-manager.labels" . | nindent 4 }}
     app.kubernetes.io/component: server

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -7,8 +7,10 @@ replicaCount: 2
 ## Container image configuration.
 image:
   repository: ghcr.io/danyaltorabi/access-manager
+  # Use a pinned sha tag for staging/production (e.g. sha-abc1234).
+  # :latest with IfNotPresent is acceptable for local/dev; never use :latest with Always in production.
   tag: "latest"
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 ## Kubernetes Service configuration.
 service:

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -87,6 +87,9 @@ postgres:
   enabled: false
   image: postgres:15-alpine
   storage: 10Gi
+  # storageClassName for the PVC. Empty string uses the cluster default storage class.
+  # For cloud providers use the appropriate class, e.g.: gke=standard-rwo, eks=gp3, aks=managed-premium.
+  storageClassName: ""
   secretName: access-manager-postgres
   resources:
     requests:

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -34,6 +34,9 @@ config:
   migrationsDir: "migrations/postgres"
   corsAllowedOrigins: "none"
   shutdownTimeoutSeconds: "60"
+  # Bind address for the HTTP server inside the pod.
+  # 0.0.0.0:8080 is required so the kubelet can reach the health probe endpoint.
+  httpAddr: "0.0.0.0:8080"
 
 ## Kubernetes Secret names and keys — must match docs/environments.md.
 ## Secrets must be created manually before installing the chart.

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -74,10 +74,10 @@ readinessProbe:
 terminationGracePeriodSeconds: 75
 
 ## In-cluster Postgres StatefulSet (for Minikube/dev only).
-## Set postgres.enabled=false for production and supply DATABASE_URL via the
-## access-manager-db Secret pointing at a managed Postgres instance.
+## Disabled by default — production should use a managed Postgres instance.
+## Enable for local dev: helm install access-manager charts/access-manager/ --set postgres.enabled=true
 postgres:
-  enabled: true
+  enabled: false
   image: postgres:15-alpine
   storage: 10Gi
   secretName: access-manager-postgres

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -1,0 +1,83 @@
+# Default values for access-manager.
+# Override with: helm install access-manager charts/access-manager/ --set image.tag=sha-abc1234
+
+## Number of replicas for the Deployment.
+replicaCount: 2
+
+## Container image configuration.
+image:
+  repository: ghcr.io/danyaltorabi/access-manager
+  tag: "latest"
+  pullPolicy: Always
+
+## Kubernetes Service configuration.
+service:
+  type: ClusterIP
+  port: 8080
+
+## Ingress configuration.
+ingress:
+  enabled: true
+  className: nginx
+  host: access-manager.local  # replace with your actual hostname
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+
+## Non-secret application configuration (mounted as env vars from ConfigMap).
+## Sensitive values (DATABASE_URL, API_BEARER_TOKEN) are read from Kubernetes Secrets;
+## see docs/kubernetes.md for secret creation instructions.
+config:
+  databaseDriver: "postgres"
+  migrationsDir: "migrations/postgres"
+  corsAllowedOrigins: "none"
+  shutdownTimeoutSeconds: "60"
+
+## Kubernetes Secret names and keys — must match docs/environments.md.
+## Secrets must be created manually before installing the chart.
+secrets:
+  db:
+    name: access-manager-db
+    key: url
+  auth:
+    name: access-manager-auth
+    key: token
+
+## Resource requests and limits for the app container.
+resources:
+  requests:
+    cpu: "50m"
+    memory: "64Mi"
+  limits:
+    cpu: "200m"
+    memory: "128Mi"
+
+## Liveness probe configuration.
+livenessProbe:
+  initialDelaySeconds: 5
+  periodSeconds: 15
+  failureThreshold: 3
+  timeoutSeconds: 3
+
+## Readiness probe configuration.
+readinessProbe:
+  initialDelaySeconds: 3
+  periodSeconds: 10
+  failureThreshold: 3
+  timeoutSeconds: 3
+
+## In-cluster Postgres StatefulSet (for Minikube/dev only).
+## Set postgres.enabled=false for production and supply DATABASE_URL via the
+## access-manager-db Secret pointing at a managed Postgres instance.
+postgres:
+  enabled: true
+  image: postgres:15-alpine
+  storage: 10Gi
+  secretName: access-manager-postgres
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -1,6 +1,10 @@
 # Default values for access-manager.
 # Override with: helm install access-manager charts/access-manager/ --set image.tag=sha-abc1234
 
+## Name overrides — standard Helm convention.
+nameOverride: ""
+fullnameOverride: ""
+
 ## Number of replicas for the Deployment.
 replicaCount: 2
 

--- a/charts/access-manager/values.yaml
+++ b/charts/access-manager/values.yaml
@@ -56,7 +56,8 @@ resources:
 
 ## Liveness probe configuration.
 livenessProbe:
-  initialDelaySeconds: 5
+  # Allow at least 30s for DB migrations to complete on first deploy before the probe fires.
+  initialDelaySeconds: 30
   periodSeconds: 15
   failureThreshold: 3
   timeoutSeconds: 3
@@ -67,6 +68,10 @@ readinessProbe:
   periodSeconds: 10
   failureThreshold: 3
   timeoutSeconds: 3
+
+## Graceful shutdown: must exceed config.shutdownTimeoutSeconds plus a safety buffer.
+## Kubernetes default is 30s which is less than SHUTDOWN_TIMEOUT_SECONDS=60.
+terminationGracePeriodSeconds: 75
 
 ## In-cluster Postgres StatefulSet (for Minikube/dev only).
 ## Set postgres.enabled=false for production and supply DATABASE_URL via the

--- a/deploy/k8s/configmap.yaml
+++ b/deploy/k8s/configmap.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: access-manager
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: config
+data:
+  DATABASE_DRIVER: "postgres"
+  HTTP_ADDR: "0.0.0.0:8080"
+  MIGRATIONS_DIR: "migrations/postgres"
+  CORS_ALLOWED_ORIGINS: "none"
+  SHUTDOWN_TIMEOUT_SECONDS: "60"

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -31,8 +31,11 @@ spec:
         fsGroup: 65532
       containers:
         - name: server
+          # Replace :latest with a pinned sha tag before deploying to staging/production.
+          # Example: ghcr.io/danyaltorabi/access-manager:sha-abc1234
+          # See docs/environments.md §Image tag strategy and docs/kubernetes.md §Rolling update.
           image: ghcr.io/danyaltorabi/access-manager:latest
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - name: http
               containerPort: 8080

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         runAsUser: 65532
         runAsGroup: 65532
         fsGroup: 65532
+      # Allow the app to finish graceful shutdown before SIGKILL.
+      # Must exceed SHUTDOWN_TIMEOUT_SECONDS (60) plus a safety buffer.
+      terminationGracePeriodSeconds: 75
       containers:
         - name: server
           # Replace :latest with a pinned sha tag before deploying to staging/production.
@@ -59,7 +62,9 @@ spec:
             httpGet:
               path: /health
               port: http
-            initialDelaySeconds: 5
+            # The server runs DB migrations before binding HTTP. Allow at least 30s
+            # for the first-deploy migration run before the liveness probe fires.
+            initialDelaySeconds: 30
             periodSeconds: 15
             failureThreshold: 3
             timeoutSeconds: 3

--- a/deploy/k8s/deployment.yaml
+++ b/deploy/k8s/deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: access-manager
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: server
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: access-manager
+      app.kubernetes.io/component: server
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: access-manager
+        app.kubernetes.io/component: server
+    spec:
+      # Match Dockerfile: distroless nonroot UID/GID 65532.
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        fsGroup: 65532
+      containers:
+        - name: server
+          image: ghcr.io/danyaltorabi/access-manager:latest
+          imagePullPolicy: Always
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: access-manager
+          env:
+            # Sensitive values come from Secrets; names match docs/environments.md.
+            - name: DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: access-manager-db
+                  key: url
+            - name: API_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: access-manager-auth
+                  key: token
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            failureThreshold: 3
+            timeoutSeconds: 3
+          readinessProbe:
+            # TODO(T21): replace with a dedicated /readyz endpoint that also pings
+            # the database once that endpoint is added to the server.
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+            failureThreshold: 3
+            timeoutSeconds: 3
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              cpu: "200m"
+              memory: "128Mi"
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      # TODO(T21): add a dedicated ServiceAccount with minimal RBAC instead of
+      # relying on the default ServiceAccount.
+      automountServiceAccountToken: false

--- a/deploy/k8s/ingress.yaml
+++ b/deploy/k8s/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: access-manager
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: ingress
+  annotations:
+    # nginx ingress controller — adjust annotations for your cluster's controller.
+    nginx.ingress.kubernetes.io/proxy-body-size: "1m"
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "60"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: access-manager.local  # replace with your actual hostname
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: access-manager
+                port:
+                  name: http

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: access-manager
+
+resources:
+  - namespace.yaml
+  - configmap.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml
+  # Uncomment the postgres/ overlay to deploy the in-cluster Postgres StatefulSet.
+  # For production, use a managed Postgres and supply access-manager-db Secret manually.
+  # - postgres/statefulset.yaml
+  # - postgres/service.yaml

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: access-manager
+# namespace is intentionally not set here — each manifest owns its namespace: field.
+# Setting it here would silently override all resource namespaces in overlays,
+# which makes it hard to reason about which namespace a resource lands in.
 
 resources:
   - namespace.yaml

--- a/deploy/k8s/kustomization.yaml
+++ b/deploy/k8s/kustomization.yaml
@@ -13,3 +13,7 @@ resources:
   # For production, use a managed Postgres and supply access-manager-db Secret manually.
   # - postgres/statefulset.yaml
   # - postgres/service.yaml
+  #
+  # NOTE: secret.example and postgres/secret.example are NOT listed here.
+  # They are reference templates only — create secrets with kubectl create secret generic.
+  # See docs/kubernetes.md for instructions.

--- a/deploy/k8s/namespace.yaml
+++ b/deploy/k8s/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/managed-by: kubectl

--- a/deploy/k8s/postgres/secret.example
+++ b/deploy/k8s/postgres/secret.example
@@ -1,4 +1,4 @@
-# postgres/secret.example.yaml — PLACEHOLDER ONLY. Do not fill in real values here.
+# postgres/secret.example — PLACEHOLDER ONLY. Do not fill in real values here.
 #
 # Create the actual secret with kubectl before deploying Postgres:
 #

--- a/deploy/k8s/postgres/secret.example.yaml
+++ b/deploy/k8s/postgres/secret.example.yaml
@@ -1,0 +1,31 @@
+# postgres/secret.example.yaml — PLACEHOLDER ONLY. Do not fill in real values here.
+#
+# Create the actual secret with kubectl before deploying Postgres:
+#
+#   kubectl create secret generic access-manager-postgres \
+#     --from-literal=POSTGRES_USER=access \
+#     --from-literal=POSTGRES_PASSWORD='<strong-random-password>' \
+#     --from-literal=POSTGRES_DB=access_manager \
+#     -n access-manager
+#
+# The DATABASE_URL in the app secret (access-manager-db) must use the same
+# user/password/db values:
+#
+#   kubectl create secret generic access-manager-db \
+#     --from-literal=url='postgres://access:<password>@postgres.access-manager.svc.cluster.local:5432/access_manager?sslmode=disable' \
+#     -n access-manager
+#
+# See docs/kubernetes.md for full setup instructions.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: access-manager-postgres
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: postgres
+type: Opaque
+stringData:
+  POSTGRES_USER: "REPLACE_ME"      # never commit a real value
+  POSTGRES_PASSWORD: "REPLACE_ME"  # never commit a real value
+  POSTGRES_DB: "REPLACE_ME"        # never commit a real value

--- a/deploy/k8s/postgres/service.yaml
+++ b/deploy/k8s/postgres/service.yaml
@@ -17,3 +17,24 @@ spec:
       port: 5432
       targetPort: postgres
       protocol: TCP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-headless
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: postgres
+spec:
+  # Headless service required by the StatefulSet governing service.
+  # Gives each pod a stable DNS entry: postgres-0.postgres-headless.access-manager.svc.cluster.local
+  clusterIP: None
+  selector:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP

--- a/deploy/k8s/postgres/service.yaml
+++ b/deploy/k8s/postgres/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: postgres
+spec:
+  # ClusterIP (not headless) so the app can resolve postgres.access-manager.svc.cluster.local:5432.
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+      protocol: TCP

--- a/deploy/k8s/postgres/statefulset.yaml
+++ b/deploy/k8s/postgres/statefulset.yaml
@@ -64,6 +64,13 @@ spec:
             limits:
               cpu: "500m"
               memory: "512Mi"
+          # postgres writes to its data directory so readOnlyRootFilesystem cannot be set.
+          # Drop all capabilities and disallow privilege escalation at the container level.
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
           volumeMounts:
             - name: postgres-data
               mountPath: /var/lib/postgresql/data

--- a/deploy/k8s/postgres/statefulset.yaml
+++ b/deploy/k8s/postgres/statefulset.yaml
@@ -38,11 +38,9 @@ spec:
           readinessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $(POSTGRES_USER)
-                - -d
-                - $(POSTGRES_DB)
+                - sh
+                - -c
+                - 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
             initialDelaySeconds: 5
             periodSeconds: 10
             failureThreshold: 5
@@ -50,11 +48,9 @@ spec:
           livenessProbe:
             exec:
               command:
-                - pg_isready
-                - -U
-                - $(POSTGRES_USER)
-                - -d
-                - $(POSTGRES_DB)
+                - sh
+                - -c
+                - 'pg_isready -U "$POSTGRES_USER" -d "$POSTGRES_DB"'
             initialDelaySeconds: 15
             periodSeconds: 20
             failureThreshold: 3

--- a/deploy/k8s/postgres/statefulset.yaml
+++ b/deploy/k8s/postgres/statefulset.yaml
@@ -7,7 +7,9 @@ metadata:
     app.kubernetes.io/name: access-manager
     app.kubernetes.io/component: postgres
 spec:
-  serviceName: postgres
+  # serviceName must reference the headless Service (clusterIP: None) that governs
+  # the StatefulSet. The ClusterIP service 'postgres' is kept for app connectivity.
+  serviceName: postgres-headless
   replicas: 1
   selector:
     matchLabels:

--- a/deploy/k8s/postgres/statefulset.yaml
+++ b/deploy/k8s/postgres/statefulset.yaml
@@ -81,6 +81,10 @@ spec:
       spec:
         accessModes:
           - ReadWriteOnce
+        # Leave storageClassName empty to use the cluster default storage class.
+        # For cloud providers set this to the appropriate class, e.g.:
+        #   gke: standard-rwo  eks: gp3  aks: managed-premium
+        storageClassName: ""
         resources:
           requests:
             storage: 10Gi

--- a/deploy/k8s/postgres/statefulset.yaml
+++ b/deploy/k8s/postgres/statefulset.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: postgres
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: postgres
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: access-manager
+      app.kubernetes.io/component: postgres
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: access-manager
+        app.kubernetes.io/component: postgres
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 999   # standard postgres image UID
+        runAsGroup: 999
+        fsGroup: 999
+      containers:
+        - name: postgres
+          image: postgres:15-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: postgres
+              containerPort: 5432
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: access-manager-postgres
+          readinessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            failureThreshold: 5
+            timeoutSeconds: 5
+          livenessProbe:
+            exec:
+              command:
+                - pg_isready
+                - -U
+                - $(POSTGRES_USER)
+                - -d
+                - $(POSTGRES_DB)
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            failureThreshold: 3
+            timeoutSeconds: 5
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "256Mi"
+            limits:
+              cpu: "500m"
+              memory: "512Mi"
+          volumeMounts:
+            - name: postgres-data
+              mountPath: /var/lib/postgresql/data
+              subPath: pgdata
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 10Gi

--- a/deploy/k8s/postgres/statefulset.yaml
+++ b/deploy/k8s/postgres/statefulset.yaml
@@ -19,10 +19,10 @@ spec:
         app.kubernetes.io/name: access-manager
         app.kubernetes.io/component: postgres
     spec:
+      # The official postgres image starts as root to initialise the data directory
+      # (chmod/chown /var/lib/postgresql/data) then drops to UID 999 (postgres)
+      # via su-exec internally. Do not set runAsNonRoot at the pod level.
       securityContext:
-        runAsNonRoot: true
-        runAsUser: 999   # standard postgres image UID
-        runAsGroup: 999
         fsGroup: 999
       containers:
         - name: postgres

--- a/deploy/k8s/secret.example
+++ b/deploy/k8s/secret.example
@@ -1,4 +1,4 @@
-# secret.example.yaml — PLACEHOLDER ONLY. Do not fill in real values here.
+# secret.example — PLACEHOLDER ONLY. Do not fill in real values here.
 #
 # Create the actual secrets with kubectl before deploying:
 #

--- a/deploy/k8s/secret.example.yaml
+++ b/deploy/k8s/secret.example.yaml
@@ -1,0 +1,38 @@
+# secret.example.yaml — PLACEHOLDER ONLY. Do not fill in real values here.
+#
+# Create the actual secrets with kubectl before deploying:
+#
+#   kubectl create secret generic access-manager-db \
+#     --from-literal=url='postgres://user:password@host:5432/access_manager?sslmode=disable' \
+#     -n access-manager
+#
+#   kubectl create secret generic access-manager-auth \
+#     --from-literal=token='<strong-random-bearer-token>' \
+#     -n access-manager
+#
+# Secret names and keys match docs/environments.md §Config key → secrets mapping.
+# See docs/kubernetes.md for full setup instructions.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: access-manager-db
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: database
+type: Opaque
+stringData:
+  url: "REPLACE_ME"  # postgres DSN — never commit a real value
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: access-manager-auth
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: auth
+type: Opaque
+stringData:
+  token: "REPLACE_ME"  # strong random bearer token — never commit a real value

--- a/deploy/k8s/service.yaml
+++ b/deploy/k8s/service.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: access-manager
+  namespace: access-manager
+  labels:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: server
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: access-manager
+    app.kubernetes.io/component: server
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -134,8 +134,9 @@ helm template access-manager charts/access-manager/ | kubectl apply --dry-run=cl
 ### Install
 
 ```bash
-# With default values (postgres.enabled=true, image.tag=latest)
+# Dev/Minikube: enable in-cluster Postgres
 helm install access-manager charts/access-manager/ \
+  --set postgres.enabled=true \
   --namespace access-manager \
   --create-namespace
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -1,0 +1,269 @@
+# Kubernetes Deployment — access-manager
+
+This guide covers deploying access-manager to a Kubernetes cluster using either **raw manifests** (`deploy/k8s/`) or the **Helm chart** (`charts/access-manager/`). Both approaches are fully equivalent; pick whichever fits your workflow.
+
+See [docs/environments.md](environments.md) for the complete environment tier matrix and config/secrets reference.
+
+---
+
+## Prerequisites
+
+| Tool | Minimum version | Notes |
+|------|----------------|-------|
+| `kubectl` | 1.27+ | [Install guide](https://kubernetes.io/docs/tasks/tools/) |
+| `helm` | 3.12+ | [Install guide](https://helm.sh/docs/intro/install/) — required for Helm path only |
+| `minikube` | 1.33+ | For local testing; optional for production clusters |
+| A running cluster | — | Minikube, kind, EKS, GKE, AKS, etc. |
+
+The image is published to **GHCR** by CI on every push to `main`:
+```
+ghcr.io/danyaltorabi/access-manager:<sha-tag>
+```
+Find the latest tag on the [GHCR package page](https://github.com/DanyalTorabi/access-manager/pkgs/container/access-manager) or in the CI `publish` job output.
+
+---
+
+## Create Secrets (required for all approaches)
+
+**Never commit real secrets.** Create them manually with `kubectl` before deploying.
+
+### App secrets
+
+Secret names and keys must match exactly — they are referenced by both the raw manifests and the Helm chart:
+
+```bash
+# Database DSN (matches docs/environments.md: Secret access-manager-db, key url)
+kubectl create secret generic access-manager-db \
+  --from-literal=url='postgres://user:password@host:5432/access_manager?sslmode=disable' \
+  -n access-manager
+
+# Bearer token for /api/v1/* (matches docs/environments.md: Secret access-manager-auth, key token)
+kubectl create secret generic access-manager-auth \
+  --from-literal=token='<strong-random-bearer-token>' \
+  -n access-manager
+```
+
+For **production**, use a managed Postgres instance (RDS, Cloud SQL, etc.) and supply its DSN in `access-manager-db`.
+
+### In-cluster Postgres secrets (dev/Minikube only)
+
+```bash
+kubectl create secret generic access-manager-postgres \
+  --from-literal=POSTGRES_USER=access \
+  --from-literal=POSTGRES_PASSWORD='<strong-random-password>' \
+  --from-literal=POSTGRES_DB=access_manager \
+  -n access-manager
+```
+
+The `DATABASE_URL` must use the same credentials and point to the in-cluster service:
+```
+postgres://access:<password>@postgres.access-manager.svc.cluster.local:5432/access_manager?sslmode=disable
+```
+
+---
+
+## Raw Manifests (`deploy/k8s/`)
+
+### Deploy
+
+```bash
+# 1. (Minikube/dev) Deploy in-cluster Postgres first
+kubectl apply -f deploy/k8s/postgres/
+
+# 2. Wait for Postgres to be ready
+kubectl rollout status statefulset/postgres -n access-manager
+
+# 3. Deploy the app
+kubectl apply -f deploy/k8s/
+
+# 4. Wait for app rollout
+kubectl rollout status deployment/access-manager -n access-manager
+
+# 5. Verify
+kubectl get pods -n access-manager
+```
+
+### Smoke test (port-forward)
+
+```bash
+kubectl port-forward svc/access-manager 8080:8080 -n access-manager &
+curl -s http://127.0.0.1:8080/health
+# Expected: {"status":"ok"}
+```
+
+### Rolling update
+
+```bash
+# Edit deploy/k8s/deployment.yaml: update image tag to the new SHA
+# e.g.: image: ghcr.io/danyaltorabi/access-manager:sha-abc1234
+
+kubectl apply -f deploy/k8s/deployment.yaml
+
+# Watch rollout (maxUnavailable:0 means no traffic loss)
+kubectl rollout status deployment/access-manager -n access-manager
+```
+
+### Kustomize
+
+A `kustomization.yaml` ties all resources together. Uncomment the postgres overlay for dev clusters:
+
+```bash
+# Dry-run
+kubectl apply --dry-run=client -k deploy/k8s/
+
+# Apply
+kubectl apply -k deploy/k8s/
+```
+
+---
+
+## Helm Chart (`charts/access-manager/`)
+
+### Lint and dry-run
+
+```bash
+helm lint charts/access-manager/
+
+# Preview rendered manifests
+helm template access-manager charts/access-manager/ --debug
+
+# Kubernetes dry-run
+helm template access-manager charts/access-manager/ | kubectl apply --dry-run=client -f -
+```
+
+### Install
+
+```bash
+# With default values (postgres.enabled=true, image.tag=latest)
+helm install access-manager charts/access-manager/ \
+  --namespace access-manager \
+  --create-namespace
+
+# Production: external Postgres, pinned image tag
+helm install access-manager charts/access-manager/ \
+  --set postgres.enabled=false \
+  --set image.tag=sha-abc1234 \
+  --set ingress.host=access-manager.example.com \
+  --namespace access-manager \
+  --create-namespace
+```
+
+### Upgrade
+
+```bash
+helm upgrade access-manager charts/access-manager/ \
+  --set image.tag=sha-newsha \
+  --namespace access-manager
+```
+
+### Uninstall
+
+```bash
+helm uninstall access-manager --namespace access-manager
+```
+
+### Key values
+
+| Value | Default | Description |
+|-------|---------|-------------|
+| `image.tag` | `latest` | Image tag — use a pinned `sha-<sha>` in staging/production |
+| `image.pullPolicy` | `Always` | Set to `Never` when using a locally loaded Minikube image |
+| `replicaCount` | `2` | Number of app replicas |
+| `ingress.enabled` | `true` | Toggle Ingress resource |
+| `ingress.host` | `access-manager.local` | Hostname — replace with your actual domain |
+| `postgres.enabled` | `true` | Deploy in-cluster Postgres StatefulSet |
+| `postgres.storage` | `10Gi` | PVC size for in-cluster Postgres |
+| `secrets.db.name` | `access-manager-db` | Name of the K8s Secret with `DATABASE_URL` |
+| `secrets.auth.name` | `access-manager-auth` | Name of the K8s Secret with `API_BEARER_TOKEN` |
+
+---
+
+## Minikube Local Testing
+
+```bash
+# Start cluster
+minikube start --driver=docker
+
+# Build and load image locally (avoids GHCR pull)
+docker build -t ghcr.io/danyaltorabi/access-manager:local .
+minikube image load ghcr.io/danyaltorabi/access-manager:local
+
+# Create namespace and secrets
+kubectl create namespace access-manager
+kubectl create secret generic access-manager-postgres \
+  --from-literal=POSTGRES_USER=access \
+  --from-literal=POSTGRES_PASSWORD=devpassword \
+  --from-literal=POSTGRES_DB=access_manager \
+  -n access-manager
+kubectl create secret generic access-manager-db \
+  --from-literal=url='postgres://access:devpassword@postgres.access-manager.svc.cluster.local:5432/access_manager?sslmode=disable' \
+  -n access-manager
+kubectl create secret generic access-manager-auth \
+  --from-literal=token='devtoken' \
+  -n access-manager
+
+# Deploy Postgres, then app
+kubectl apply -f deploy/k8s/postgres/
+kubectl rollout status statefulset/postgres -n access-manager
+kubectl apply -f deploy/k8s/
+
+# Use local image (not from GHCR)
+kubectl set image deployment/access-manager \
+  server=ghcr.io/danyaltorabi/access-manager:local \
+  -n access-manager
+kubectl rollout status deployment/access-manager -n access-manager
+
+# Verify
+kubectl port-forward svc/access-manager 8080:8080 -n access-manager &
+curl -s http://127.0.0.1:8080/health
+# Expected: {"status":"ok"}
+
+# Test rolling update: reload image, trigger rollout
+minikube image load ghcr.io/danyaltorabi/access-manager:local
+kubectl rollout restart deployment/access-manager -n access-manager
+kubectl rollout status deployment/access-manager -n access-manager
+```
+
+---
+
+## Configuration Reference
+
+All non-secret configuration is in the `ConfigMap`. Secret values are injected from K8s Secrets. See [go/README.md](../go/README.md#environment-variables) for the full config reference.
+
+| Env var | Source | Value in K8s |
+|---------|--------|--------------|
+| `DATABASE_URL` | Secret `access-manager-db` key `url` | Postgres DSN |
+| `API_BEARER_TOKEN` | Secret `access-manager-auth` key `token` | Strong random token |
+| `DATABASE_DRIVER` | ConfigMap | `postgres` |
+| `HTTP_ADDR` | ConfigMap | `0.0.0.0:8080` |
+| `MIGRATIONS_DIR` | ConfigMap | `migrations/postgres` |
+| `CORS_ALLOWED_ORIGINS` | ConfigMap | `none` (reverse proxy handles CORS) |
+| `SHUTDOWN_TIMEOUT_SECONDS` | ConfigMap | `60` |
+
+---
+
+## Rollback
+
+For application rollback instructions, see [docs/environments.md — Rollback procedure](environments.md#rollback-procedure).
+
+The short form:
+```bash
+kubectl set image deployment/access-manager \
+  server=ghcr.io/danyaltorabi/access-manager:sha-lastgoodsha \
+  -n access-manager
+kubectl rollout status deployment/access-manager -n access-manager
+```
+
+---
+
+## Out of Scope (deferred)
+
+The following are tracked in the codebase with `// TODO(T21): ...` comments and will be addressed in future tickets:
+
+- Dedicated `/readyz` endpoint with database ping for readiness (currently both probes use `/health`)
+- ServiceAccount with minimal RBAC (`automountServiceAccountToken: false` is already set)
+- NetworkPolicy to restrict ingress/egress between pods
+- HPA (Horizontal Pod Autoscaler)
+- TLS termination in-cluster — use your ingress controller's TLS configuration or a reverse proxy
+- Service mesh (Istio, Linkerd)
+- Argo CD / Terraform — defer to when org infrastructure is defined

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -168,18 +168,24 @@ helm uninstall access-manager --namespace access-manager
 | Value | Default | Description |
 |-------|---------|-------------|
 | `image.tag` | `latest` | Image tag — use a pinned `sha-<sha>` in staging/production |
-| `image.pullPolicy` | `Always` | Set to `Never` when using a locally loaded Minikube image |
+| `image.pullPolicy` | `IfNotPresent` | Set to `Never` when using a locally loaded Minikube image |
 | `replicaCount` | `2` | Number of app replicas |
 | `ingress.enabled` | `true` | Toggle Ingress resource |
 | `ingress.host` | `access-manager.local` | Hostname — replace with your actual domain |
-| `postgres.enabled` | `true` | Deploy in-cluster Postgres StatefulSet |
+| `postgres.enabled` | `false` | Deploy in-cluster Postgres StatefulSet (dev/Minikube only) |
 | `postgres.storage` | `10Gi` | PVC size for in-cluster Postgres |
+| `postgres.storageClassName` | `""` | Storage class for PVC — empty uses cluster default |
 | `secrets.db.name` | `access-manager-db` | Name of the K8s Secret with `DATABASE_URL` |
 | `secrets.auth.name` | `access-manager-auth` | Name of the K8s Secret with `API_BEARER_TOKEN` |
 
 ---
 
 ## Minikube Local Testing
+
+> **Warning: Local only.** The example credentials below (`devpassword`, etc.) are for local
+> development only. Do not use them against any shared, staging, or cloud-hosted cluster.
+> See [docs/environments.md](environments.md) for the secret rotation procedure before
+> deploying to any shared environment.
 
 ```bash
 # Start cluster

--- a/plan/phase-6/T21-kubernetes.md
+++ b/plan/phase-6/T21-kubernetes.md
@@ -1,8 +1,8 @@
-# T21 — Kubernetes
+# T21 — Kubernetes Manifests + Helm Chart
 
 ## Ticket
 
-**T21** — Kubernetes (GitHub [#32](https://github.com/DanyalTorabi/access-manager/issues/32))
+**T21** — Kubernetes Manifests + Helm Chart (GitHub [#32](https://github.com/DanyalTorabi/access-manager/issues/32))
 
 ## Phase
 
@@ -10,36 +10,54 @@
 
 ## Goal
 
-Deploy the server (and dependencies or externalize them) with **Deployments**, **Services**, **ConfigMaps/Secrets**, **liveness/readiness** probes—config values aligned with **T26**.
+Ship production-ready Kubernetes deployment for access-manager: raw manifests **and** a Helm chart, both wiring liveness/readiness probes to `/health`, enforcing non-root pod security, and aligning config/secret names with the tier matrix in `docs/environments.md`. An optional in-cluster Postgres StatefulSet is included for Minikube/dev clusters; production users substitute a managed database.
 
 ## Deliverables
 
-- `deploy/k8s/` manifests or a **Helm chart** with values for image, env, resources.
-- Health checks wired to `/health` and optionally DB ping for readiness.
+- `deploy/k8s/` — raw manifests (Namespace, ConfigMap, Deployment, Service, Ingress) + `postgres/` overlay (StatefulSet, Service)
+- `deploy/k8s/kustomization.yaml` — Kustomize resource list tying everything together
+- `charts/access-manager/` — Helm chart mirroring the raw manifests; Postgres is conditional on `.Values.postgres.enabled`
+- `docs/kubernetes.md` — prerequisites, secret creation, `kubectl apply`, Helm install, rolling-update and rollback procedures
 
 ## Steps
 
-1. Start from image produced in **T13**.
-2. Externalize DB: use managed SQL or in-cluster Postgres with persistence (team choice).
-3. Add resource requests/limits; run as non-root (match Dockerfile).
-4. Document `kubectl apply` or Helm install in README/docs.
-5. Optional: Argo CD / Terraform when org defines (TBC in GitHub / product planning).
+1. **Branch** from latest `main`: `danyal/feature/t21-kubernetes`.
+2. **Raw manifests — app:** Namespace, ConfigMap (non-secret env), `secret.example.yaml` (placeholder, not committed with real values), Deployment (2 replicas, RollingUpdate maxSurge:1/maxUnavailable:0, `/health` liveness + readiness, `securityContext` matching Dockerfile's distroless `nonroot` UID 65532, resource requests/limits mirroring `compose.prod.yml`), ClusterIP Service, nginx Ingress.
+3. **Raw manifests — Postgres:** `postgres/` sub-directory with StatefulSet (postgres:15-alpine, PVC 10Gi, `pg_isready` readiness), headless ClusterIP Service.
+4. **Kustomize base + `.gitignore`** patch to prevent accidental real-secret commits.
+5. **Helm chart:** `Chart.yaml`, `values.yaml` (image.tag, replicaCount, resources, ingress.host, postgres.enabled), `templates/_helpers.tpl`, templates for all resources.
+6. **Docs:** `docs/kubernetes.md` + root `README.md` K8s section + `CHANGELOG.md` Unreleased entry.
+7. **Minikube smoke test:** build local image → load into Minikube → create secrets → apply manifests → rollout status → `curl /health` 200 OK → rolling-update test → `helm lint` + `helm template | kubectl apply --dry-run=client`.
 
 ## Files / paths
 
-- **Create:** `deploy/k8s/*.yaml` or `charts/access-manager/`
+- **Create:** `deploy/k8s/*.yaml`, `deploy/k8s/postgres/*.yaml`, `deploy/k8s/kustomization.yaml`
+- **Create:** `charts/access-manager/Chart.yaml`, `charts/access-manager/values.yaml`, `charts/access-manager/templates/`
+- **Create:** `docs/kubernetes.md`
+- **Update:** `README.md` (root), `CHANGELOG.md`
 
 ## Acceptance criteria
 
-- Rolling update completes with zero unbounded downtime given readiness probe.
+- `kubectl apply --dry-run=client -f deploy/k8s/` succeeds with no warnings.
+- `helm lint charts/access-manager/` passes.
+- `helm template access-manager charts/access-manager/ | kubectl apply --dry-run=client -f -` succeeds.
+- Minikube deploy: `GET /health` → `{"status":"ok"}` 200 after rollout.
+- Rolling update with `maxUnavailable:0` completes without dropping traffic (readiness probe gates pod inclusion).
+- Secret names match `docs/environments.md` exactly: `access-manager-db` (key `url`) and `access-manager-auth` (key `token`).
+- No real secrets committed; `secret.example.yaml` contains only placeholder values.
+- `make test` and `make lint` pass (no Go code changed).
 
 ## Out of scope
 
-- Service mesh unless required later.
+- Service mesh (Istio/Linkerd).
+- Argo CD / Terraform — defer to a future ticket when org infrastructure is defined.
+- HPA, NetworkPolicy, ServiceAccount/RBAC — deferred; `// TODO(T21): ...` comments left at relevant locations.
+- TLS termination in-cluster — handled by ingress controller or reverse proxy (per `docs/environments.md`).
+- Dedicated `/readyz` endpoint with DB ping — deferred; `// TODO(T21): ...` comment in handler.
 
 ## Dependencies
 
-- **T19** image; **T22** env strategy; **T26** config keys.
+- **T19** Docker image + GHCR publish; **T22** env/secrets tier matrix (`docs/environments.md`); **T26** config keys.
 
 ## Curriculum link
 


### PR DESCRIPTION
## Summary

Ship production-ready Kubernetes deployment for access-manager: raw manifests (`deploy/k8s/`) and a Helm chart (`charts/access-manager/`), both fully smoke-tested on Minikube.

### What's in this PR

**Raw manifests (`deploy/k8s/`):**
- `namespace.yaml` — Namespace `access-manager`
- `configmap.yaml` — Non-secret env vars (`DATABASE_DRIVER`, `HTTP_ADDR`, `MIGRATIONS_DIR`, `CORS_ALLOWED_ORIGINS=none`, `SHUTDOWN_TIMEOUT_SECONDS=60`)
- `secret.example` — Placeholder reference (no `.yaml` extension so `kubectl apply -f dir/` ignores it)
- `deployment.yaml` — 2 replicas, RollingUpdate (maxSurge:1/maxUnavailable:0), `/health` liveness + readiness, `securityContext` (runAsUser 65532 = distroless nonroot, readOnlyRootFilesystem), resource requests/limits mirroring `compose.prod.yml`
- `service.yaml` — ClusterIP port 8080
- `ingress.yaml` — nginx class, host `access-manager.local` (placeholder)
- `kustomization.yaml` — Kustomize resource list

**In-cluster Postgres overlay (`deploy/k8s/postgres/`):**
- `statefulset.yaml` — postgres:15-alpine, PVC 10Gi, `pg_isready` readiness + liveness probes
- `service.yaml` — ClusterIP named `postgres`
- `secret.example` — Placeholder reference (no `.yaml` extension)

**Helm chart (`charts/access-manager/`):**
- Full mirror of raw manifests; Postgres conditional on `.Values.postgres.enabled`
- Parameterised: image tag, replicaCount, resources, ingress host, secrets references, probe timeouts

**Dockerfile:**
- Bundle all migration dialects (sqlite, postgres, mysql) so the same image works with any `DATABASE_DRIVER`. Previously only `migrations/sqlite` was copied.

**Documentation:**
- `docs/kubernetes.md` — prerequisites, secret creation, `kubectl apply`, Kustomize, Helm install/upgrade, Minikube smoke-test walk-through, rollback pointer
- Root `README.md` — Kubernetes section
- `CHANGELOG.md` — Unreleased entry

### Local testing (Minikube)

- `minikube start --driver=docker` → cluster up
- `docker build` + `minikube image load` → image loaded
- `kubectl apply -f deploy/k8s/postgres/` → postgres-0 1/1 Running
- `kubectl apply -f deploy/k8s/` + image set → 2/2 pods 1/1 Running
- `curl /health` → `{"status":"ok"}` 200
- Rolling update with `maxUnavailable:0`: readiness probe correctly blocked broken image from replacing healthy pods (zero downtime confirmed)
- `helm lint charts/access-manager/` → 0 charts failed
- `helm template | kubectl apply --dry-run=client` → all resources valid
- `go test -race ./...` → all pass

### Key design decisions

- Secret names match `docs/environments.md` exactly: `access-manager-db` (key `url`) + `access-manager-auth` (key `token`) — no drift
- `runAsUser: 65532` — matches distroless `nonroot` UID in Dockerfile
- `readOnlyRootFilesystem: true` — distroless needs no container-root writes
- Postgres StatefulSet for Minikube/dev; docs note to use managed DB for production
- `TODO(T21)` comments at: /readyz+DB ping, ServiceAccount/RBAC, NetworkPolicy

## Ticket

Closes #32

## Checklist

- [x] Raw K8s manifests (`deploy/k8s/`)
- [x] In-cluster Postgres overlay (`deploy/k8s/postgres/`)
- [x] Kustomize base
- [x] Helm chart (`charts/access-manager/`)
- [x] Dockerfile bundles all migration dialects
- [x] docs/kubernetes.md
- [x] README.md + CHANGELOG.md updated
- [x] Minikube smoke test: /health 200 OK
- [x] Rolling update verified (maxUnavailable:0)
- [x] helm lint: 0 failures
- [x] helm template dry-run: valid
- [x] go test -race ./...: all pass
- [x] No real secrets committed (secret.example files are placeholders without .yaml extension)