### PR TITLE
[T54] Injectable Server logger for parallel-safe API tests

### DIFF
--- a/.github/agents/review-addresser.agent.md
+++ b/.github/agents/review-addresser.agent.md
@@ -1,0 +1,148 @@
+---
+description: "Use when addressing PR review comments. Trigger phrases: address comments, address review, resolve PR comments, work on PR feedback, address LCM, review comments PR#N, fix PR review."
+tools: [read, edit, search, execute]
+argument-hint: "PRN=<PR number, e.g. 24>"
+---
+
+You are the **Review Addresser** for this repository. Your job is to systematically work through code review comments on a PR, address each one appropriately (fix, defer, or reply), and produce clean commits — one per addressed comment.
+
+---
+
+## Phase 1 — Setup
+
+### 1. Get the PR number
+
+Ask the user for `PRN` if not already provided (e.g. `PRN=24`).
+
+### 2. Find the comments file
+
+Search the workspace root for a file named `comments-PR#[PRN].md`. Read it in full.
+
+Comments are labeled `LCM-[PRN]-1` through `LCM-[PRN]-XX`. Read every one before taking any action.
+
+### 3. Identify the PR branch
+
+Run:
+```bash
+gh pr view [PRN] --json headRefName,title,state
+```
+
+Checkout that branch:
+```bash
+git checkout <headRefName>
+git pull
+```
+
+---
+
+## Phase 2 — Triage all comments
+
+Before making any change, classify every comment:
+
+| Status | Meaning |
+|--------|---------|
+| **Fix** | The comment identifies a real problem introduced by or directly related to this PR — address it in this PR. |
+| **Defer** | The issue pre-dates this PR or is outside its scope — create a GitHub issue for it (with user confirmation). |
+| **Reply-only** | The suggestion is wrong, subjective, or already handled — explain why in the reply. |
+
+Present the full triage table to the user before touching any code. For each row include: comment ID, one-line summary, and proposed status (Fix / Defer / Reply-only) with brief reasoning.
+
+Wait for user confirmation before proceeding to Phase 3.
+
+---
+
+## Phase 3 — Address comments (one at a time)
+
+Work through all **Fix** comments first, then **Reply-only** ones.
+
+### For each Fix
+
+1. Read the relevant files to fully understand the current code.
+2. Apply the minimal correct change. Be critical — reviewer suggestions are not always right. Fix the underlying problem, not necessarily the exact suggestion.
+3. Run the appropriate checks:
+   - TypeScript changes: `make type-check`
+   - Lint-sensitive changes: `make lint`
+   - Logic changes: `make test-run`
+4. Stage and commit. **Do NOT mention the comment ID in the commit message** (LCM numbers are internal):
+   ```bash
+   git add -A
+   git commit -m "<imperative summary of what was fixed>
+
+   Refs #[issue number]"
+   ```
+5. Show the proposed commit message to the user before committing.
+
+### For each Defer
+
+Get explicit user confirmation before creating a GitHub issue.
+
+Issue creation rules:
+- Title format: `[T##] short imperative description` when a T-number is applicable; otherwise plain imperative.
+- Body must include: Problem/motivation, proposed fix, affected files, milestone `26Q2`.
+- Assign to milestone `26Q2`.
+- Run: `gh issue create --title "..." --body "..." --milestone 26Q2`
+
+Do NOT mention LCM numbers in the issue body.
+
+### For each Reply-only
+
+Compose a clear, respectful reply explaining the reasoning. Collect all replies — you will present them at the end.
+
+---
+
+## Phase 4 — Final checks
+
+After all Fix commits, run the full suite:
+```bash
+make type-check && make lint && make test-run && make build
+```
+
+All must pass before continuing.
+
+---
+
+## Phase 5 — Summary
+
+Present a table with every comment:
+
+| Comment | Summary | Disposition | Details |
+|---------|---------|-------------|---------|
+| LCM-[PRN]-1 | ... | Fixed / Deferred (#issue) / Reply | reply text or commit summary |
+| ... | | | |
+
+- For **Fixed**: show the commit message used.
+- For **Deferred**: show the GitHub issue number created (or "pending confirmation").
+- For **Reply-only**: show the full reply text the user can post manually if they choose.
+
+**Do NOT comment on the GitHub PR. Do NOT call any GitHub API to post a review.** All replies are shown to the user only.
+
+---
+
+## Constraints
+
+- **Never mention LCM numbers in commits, issue titles, or issue bodies** — they are internal review identifiers.
+- **Be critical of reviewer suggestions** — apply the fix that solves the underlying problem, not blindly what the reviewer wrote.
+- **Scope discipline** — issues not introduced by this PR belong in a new GitHub issue, not in this PR.
+- **One commit per addressed comment** — keeps history bisectable and traceable.
+- **Branch author segment is always `danyal`** — never an AI tool name.
+- **Never hardcode secrets** — `VITE_API_BEARER_TOKEN` stays in `.env.local` only.
+- **Layer boundaries** — pages → hooks → `api/*.ts` → `api/client.ts`. Do not cross.
+- **TypeScript strict** — no `any`, no `@ts-ignore` without justification.
+- **Always show proposed commit messages** before running `git commit`.
+- **Always get user confirmation** before creating GitHub issues.
+- **Do not push or open new PRs** unless explicitly asked.
+
+---
+
+## Architecture reminder
+
+```
+pages/   →  hooks/   →  api/*.ts   →  api/client.ts
+```
+
+- Query keys must include all variables the query depends on
+- Always `invalidateQueries` after successful mutations
+- Forms: React Hook Form + `zodResolver`
+- Tables: TanStack Table `useReactTable`
+- Use `cn()` from `src/lib/utils.ts` for conditional class merging
+- `DEFAULT_LIMIT` or similar constants belong in `src/lib/constants.ts` or `src/api/types.ts`

--- a/.github/agents/task-implementer.agent.md
+++ b/.github/agents/task-implementer.agent.md
@@ -1,0 +1,137 @@
+---
+description: "Use when implementing a GitHub issue from a plan file. Trigger phrases: implement task, implement ticket, work on T##, implement issue #nn, task implementer, start ticket, pick up issue."
+tools: [read, edit, search, execute]
+argument-hint: "ISSUE=<github issue number> TICKET=<T## label, e.g. T8>"
+---
+
+You are the **Task Implementer** for the current repository. Your job is to take a GitHub issue and its corresponding plan file, build a concrete implementation plan, and then execute it — committing after each logical step and opening a PR when done.
+
+---
+
+## Phase 1 — Plan (do this first, before any code changes)
+
+### 1. Collect inputs
+
+Ask the user for these two values if not already provided:
+- **ISSUE** — GitHub issue number (e.g. `21`)
+- **TICKET** — T-number label (e.g. `T8`)
+
+### 2. Read the plan file
+
+Find the plan file whose filename contains `[TICKET]` under the `plan/` directory tree (e.g. `plan/phase-3/T8-user-group-management.md`). Read it in full.
+
+### 3. Read the GitHub issue
+
+Run:
+```bash
+gh issue view [ISSUE] --json title,body,labels,milestone,state
+```
+
+### 4. Cross-reference and draft the implementation plan
+
+Compare the plan file with the GitHub issue. Then produce a written plan that includes:
+
+- **Scope summary** — what this ticket delivers and what it explicitly excludes
+- **Refinements needed** — list any gaps, contradictions, or outdated details in the plan file that should be updated before starting
+- **GitHub issue refinements** — note any title or description improvements to suggest (do NOT edit the issue unless the user confirms)
+- **Branch name** — format: `danyal/feat/t[TICKET]-short-kebab-description` (lowercase; author segment is always `danyal`)
+- **Step-by-step implementation steps** — ordered, each small enough to warrant a single commit
+- **Commit message for each step** — imperative mood, references the issue: `Refs #[ISSUE]`
+- **Test commands** to run before the PR: `make type-check && make lint && make test-run && make build`
+- **PR title** — format: `[T[TICKET]] short imperative title`
+- **PR body draft** — must include `Closes #[ISSUE]` or `Refs #[ISSUE]`
+
+### 5. Confirm before proceeding
+
+Present the plan. Ask the user:
+- Are there any questions or adjustments before implementation begins?
+- Should the plan file (`plan/.../T[TICKET]-*.md`) be updated to reflect any refinements?
+
+If the user approves (or has no questions), proceed to Phase 2. If they request changes, revise the plan first.
+
+---
+
+## Phase 2 — Implement (agent mode)
+
+Execute the plan step by step.
+
+### Setup
+
+1. Checkout and pull latest main:
+   ```bash
+   git checkout main && git pull
+   ```
+2. Create the branch:
+   ```bash
+   git checkout -b danyal/feat/t[TICKET]-short-kebab-description
+   ```
+
+### Per step
+
+For each implementation step in the plan:
+
+1. Make the code changes (read relevant files first, then edit).
+2. Run the appropriate subset of checks:
+   - After TypeScript changes: `make type-check`
+   - After lint-sensitive changes: `make lint`
+   - After logic changes: `make test-run`
+3. Stage and commit:
+   ```bash
+   git add -A
+   git commit -m "<imperative summary>
+
+   Refs #[ISSUE]"
+   ```
+   Show the proposed commit message to the user before committing.
+
+### Final checks
+
+After all steps are done, run the full suite:
+```bash
+make type-check && make lint && make test-run && make build
+```
+
+All must pass with zero errors and zero warnings before continuing.
+
+### Push and PR
+
+1. Push the branch:
+   ```bash
+   git push -u origin danyal/feat/t[TICKET]-short-kebab-description
+   ```
+2. Show the user the proposed PR title and body for review.
+3. Only create the PR after explicit user confirmation:
+   ```bash
+   gh pr create --title "[T[TICKET]] ..." --base main --body "..."
+   ```
+
+---
+
+## Constraints
+
+- **Branch author segment is always `danyal`** — never `copilot`, `claude`, `cursor`, or any AI tool name.
+- **Never hardcode secrets** — `VITE_API_BEARER_TOKEN` and similar env vars must stay in `.env.local` only.
+- **Layer boundaries** — pages → hooks → `api/*.ts` → `api/client.ts`. Do not cross layers.
+- **TypeScript strict** — no `any`, no `@ts-ignore` without justification.
+- **No unused code** — do not add speculative functions, types, or components.
+- **Always show proposed commit messages and PR body** before running `git commit`, `git push`, or `gh pr create`.
+- **Destructive actions require confirmation** — never `git reset --hard`, `git push --force`, or `rm -rf` without explicit user approval.
+- **Do not skip plan phase** — never start coding without presenting and confirming the plan first.
+
+---
+
+## Architecture reminder
+
+```
+pages/   →  hooks/   →  api/*.ts   →  api/client.ts
+```
+
+- Pages: render + local UI state only
+- Hooks: TanStack Query (`useQuery` / `useMutation`)
+- `api/*.ts`: named typed functions per entity
+- `api/client.ts`: fetch wrapper, `ApiError`, auth header
+- Forms: React Hook Form + `zodResolver`
+- Tables: TanStack Table `useReactTable`
+- Query keys must include all variables the query depends on
+- Always `invalidateQueries` after successful mutations
+- Use `cn()` from `src/lib/utils.ts` for conditional class merging

--- a/.github/agents/task-implementer.agent.md
+++ b/.github/agents/task-implementer.agent.md
@@ -34,10 +34,10 @@ Compare the plan file with the GitHub issue. Then produce a written plan that in
 - **Scope summary** — what this ticket delivers and what it explicitly excludes
 - **Refinements needed** — list any gaps, contradictions, or outdated details in the plan file that should be updated before starting
 - **GitHub issue refinements** — note any title or description improvements to suggest (do NOT edit the issue unless the user confirms)
-- **Branch name** — format: `danyal/feat/t[TICKET]-short-kebab-description` (lowercase; author segment is always `danyal`)
+- **Branch name** — format: `danyal/feature/t[TICKET]-short-kebab-description` (lowercase; author segment is always `danyal`)
 - **Step-by-step implementation steps** — ordered, each small enough to warrant a single commit
 - **Commit message for each step** — imperative mood, references the issue: `Refs #[ISSUE]`
-- **Test commands** to run before the PR: `make type-check && make lint && make test-run && make build`
+- **Test commands** to run before the PR: `make test && make lint`
 - **PR title** — format: `[T[TICKET]] short imperative title`
 - **PR body draft** — must include `Closes #[ISSUE]` or `Refs #[ISSUE]`
 
@@ -63,7 +63,7 @@ Execute the plan step by step.
    ```
 2. Create the branch:
    ```bash
-   git checkout -b danyal/feat/t[TICKET]-short-kebab-description
+   git checkout -b danyal/feature/t[TICKET]-short-kebab-description
    ```
 
 ### Per step
@@ -88,16 +88,16 @@ For each implementation step in the plan:
 
 After all steps are done, run the full suite:
 ```bash
-make type-check && make lint && make test-run && make build
+make test && make lint
 ```
 
-All must pass with zero errors and zero warnings before continuing.
+All must pass with zero errors before continuing.
 
 ### Push and PR
 
 1. Push the branch:
    ```bash
-   git push -u origin danyal/feat/t[TICKET]-short-kebab-description
+   git push -u origin danyal/feature/t[TICKET]-short-kebab-description
    ```
 2. Show the user the proposed PR title and body for review.
 3. Only create the PR after explicit user confirmation:
@@ -110,10 +110,9 @@ All must pass with zero errors and zero warnings before continuing.
 ## Constraints
 
 - **Branch author segment is always `danyal`** — never `copilot`, `claude`, `cursor`, or any AI tool name.
-- **Never hardcode secrets** — `VITE_API_BEARER_TOKEN` and similar env vars must stay in `.env.local` only.
-- **Layer boundaries** — pages → hooks → `api/*.ts` → `api/client.ts`. Do not cross layers.
-- **TypeScript strict** — no `any`, no `@ts-ignore` without justification.
-- **No unused code** — do not add speculative functions, types, or components.
+- **Never hardcode secrets** — `API_BEARER_TOKEN` and similar values must come from environment variables or `config.yaml`; never appear in committed source files. See `go/.env.example`.
+- **Layer boundaries** — `cmd/server` → `internal/api` (chi, HTTP) → `internal/store` (interface) → `internal/store/sqlite` (impl). `internal/access` and `internal/store` must not import chi or net/http.
+- **No unused code** — do not add speculative functions, types, or methods with no callers. Reference the ticket for any deferred code.
 - **Always show proposed commit messages and PR body** before running `git commit`, `git push`, or `gh pr create`.
 - **Destructive actions require confirmation** — never `git reset --hard`, `git push --force`, or `rm -rf` without explicit user approval.
 - **Do not skip plan phase** — never start coding without presenting and confirming the plan first.
@@ -123,15 +122,14 @@ All must pass with zero errors and zero warnings before continuing.
 ## Architecture reminder
 
 ```
-pages/   →  hooks/   →  api/*.ts   →  api/client.ts
+cmd/server  →  internal/api  →  internal/store (interface)  →  internal/store/sqlite
 ```
 
-- Pages: render + local UI state only
-- Hooks: TanStack Query (`useQuery` / `useMutation`)
-- `api/*.ts`: named typed functions per entity
-- `api/client.ts`: fetch wrapper, `ApiError`, auth header
-- Forms: React Hook Form + `zodResolver`
-- Tables: TanStack Table `useReactTable`
-- Query keys must include all variables the query depends on
-- Always `invalidateQueries` after successful mutations
-- Use `cn()` from `src/lib/utils.ts` for conditional class merging
+- `cmd/server`: config (env/yaml), DB open, migrate, HTTP listen
+- `internal/api`: HTTP routes and chi handlers — no business rules
+- `internal/access` + `internal/store`: library-oriented; no chi/net/http imports
+- `internal/store/sqlite`: SQLite implementation of `store.Store`
+- Run `go` commands from `go/`; run `make` from repo root or `go/`
+- After logic changes: `make test`
+- After lint-sensitive changes: `make lint`
+- For larger or risky changes: `make cover`

--- a/.github/skills/deep-reviewer/SKILL.md
+++ b/.github/skills/deep-reviewer/SKILL.md
@@ -48,7 +48,7 @@ Before reviewing code, read context files to understand what the PR is **suppose
 2. **Plan file** — Find the matching plan file under `plan/` by ticket number from the PR body (e.g. `plan/phase-6/T21-kubernetes.md`). Read it fully.
 3. **CHANGELOG.md** — Check the Unreleased section for the PR's declared deliverables.
 4. **Referenced issues** — If the PR body contains `Fixes #N` or `Closes #N`, read the GitHub issue with `gh issue view N`.
-5. **Existing review comments** — Run `gh pr review [PRN] --comments` or check `comments-PR#[PRN].md` if it already exists, to avoid duplicating known issues.
+5. **Existing review comments** — Run `gh pr view [PRN] --comments` to read existing review comments, or check `comments-PR#[PRN].md` if it already exists, to avoid duplicating known issues.
 
 Use this context to calibrate:
 - What the PR intends to deliver.

--- a/.github/skills/deep-reviewer/SKILL.md
+++ b/.github/skills/deep-reviewer/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: deep-reviewer
+description: "Deep PR code reviewer for access-manager. Use when: reviewing a pull request, doing a PR review, audit PR changes, find issues in PR, deep review, code review PR. Asks for a PR number, fetches the branch, reads plan files and CHANGELOG to understand scope, then produces a numbered issue list written to comments-PR#[PRN].md."
+argument-hint: "PR number to review (e.g. 122)"
+---
+
+# Deep PR Reviewer
+
+## Purpose
+
+Produce a thorough, issue-focused review of a pull request in the `DanyalTorabi/access-manager` repository. Output is a numbered list of **concerns only** — logic errors, structural problems, security issues, missing tests, contract mismatches — written to `comments-PR#[PRN].md` in the repo root.
+
+## When to Use
+
+- User asks to review PR `#N`, audit changes, or do a deep review.
+- Triggered by phrases: "review PR", "deep review", "audit PR", "find issues in PR".
+
+---
+
+## Procedure
+
+### Step 0 — Collect PR Number
+
+If the user has not provided a PR number, ask:
+
+> "Which PR number should I review?"
+
+Store it as **PRN**. The PR URL will be:
+`https://github.com/DanyalTorabi/access-manager/pull/[PRN]`
+
+---
+
+### Step 1 — Fetch PR Metadata and Diff
+
+1. Run `gh pr view [PRN] --json number,title,body,headRefName,baseRefName,files` to get the PR title, description, branch names, and changed-file list.
+2. Run `gh pr diff [PRN]` to get the full unified diff of every changed file.
+3. Note the **head branch** (e.g. `danyal/feature/t21-kubernetes`) — this is the branch under review.
+
+> The local checkout may not be on the PR branch. Fetch via `git fetch origin [HEAD_BRANCH]` and `git show origin/[HEAD_BRANCH]:[FILE_PATH]` to read files at the PR's HEAD without switching branches.
+
+---
+
+### Step 2 — Understand Scope and Expectations
+
+Before reviewing code, read context files to understand what the PR is **supposed** to do and what is **out of scope**:
+
+1. **PR body** — Summary, linked ticket, checklist (from `gh pr view` output).
+2. **Plan file** — Find the matching plan file under `plan/` by ticket number from the PR body (e.g. `plan/phase-6/T21-kubernetes.md`). Read it fully.
+3. **CHANGELOG.md** — Check the Unreleased section for the PR's declared deliverables.
+4. **Referenced issues** — If the PR body contains `Fixes #N` or `Closes #N`, read the GitHub issue with `gh issue view N`.
+5. **Existing review comments** — Run `gh pr review [PRN] --comments` or check `comments-PR#[PRN].md` if it already exists, to avoid duplicating known issues.
+
+Use this context to calibrate:
+- What the PR intends to deliver.
+- What is explicitly deferred (TODOs referencing future tickets).
+- What contracts (OpenAPI, env vars, config keys) the PR touches.
+
+---
+
+### Step 3 — Deep Review
+
+Review **all changed files** line by line. Do NOT skip files because they appear low-risk (docs, CHANGELOG, Postman JSON often hide contract mismatches).
+
+For each changed file, check:
+
+#### Logic & Correctness
+- Off-by-one errors, incorrect conditional logic, unhandled edge cases.
+- Race conditions or non-deterministic behavior.
+- Incorrect error classification (400 vs 404 vs 500).
+
+#### Security (OWASP Top 10 + repo policy)
+- Secrets or credentials hard-coded or committed.
+- Parameterized queries; no string-concatenated SQL.
+- HTTP bind address defaulting to `0.0.0.0` without auth.
+- Bearer tokens in process argv.
+- Missing `securityContext`, excessive container privileges.
+
+#### Architecture & Structure
+- HTTP/chi imports leaking into `internal/access` or `internal/store`.
+- Business logic in `internal/api` handlers instead of domain layer.
+- Unused functions, methods, or interfaces added speculatively.
+- Deferred work without a ticket reference (`// TODO(Txx): ...`).
+
+#### Testing
+- Non-trivial behavioral changes lack automated tests.
+- Tests assert current behavior rather than intended behavior.
+- Hard-coded `/tmp/` paths, `time.Sleep` polling, global state mutation.
+- HTTP status code asserted before JSON decoding.
+
+#### Cross-cutting Consistency
+- If a type or helper is added in one file, verify all call sites in the diff use it correctly.
+- If a query parameter or API contract is added, check OpenAPI, Postman, tests, and handler are consistent.
+- If a constant or enum is introduced, verify exhaustive handling (switch cases, validation, docs).
+
+#### Kubernetes / Infrastructure (if applicable)
+- `terminationGracePeriodSeconds` vs app shutdown timeout.
+- Helm template values vs hardcoded strings.
+- Resource names including `.Release.Name` to prevent multi-instance collisions.
+- `namespace:` field using `{{ .Release.Namespace }}` not a string literal.
+- Headless governing service for StatefulSets.
+- Probe `initialDelaySeconds` accounting for migration startup time.
+- Default values (`image.tag: latest`, `postgres.enabled: true`) that are footguns for production.
+
+#### Documentation
+- README, docs, and CHANGELOG updated if behavior or setup changed.
+- No placeholder text left where factual content existed before.
+- Security warnings present before copy-pasteable credential examples.
+
+---
+
+### Step 4 — Write Issues to File
+
+1. Determine the output file path: `[REPO_ROOT]/comments-PR#[PRN].md`.
+2. If the file does not exist, create it with this header:
+
+```markdown
+# PR #[PRN] Review — [PR TITLE]
+
+Branch: `[HEAD_BRANCH]` → `[BASE_BRANCH]`
+Reviewed: [TODAY'S DATE]
+Scope: all [N] changed files ([comma-separated file list or areas])
+
+---
+
+## Issues
+
+---
+```
+
+3. For each issue found, append a section using this format:
+
+```markdown
+### LCM-[PRN]-[N] — [Short imperative title of the problem]
+
+**Files:** `path/to/file.go` (line N or lines N–M if helpful)
+
+[One paragraph explaining what the problem is and why it matters. Include code snippets where they help clarify the issue.]
+
+**Fix:** [Concrete, actionable fix. Include corrected code snippet where applicable.]
+
+---
+```
+
+4. **Do not stop at 10 issues.** Continue until all concerns found in Step 3 are documented.
+5. **Issues only** — do not list praise, positive observations, or notes about correct code. If the PR is clean, state that explicitly at the end.
+
+---
+
+### Step 5 — Summary
+
+After writing all issues to the file, reply to the user with:
+
+- Total issue count.
+- A one-line summary per issue (issue ID + title).
+- The path to the output file.
+- Any issues that are borderline or context-dependent (flag, don't suppress).
+
+---
+
+## Output Format Rules
+
+- Issue IDs are sequential: `LCM-[PRN]-1`, `LCM-[PRN]-2`, …, `LCM-[PRN]-N`.
+- Each issue is self-contained: a reader unfamiliar with the PR can understand it from the issue text alone.
+- Code snippets in issues use fenced blocks with the language tag.
+- "Fix" is always concrete — avoid "consider adding X". Say what to add and where.
+- Do not reference praise ("the rest of the file is fine"). Issue list = problems only.
+
+---
+
+## Reference: Repo Conventions
+
+See also:
+- [`.github/copilot-instructions.md`](../../copilot-instructions.md) — full review checklist
+- [`AGENTS.md`](../../../AGENTS.md) — architecture, library vs service boundaries, unused code policy
+- [`CONTRIBUTING.md`](../../../CONTRIBUTING.md) — self-review checklist, branching, PR template

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -38,6 +38,9 @@ func (s *Server) serverLogger() *slog.Logger {
 	return logger.Get()
 }
 
+// TODO(T55): add logWith(r *http.Request) *slog.Logger returning serverLogger()
+// enriched with method and path for per-request context in encode-failure logs.
+
 // auditLog emits a structured audit event at INFO level with audit=true.
 func (s *Server) auditLog(ctx context.Context, action string, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, len(attrs)+2)

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -38,15 +38,6 @@ func (s *Server) serverLogger() *slog.Logger {
 	return logger.Get()
 }
 
-// logWith returns serverLogger enriched with the request method and path.
-// Callers may use it for per-request structured logging (see T55).
-func (s *Server) logWith(r *http.Request) *slog.Logger {
-	return s.serverLogger().With(
-		slog.String("method", r.Method),
-		slog.String("path", r.URL.Path),
-	)
-}
-
 // auditLog emits a structured audit event at INFO level with audit=true.
 func (s *Server) auditLog(ctx context.Context, action string, attrs ...slog.Attr) {
 	all := make([]slog.Attr, 0, len(attrs)+2)

--- a/go/internal/api/server.go
+++ b/go/internal/api/server.go
@@ -1,9 +1,12 @@
 package api
 
 import (
+	"context"
+	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
@@ -19,8 +22,37 @@ type Server struct {
 	// CORSAllowedOrigins lists origins permitted via Access-Control-Allow-Origin.
 	// ["*"] allows any origin (default). Empty slice disables CORS headers entirely.
 	CORSAllowedOrigins []string
+	// Log is an optional per-server logger. When nil, the package-level logger
+	// from internal/logger is used. Set this in tests to capture log output
+	// per-test without mutating global state.
+	Log *slog.Logger
 
 	metrics *Metrics
+}
+
+// serverLogger returns s.Log when set, or the package-level logger otherwise.
+func (s *Server) serverLogger() *slog.Logger {
+	if s.Log != nil {
+		return s.Log
+	}
+	return logger.Get()
+}
+
+// logWith returns serverLogger enriched with the request method and path.
+// Callers may use it for per-request structured logging (see T55).
+func (s *Server) logWith(r *http.Request) *slog.Logger {
+	return s.serverLogger().With(
+		slog.String("method", r.Method),
+		slog.String("path", r.URL.Path),
+	)
+}
+
+// auditLog emits a structured audit event at INFO level with audit=true.
+func (s *Server) auditLog(ctx context.Context, action string, attrs ...slog.Attr) {
+	all := make([]slog.Attr, 0, len(attrs)+2)
+	all = append(all, slog.Bool("audit", true), slog.String("action", action))
+	all = append(all, attrs...)
+	s.serverLogger().LogAttrs(ctx, slog.LevelInfo, "audit", all...)
 }
 
 // NegativeMaskCounter returns the store_negative_mask_observed_total
@@ -122,7 +154,7 @@ func (s *Server) Router(reg prometheus.Registerer, gather prometheus.Gatherer) c
 }
 
 func (s *Server) health(w http.ResponseWriter, r *http.Request) {
-	writeJSON(w, r, http.StatusOK, map[string]string{"status": "ok"})
+	s.writeJSON(w, r, http.StatusOK, map[string]string{"status": "ok"})
 }
 
 type titleBody struct {

--- a/go/internal/api/server_access_types.go
+++ b/go/internal/api/server_access_types.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -24,48 +23,48 @@ type accessTypePatchBody struct {
 func (s *Server) accessTypeCreate(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	var b accessTypeBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	bit, err := parseUint64Validated(b.Bit, maxAccessMask)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	a := &store.AccessType{ID: uuid.NewString(), DomainID: domainID, Title: b.Title, Bit: bit}
 	if err := s.Store.AccessTypeCreate(r.Context(), a); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "access_type_create",
+	s.auditLog(r.Context(), "access_type_create",
 		slog.String("domain_id", domainID),
 		slog.String("access_type_id", a.ID),
 		slog.Uint64("bit", a.Bit),
 	)
-	writeJSON(w, r, http.StatusCreated, a)
+	s.writeJSON(w, r, http.StatusCreated, a)
 }
 
 func (s *Server) accessTypeList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.AccessTypeSortFields)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
 	list, total, err := s.Store.AccessTypeList(r.Context(), domainID, opts)
 	if err != nil {
-		writeInternalErr(w, r, err)
+		s.writeInternalErr(w, r, err)
 		return
 	}
 	if list == nil {
 		list = []store.AccessType{}
 	}
-	writeList(w, r, list, total, opts)
+	s.writeList(w, r, list, total, opts)
 }
 
 func (s *Server) accessTypeGet(w http.ResponseWriter, r *http.Request) {
@@ -73,52 +72,52 @@ func (s *Server) accessTypeGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "accessTypeID")
 	a, err := s.Store.AccessTypeGet(r.Context(), domainID, id)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, r, http.StatusOK, a)
+	s.writeJSON(w, r, http.StatusOK, a)
 }
 
 func (s *Server) accessTypePatch(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "accessTypeID")
 	var b accessTypePatchBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	if b.Title == nil && b.Bit == nil {
-		writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, bit is required"))
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, bit is required"))
 		return
 	}
 	params := store.AccessTypePatchParams{Title: b.Title}
 	if b.Bit != nil {
 		bit, err := parseUint64Validated(*b.Bit, maxAccessMask)
 		if err != nil {
-			writeErr(w, r, http.StatusBadRequest, err)
+			s.writeErr(w, r, http.StatusBadRequest, err)
 			return
 		}
 		params.Bit = &bit
 	}
 	a, err := s.Store.AccessTypePatch(r.Context(), domainID, id, params)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "access_type_patch",
+	s.auditLog(r.Context(), "access_type_patch",
 		slog.String("domain_id", domainID),
 		slog.String("access_type_id", id),
 		slog.Uint64("bit", a.Bit),
 	)
-	writeJSON(w, r, http.StatusOK, a)
+	s.writeJSON(w, r, http.StatusOK, a)
 }
 
 func (s *Server) accessTypeDelete(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "accessTypeID")
 	if err := s.Store.AccessTypeDelete(r.Context(), domainID, id); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "access_type_delete", slog.String("domain_id", domainID), slog.String("access_type_id", id))
+	s.auditLog(r.Context(), "access_type_delete", slog.String("domain_id", domainID), slog.String("access_type_id", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/api/server_authz.go
+++ b/go/internal/api/server_authz.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/dtorabi/access-manager/internal/access"
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 )
@@ -16,10 +15,10 @@ func (s *Server) addUserToGroup(w http.ResponseWriter, r *http.Request) {
 	uid := chi.URLParam(r, "userID")
 	gid := chi.URLParam(r, "groupID")
 	if err := s.Store.AddUserToGroup(r.Context(), domainID, uid, gid); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "add_user_to_group", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("group_id", gid))
+	s.auditLog(r.Context(), "add_user_to_group", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("group_id", gid))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -28,10 +27,10 @@ func (s *Server) removeUserFromGroup(w http.ResponseWriter, r *http.Request) {
 	uid := chi.URLParam(r, "userID")
 	gid := chi.URLParam(r, "groupID")
 	if err := s.Store.RemoveUserFromGroup(r.Context(), domainID, uid, gid); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "remove_user_from_group", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("group_id", gid))
+	s.auditLog(r.Context(), "remove_user_from_group", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("group_id", gid))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -40,10 +39,10 @@ func (s *Server) grantUserPermission(w http.ResponseWriter, r *http.Request) {
 	uid := chi.URLParam(r, "userID")
 	pid := chi.URLParam(r, "permissionID")
 	if err := s.Store.GrantUserPermission(r.Context(), domainID, uid, pid); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "grant_user_permission", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("permission_id", pid))
+	s.auditLog(r.Context(), "grant_user_permission", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("permission_id", pid))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -52,10 +51,10 @@ func (s *Server) revokeUserPermission(w http.ResponseWriter, r *http.Request) {
 	uid := chi.URLParam(r, "userID")
 	pid := chi.URLParam(r, "permissionID")
 	if err := s.Store.RevokeUserPermission(r.Context(), domainID, uid, pid); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "revoke_user_permission", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("permission_id", pid))
+	s.auditLog(r.Context(), "revoke_user_permission", slog.String("domain_id", domainID), slog.String("user_id", uid), slog.String("permission_id", pid))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -64,7 +63,7 @@ const userAuthzResourcesSortField = "resource_id"
 func (s *Server) userAuthzResources(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	// This endpoint only exposes pagination and uses a fixed stable ordering.
@@ -75,10 +74,10 @@ func (s *Server) userAuthzResources(w http.ResponseWriter, r *http.Request) {
 	uid := chi.URLParam(r, "userID")
 	list, total, err := s.Store.UserAuthzResourcesList(r.Context(), domainID, uid, opts)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, r, userAuthzResourceDTOs(list), total, opts)
+	s.writeList(w, r, userAuthzResourceDTOs(list), total, opts)
 }
 
 const groupAuthzResourcesSortField = "resource_id"
@@ -86,7 +85,7 @@ const groupAuthzResourcesSortField = "resource_id"
 func (s *Server) groupAuthzResources(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort = groupAuthzResourcesSortField
@@ -96,10 +95,10 @@ func (s *Server) groupAuthzResources(w http.ResponseWriter, r *http.Request) {
 	gid := chi.URLParam(r, "groupID")
 	list, total, err := s.Store.GroupAuthzResourcesList(r.Context(), domainID, gid, opts)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, r, groupAuthzResourceDTOs(list), total, opts)
+	s.writeList(w, r, groupAuthzResourceDTOs(list), total, opts)
 }
 
 // resourceAuthzUsersSortField is the meta.sort label returned to clients.
@@ -114,7 +113,7 @@ const resourceAuthzUsersSortField = "user_id"
 func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	// Populated for meta only; the store enforces fixed ORDER BY users.id ASC.
@@ -125,10 +124,10 @@ func (s *Server) resourceAuthzUsers(w http.ResponseWriter, r *http.Request) {
 	rid := chi.URLParam(r, "resourceID")
 	list, total, err := s.Store.ResourceAuthzUsersList(r.Context(), domainID, rid, opts)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, r, resourceAuthzUserDTOs(list), total, opts)
+	s.writeList(w, r, resourceAuthzUserDTOs(list), total, opts)
 }
 
 const resourceAuthzGroupsSortField = "group_id"
@@ -136,7 +135,7 @@ const resourceAuthzGroupsSortField = "group_id"
 func (s *Server) resourceAuthzGroups(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseOffsetLimitOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	// Populated for meta only; the store enforces fixed ORDER BY group_permissions.group_id ASC.
@@ -147,10 +146,10 @@ func (s *Server) resourceAuthzGroups(w http.ResponseWriter, r *http.Request) {
 	rid := chi.URLParam(r, "resourceID")
 	list, total, err := s.Store.ResourceAuthzGroupsList(r.Context(), domainID, rid, opts)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeList(w, r, resourceAuthzGroupDTOs(list), total, opts)
+	s.writeList(w, r, resourceAuthzGroupDTOs(list), total, opts)
 }
 
 func (s *Server) grantGroupPermission(w http.ResponseWriter, r *http.Request) {
@@ -158,10 +157,10 @@ func (s *Server) grantGroupPermission(w http.ResponseWriter, r *http.Request) {
 	gid := chi.URLParam(r, "groupID")
 	pid := chi.URLParam(r, "permissionID")
 	if err := s.Store.GrantGroupPermission(r.Context(), domainID, gid, pid); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "grant_group_permission", slog.String("domain_id", domainID), slog.String("group_id", gid), slog.String("permission_id", pid))
+	s.auditLog(r.Context(), "grant_group_permission", slog.String("domain_id", domainID), slog.String("group_id", gid), slog.String("permission_id", pid))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -170,10 +169,10 @@ func (s *Server) revokeGroupPermission(w http.ResponseWriter, r *http.Request) {
 	gid := chi.URLParam(r, "groupID")
 	pid := chi.URLParam(r, "permissionID")
 	if err := s.Store.RevokeGroupPermission(r.Context(), domainID, gid, pid); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "revoke_group_permission", slog.String("domain_id", domainID), slog.String("group_id", gid), slog.String("permission_id", pid))
+	s.auditLog(r.Context(), "revoke_group_permission", slog.String("domain_id", domainID), slog.String("group_id", gid), slog.String("permission_id", pid))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -203,17 +202,17 @@ func (s *Server) authzCheck(w http.ResponseWriter, r *http.Request) {
 	}
 	bit, err := parseUint64Validated(bitStr, maxAccessMask)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	mask, err := s.Store.EffectiveMask(r.Context(), domainID, userID, resourceID)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
 	allowed := access.HasBit(mask, bit)
 	result = authzResultOK
-	writeJSON(w, r, http.StatusOK, map[string]any{
+	s.writeJSON(w, r, http.StatusOK, map[string]any{
 		"allowed":        allowed,
 		"effective_mask": strconv.FormatUint(mask, 10),
 	})
@@ -233,9 +232,9 @@ func (s *Server) authzMasks(w http.ResponseWriter, r *http.Request) {
 	}
 	masks, err := s.Store.PermissionMasksForUserResource(r.Context(), domainID, userID, resourceID)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
 	result = authzResultOK
-	writeJSON(w, r, http.StatusOK, map[string]any{"masks": masks})
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"masks": masks})
 }

--- a/go/internal/api/server_authz_test.go
+++ b/go/internal/api/server_authz_test.go
@@ -1480,13 +1480,4 @@ func TestAPI_authzCheck_accessBitOutOfRange(t *testing.T) {
 	}
 }
 
-// --- T52: request/response error hardening tests ---
-
-// TestWriteJSON_encodeErrorLogged asserts that a response encoding failure is
-// logged at ERROR level with method and path so operators can identify the
-// failing endpoint. Because the status header is already committed, the only
-// observable signal is the log entry.
-//
-// NOTE: This test mutates the package-level logger via logger.Init.
-// t.Parallel() is intentionally omitted until T54 (injectable logger) lands.
-// See TODO(T54) in writeJSON.
+// --- T52: request/response error hardening tests are in server_request_test.go ---

--- a/go/internal/api/server_domains.go
+++ b/go/internal/api/server_domains.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -13,75 +12,75 @@ import (
 
 func (s *Server) domainCreate(w http.ResponseWriter, r *http.Request) {
 	var b titleBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	d := &store.Domain{ID: uuid.NewString(), Title: b.Title}
 	if err := s.Store.DomainCreate(r.Context(), d); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "domain_create", slog.String("domain_id", d.ID))
-	writeJSON(w, r, http.StatusCreated, d)
+	s.auditLog(r.Context(), "domain_create", slog.String("domain_id", d.ID))
+	s.writeJSON(w, r, http.StatusCreated, d)
 }
 
 func (s *Server) domainList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.DomainSortFields)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	list, total, err := s.Store.DomainList(r.Context(), opts)
 	if err != nil {
-		writeInternalErr(w, r, err)
+		s.writeInternalErr(w, r, err)
 		return
 	}
 	if list == nil {
 		list = []store.Domain{}
 	}
-	writeList(w, r, list, total, opts)
+	s.writeList(w, r, list, total, opts)
 }
 
 func (s *Server) domainGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "domainID")
 	d, err := s.Store.DomainGet(r.Context(), id)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, r, http.StatusOK, d)
+	s.writeJSON(w, r, http.StatusOK, d)
 }
 
 func (s *Server) domainPatch(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "domainID")
 	var b patchTitleBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	if b.Title == nil {
-		writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
 		return
 	}
 	d, err := s.Store.DomainPatch(r.Context(), id, b.Title)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "domain_patch", slog.String("domain_id", id))
-	writeJSON(w, r, http.StatusOK, d)
+	s.auditLog(r.Context(), "domain_patch", slog.String("domain_id", id))
+	s.writeJSON(w, r, http.StatusOK, d)
 }
 
 func (s *Server) domainDelete(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "domainID")
 	if err := s.Store.DomainDelete(r.Context(), id); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "domain_delete", slog.String("domain_id", id))
+	s.auditLog(r.Context(), "domain_delete", slog.String("domain_id", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/api/server_domains_test.go
+++ b/go/internal/api/server_domains_test.go
@@ -1,31 +1,22 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 )
 
-// NOTE: Tests that call logger.Init mutate the package-level logger pointer.
-// This is safe only because no test in this file uses t.Parallel().
-// Do NOT add t.Parallel() without first switching to a logger-injectable
-// Server field or an atomic pointer. Tracked on #47 (T36 follow-ups).
+// NOTE: Each test gets its own logger through newTestAPIWithLog or the
+// discard logger in newTestAPI. The global logger is never mutated.
 
 func TestAPI_auditLog_domainCreate(t *testing.T) {
-	var buf bytes.Buffer
-	logger.Init(slog.LevelInfo, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
-
-	ts, _ := newTestAPI(t)
+	t.Parallel()
+	ts, _, logBuf := newTestAPIWithLog(t)
 	payload := `{"title":"AuditCo"}`
 	res, err := http.Post(ts.URL+"/api/v1/domains", "application/json", strings.NewReader(payload))
 	if err != nil {
@@ -41,9 +32,9 @@ func TestAPI_auditLog_domainCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	domainAudits := auditLogEntriesWithAction(t, buf.String(), "domain_create")
+	domainAudits := auditLogEntriesWithAction(t, logBuf.String(), "domain_create")
 	if len(domainAudits) != 1 {
-		t.Fatalf("want 1 domain_create audit, got %d in %q", len(domainAudits), buf.String())
+		t.Fatalf("want 1 domain_create audit, got %d in %q", len(domainAudits), logBuf.String())
 	}
 	line := domainAudits[0]
 	if line["msg"] != "audit" {

--- a/go/internal/api/server_groups.go
+++ b/go/internal/api/server_groups.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -41,41 +40,41 @@ func (s *Server) groupCreate(w http.ResponseWriter, r *http.Request) {
 		Title         string  `json:"title"`
 		ParentGroupID *string `json:"parent_group_id"`
 	}
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	g := &store.Group{ID: uuid.NewString(), DomainID: domainID, Title: b.Title, ParentGroupID: b.ParentGroupID}
 	if err := s.Store.GroupCreate(r.Context(), g); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
 	gaudit := []slog.Attr{slog.String("domain_id", domainID), slog.String("group_id", g.ID)}
 	gaudit = append(gaudit, parentGroupAuditAttrs(b.ParentGroupID, false)...)
-	logger.Audit(r.Context(), "group_create", gaudit...)
-	writeJSON(w, r, http.StatusCreated, g)
+	s.auditLog(r.Context(), "group_create", gaudit...)
+	s.writeJSON(w, r, http.StatusCreated, g)
 }
 
 func (s *Server) groupList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseGroupListOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.GroupSortFields)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
 	list, total, err := s.Store.GroupList(r.Context(), domainID, opts)
 	if err != nil {
-		writeInternalErr(w, r, err)
+		s.writeInternalErr(w, r, err)
 		return
 	}
 	if list == nil {
 		list = []store.Group{}
 	}
-	writeList(w, r, list, total, opts.ListOpts)
+	s.writeList(w, r, list, total, opts.ListOpts)
 }
 
 func (s *Server) groupGet(w http.ResponseWriter, r *http.Request) {
@@ -83,17 +82,17 @@ func (s *Server) groupGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "groupID")
 	g, err := s.Store.GroupGet(r.Context(), domainID, id)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, r, http.StatusOK, g)
+	s.writeJSON(w, r, http.StatusOK, g)
 }
 
 func (s *Server) groupPatch(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	groupID := chi.URLParam(r, "groupID")
 	var b groupPatchBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	params := store.GroupPatchParams{Title: b.Title}
@@ -106,19 +105,19 @@ func (s *Server) groupPatch(w http.ResponseWriter, r *http.Request) {
 		default:
 			var pid string
 			if err := json.Unmarshal(trimmed, &pid); err != nil {
-				writeErr(w, r, http.StatusBadRequest, errors.New("parent_group_id must be a UUID string or null"))
+				s.writeErr(w, r, http.StatusBadRequest, errors.New("parent_group_id must be a UUID string or null"))
 				return
 			}
 			params.ParentGroupID = &pid
 		}
 	}
 	if params.Title == nil && !params.UpdateParent {
-		writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, parent_group_id is required"))
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, parent_group_id is required"))
 		return
 	}
 	g, err := s.Store.GroupPatch(r.Context(), domainID, groupID, params)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
 	gaudit := []slog.Attr{slog.String("domain_id", domainID), slog.String("group_id", groupID)}
@@ -128,18 +127,18 @@ func (s *Server) groupPatch(w http.ResponseWriter, r *http.Request) {
 	if params.UpdateParent {
 		gaudit = append(gaudit, parentGroupAuditAttrs(params.ParentGroupID, true)...)
 	}
-	logger.Audit(r.Context(), "group_patch", gaudit...)
-	writeJSON(w, r, http.StatusOK, g)
+	s.auditLog(r.Context(), "group_patch", gaudit...)
+	s.writeJSON(w, r, http.StatusOK, g)
 }
 
 func (s *Server) groupDelete(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "groupID")
 	if err := s.Store.GroupDelete(r.Context(), domainID, id); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "group_delete", slog.String("domain_id", domainID), slog.String("group_id", id))
+	s.auditLog(r.Context(), "group_delete", slog.String("domain_id", domainID), slog.String("group_id", id))
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -147,15 +146,15 @@ func (s *Server) groupSetParent(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	groupID := chi.URLParam(r, "groupID")
 	var b parentBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	if err := s.Store.GroupSetParent(r.Context(), domainID, groupID, b.ParentGroupID); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
 	auditAttrs := []slog.Attr{slog.String("domain_id", domainID), slog.String("group_id", groupID)}
 	auditAttrs = append(auditAttrs, parentGroupAuditAttrs(b.ParentGroupID, true)...)
-	logger.Audit(r.Context(), "group_set_parent", auditAttrs...)
+	s.auditLog(r.Context(), "group_set_parent", auditAttrs...)
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/api/server_groups_test.go
+++ b/go/internal/api/server_groups_test.go
@@ -1,27 +1,20 @@
 package api
 
 import (
-	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net/http"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/google/uuid"
 )
 
 func TestAPI_auditLog_groupCreate_parentFields(t *testing.T) {
-	var buf bytes.Buffer
-	logger.Init(slog.LevelInfo, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
-
-	ts, _ := newTestAPI(t)
+	t.Parallel()
+	ts, _, logBuf := newTestAPIWithLog(t)
 	var dom store.Domain
 	if err := json.Unmarshal(mustPostJSON201(t, ts.URL+"/api/v1/domains", `{"title":"ad"}`), &dom); err != nil {
 		t.Fatal(err)
@@ -29,9 +22,9 @@ func TestAPI_auditLog_groupCreate_parentFields(t *testing.T) {
 	base := ts.URL + "/api/v1/domains/" + dom.ID
 
 	mustPostJSON201(t, base+"/groups", `{"title":"rootg"}`)
-	groups := auditLogEntriesWithAction(t, buf.String(), "group_create")
+	groups := auditLogEntriesWithAction(t, logBuf.String(), "group_create")
 	if len(groups) != 1 {
-		t.Fatalf("want 1 group_create audit after first group, got %d: %q", len(groups), buf.String())
+		t.Fatalf("want 1 group_create audit after first group, got %d: %q", len(groups), logBuf.String())
 	}
 	rootLine := groups[0]
 	if rootLine["parent_root"] != true {
@@ -44,9 +37,9 @@ func TestAPI_auditLog_groupCreate_parentFields(t *testing.T) {
 	}
 	childBody := fmt.Sprintf(`{"title":"ch","parent_group_id":%q}`, parent.ID)
 	mustPostJSON201(t, base+"/groups", childBody)
-	groups = auditLogEntriesWithAction(t, buf.String(), "group_create")
+	groups = auditLogEntriesWithAction(t, logBuf.String(), "group_create")
 	if len(groups) != 3 {
-		t.Fatalf("want 3 group_create audits after domain + 3 groups, got %d: %q", len(groups), buf.String())
+		t.Fatalf("want 3 group_create audits after domain + 3 groups, got %d: %q", len(groups), logBuf.String())
 	}
 	childLine := groups[len(groups)-1]
 	if childLine["parent_group_id"] != parent.ID {

--- a/go/internal/api/server_permissions.go
+++ b/go/internal/api/server_permissions.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -26,12 +25,12 @@ type permissionPatchBody struct {
 func (s *Server) permissionCreate(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	var b permissionBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	mask, err := parseUint64Validated(b.AccessMask, maxAccessMask)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	p := &store.Permission{
@@ -39,39 +38,39 @@ func (s *Server) permissionCreate(w http.ResponseWriter, r *http.Request) {
 		ResourceID: b.ResourceID, AccessMask: mask,
 	}
 	if err := s.Store.PermissionCreate(r.Context(), p); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "permission_create",
+	s.auditLog(r.Context(), "permission_create",
 		slog.String("domain_id", domainID),
 		slog.String("permission_id", p.ID),
 		slog.String("resource_id", p.ResourceID),
 		slog.Uint64("access_mask", p.AccessMask),
 	)
-	writeJSON(w, r, http.StatusCreated, p)
+	s.writeJSON(w, r, http.StatusCreated, p)
 }
 
 func (s *Server) permissionList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parsePermissionListOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.PermissionSortFields)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
 	list, total, err := s.Store.PermissionList(r.Context(), domainID, opts)
 	if err != nil {
-		writeInternalErr(w, r, err)
+		s.writeInternalErr(w, r, err)
 		return
 	}
 	if list == nil {
 		list = []store.Permission{}
 	}
-	writeList(w, r, list, total, opts.ListOpts)
+	s.writeList(w, r, list, total, opts.ListOpts)
 }
 
 func (s *Server) permissionGet(w http.ResponseWriter, r *http.Request) {
@@ -79,53 +78,53 @@ func (s *Server) permissionGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "permissionID")
 	p, err := s.Store.PermissionGet(r.Context(), domainID, id)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, r, http.StatusOK, p)
+	s.writeJSON(w, r, http.StatusOK, p)
 }
 
 func (s *Server) permissionPatch(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "permissionID")
 	var b permissionPatchBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	if b.Title == nil && b.ResourceID == nil && b.AccessMask == nil {
-		writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, resource_id, access_mask is required"))
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("at least one of title, resource_id, access_mask is required"))
 		return
 	}
 	params := store.PermissionPatchParams{Title: b.Title, ResourceID: b.ResourceID}
 	if b.AccessMask != nil {
 		mask, err := parseUint64Validated(*b.AccessMask, maxAccessMask)
 		if err != nil {
-			writeErr(w, r, http.StatusBadRequest, err)
+			s.writeErr(w, r, http.StatusBadRequest, err)
 			return
 		}
 		params.AccessMask = &mask
 	}
 	p, err := s.Store.PermissionPatch(r.Context(), domainID, id, params)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "permission_patch",
+	s.auditLog(r.Context(), "permission_patch",
 		slog.String("domain_id", domainID),
 		slog.String("permission_id", id),
 		slog.String("resource_id", p.ResourceID),
 		slog.Uint64("access_mask", p.AccessMask),
 	)
-	writeJSON(w, r, http.StatusOK, p)
+	s.writeJSON(w, r, http.StatusOK, p)
 }
 
 func (s *Server) permissionDelete(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "permissionID")
 	if err := s.Store.PermissionDelete(r.Context(), domainID, id); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "permission_delete", slog.String("domain_id", domainID), slog.String("permission_id", id))
+	s.auditLog(r.Context(), "permission_delete", slog.String("domain_id", domainID), slog.String("permission_id", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/api/server_request.go
+++ b/go/internal/api/server_request.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"io"
@@ -21,13 +22,15 @@ func (s *Server) writeJSON(w http.ResponseWriter, r *http.Request, status int, v
 		// The response header is already committed; log with request context for
 		// operator visibility so the failing endpoint can be identified.
 		attrs := []slog.Attr{slog.String("err", err.Error())}
+		ctx := context.Background()
 		if r != nil {
+			ctx = r.Context()
 			attrs = append(attrs,
 				slog.String("method", r.Method),
 				slog.String("path", r.URL.Path),
 			)
 		}
-		s.serverLogger().LogAttrs(r.Context(), slog.LevelError, "response encode failed", attrs...)
+		s.serverLogger().LogAttrs(ctx, slog.LevelError, "response encode failed", attrs...)
 	}
 }
 

--- a/go/internal/api/server_request.go
+++ b/go/internal/api/server_request.go
@@ -11,12 +11,10 @@ import (
 	"strings"
 	"unicode/utf8"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 )
 
-// TODO(T54): replace r-threading with logWith(r) once T54 injectable logger lands.
-func writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
+func (s *Server) writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(v); err != nil {
@@ -29,18 +27,18 @@ func writeJSON(w http.ResponseWriter, r *http.Request, status int, v any) {
 				slog.String("path", r.URL.Path),
 			)
 		}
-		logger.Error("response encode failed", attrs...)
+		s.serverLogger().LogAttrs(r.Context(), slog.LevelError, "response encode failed", attrs...)
 	}
 }
 
-func writeErr(w http.ResponseWriter, r *http.Request, status int, err error) {
-	writeJSON(w, r, status, map[string]string{"error": err.Error()})
+func (s *Server) writeErr(w http.ResponseWriter, r *http.Request, status int, err error) {
+	s.writeJSON(w, r, status, map[string]string{"error": err.Error()})
 }
 
 // writeStoreErr classifies a store-layer error into the correct HTTP status
 // and returns a stable, database-agnostic message. The full error is logged
 // server-side so operators can correlate support requests with logs.
-func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
+func (s *Server) writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 	var status int
 	var msg string
 	switch {
@@ -60,8 +58,8 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 		status = http.StatusInternalServerError
 		msg = "internal server error"
 	}
-	logRequestErr(r, status, err)
-	writeJSON(w, r, status, map[string]string{"error": msg})
+	s.logRequestErr(r, status, err)
+	s.writeJSON(w, r, status, map[string]string{"error": msg})
 }
 
 // writeInternalErr logs the full error and returns a generic 500 to the client.
@@ -74,23 +72,24 @@ func writeStoreErr(w http.ResponseWriter, r *http.Request, err error) {
 // the function logs an additional ERROR-level alert so the incorrect call site
 // is immediately visible in production instead of silently producing a 500 for
 // errors that should map to 4xx. The client always receives the generic 500.
-func writeInternalErr(w http.ResponseWriter, r *http.Request, err error) {
+func (s *Server) writeInternalErr(w http.ResponseWriter, r *http.Request, err error) {
 	if errors.Is(err, store.ErrNotFound) || errors.Is(err, store.ErrConflict) ||
 		errors.Is(err, store.ErrFKViolation) || errors.Is(err, store.ErrInvalidInput) {
-		logger.Error("writeInternalErr misuse: structured store error must use writeStoreErr",
+		s.serverLogger().LogAttrs(r.Context(), slog.LevelError,
+			"writeInternalErr misuse: structured store error must use writeStoreErr",
 			slog.String("err", err.Error()),
 			slog.String("method", r.Method),
 			slog.String("path", r.URL.Path),
 		)
 	}
-	logRequestErr(r, http.StatusInternalServerError, err)
-	writeJSON(w, r, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+	s.logRequestErr(r, http.StatusInternalServerError, err)
+	s.writeJSON(w, r, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
 }
 
 // logRequestErr logs the error with request context. 5xx errors are logged at
 // ERROR level; 4xx at WARN to avoid inflating error-level alerts for expected
 // client mistakes.
-func logRequestErr(r *http.Request, status int, err error) {
+func (s *Server) logRequestErr(r *http.Request, status int, err error) {
 	attrs := []slog.Attr{
 		slog.Int("status", status),
 		slog.String("err", err.Error()),
@@ -98,9 +97,9 @@ func logRequestErr(r *http.Request, status int, err error) {
 		slog.String("path", r.URL.Path),
 	}
 	if status >= 500 {
-		logger.Error("request error", attrs...)
+		s.serverLogger().LogAttrs(r.Context(), slog.LevelError, "request error", attrs...)
 	} else {
-		logger.Warn("request error", attrs...)
+		s.serverLogger().LogAttrs(r.Context(), slog.LevelWarn, "request error", attrs...)
 	}
 }
 
@@ -266,8 +265,8 @@ func parseSortOrder(q url.Values, allowed []string) (string, store.SortOrder, er
 	return sortField, order, nil
 }
 
-func writeList(w http.ResponseWriter, r *http.Request, data any, total int64, opts store.ListOpts) {
-	writeJSON(w, r, http.StatusOK, listEnvelope{
+func (s *Server) writeList(w http.ResponseWriter, r *http.Request, data any, total int64, opts store.ListOpts) {
+	s.writeJSON(w, r, http.StatusOK, listEnvelope{
 		Data: data,
 		Meta: listMeta{
 			Total:  total,
@@ -279,20 +278,20 @@ func writeList(w http.ResponseWriter, r *http.Request, data any, total int64, op
 	})
 }
 
-func readJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
+func (s *Server) readJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	r.Body = http.MaxBytesReader(w, r.Body, maxRequestBodySize)
 	dec := json.NewDecoder(r.Body)
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(dst); err != nil {
 		var maxErr *http.MaxBytesError
 		if errors.As(err, &maxErr) {
-			logReadJSONErr(r, "body_too_large", "request body too large")
-			writeErr(w, r, http.StatusRequestEntityTooLarge, errors.New("request body too large"))
+			s.logReadJSONErr(r, "body_too_large", "request body too large")
+			s.writeErr(w, r, http.StatusRequestEntityTooLarge, errors.New("request body too large"))
 			return false
 		}
 		cls := classifyDecodeErr(err)
-		logReadJSONErr(r, cls.kind, cls.logMsg)
-		writeErr(w, r, http.StatusBadRequest, errors.New(cls.clientMsg))
+		s.logReadJSONErr(r, cls.kind, cls.logMsg)
+		s.writeErr(w, r, http.StatusBadRequest, errors.New(cls.clientMsg))
 		return false
 	}
 	// Decode a second value to verify the stream is exhausted. io.EOF means
@@ -303,8 +302,8 @@ func readJSON(w http.ResponseWriter, r *http.Request, dst any) bool {
 	// stream exhaustion, and its behaviour outside that scope is undocumented.
 	var extra json.RawMessage
 	if err := dec.Decode(&extra); !errors.Is(err, io.EOF) {
-		logReadJSONErr(r, "trailing_data", "trailing data after first JSON value")
-		writeErr(w, r, http.StatusBadRequest, errors.New("request body must contain exactly one JSON value"))
+		s.logReadJSONErr(r, "trailing_data", "trailing data after first JSON value")
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("request body must contain exactly one JSON value"))
 		return false
 	}
 	return true
@@ -349,8 +348,8 @@ func classifyDecodeErr(err error) decodeClass {
 // The detail parameter must be a pre-sanitized string — never pass err.Error()
 // directly for errors that may contain user-controlled input (e.g. unknown
 // field names from DisallowUnknownFields).
-func logReadJSONErr(r *http.Request, kind, detail string) {
-	logger.Warn("request body decode failed",
+func (s *Server) logReadJSONErr(r *http.Request, kind, detail string) {
+	s.serverLogger().LogAttrs(r.Context(), slog.LevelWarn, "request body decode failed",
 		slog.String("kind", kind),
 		slog.String("method", r.Method),
 		slog.String("path", r.URL.Path),

--- a/go/internal/api/server_request_test.go
+++ b/go/internal/api/server_request_test.go
@@ -9,11 +9,9 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"strings"
 	"testing"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/google/uuid"
 )
@@ -23,10 +21,7 @@ func dummyRequest() *http.Request {
 }
 
 func TestWriteStoreErr_allCases(t *testing.T) {
-	var buf bytes.Buffer
-	logger.Init(slog.LevelInfo, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
-
+	t.Parallel()
 	tests := []struct {
 		name    string
 		err     error
@@ -44,9 +39,11 @@ func TestWriteStoreErr_allCases(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			buf.Reset()
+			t.Parallel()
+			var buf bytes.Buffer
+			s := &Server{Log: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
 			w := httptest.NewRecorder()
-			writeStoreErr(w, dummyRequest(), tt.err)
+			s.writeStoreErr(w, dummyRequest(), tt.err)
 			if w.Code != tt.want {
 				t.Fatalf("writeStoreErr(%v) = %d, want %d", tt.err, w.Code, tt.want)
 			}
@@ -65,15 +62,15 @@ func TestWriteStoreErr_allCases(t *testing.T) {
 }
 
 func TestWriteStoreErr_noSQLLeak(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
-	logger.Init(slog.LevelInfo, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
+	s := &Server{Log: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
 
 	sqlDetail := "FOREIGN KEY constraint failed (errno 787)"
 	joined := fmt.Errorf("%w\n%s", store.ErrFKViolation, sqlDetail)
 
 	w := httptest.NewRecorder()
-	writeStoreErr(w, dummyRequest(), joined)
+	s.writeStoreErr(w, dummyRequest(), joined)
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("want 400, got %d", w.Code)
 	}
@@ -89,12 +86,12 @@ func TestWriteStoreErr_noSQLLeak(t *testing.T) {
 }
 
 func TestWriteInternalErr_generic(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
-	logger.Init(slog.LevelInfo, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
+	s := &Server{Log: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))}
 
 	w := httptest.NewRecorder()
-	writeInternalErr(w, dummyRequest(), fmt.Errorf("sql: database is closed"))
+	s.writeInternalErr(w, dummyRequest(), fmt.Errorf("sql: database is closed"))
 	if w.Code != http.StatusInternalServerError {
 		t.Fatalf("want 500, got %d", w.Code)
 	}
@@ -130,12 +127,12 @@ func TestWriteInternalErr_misuse(t *testing.T) {
 	}
 	for _, tt := range sentinels {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var buf bytes.Buffer
-			logger.Init(slog.LevelError, &buf)
-			t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
+			s := &Server{Log: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))}
 
 			w := httptest.NewRecorder()
-			writeInternalErr(w, dummyRequest(), tt.err)
+			s.writeInternalErr(w, dummyRequest(), tt.err)
 
 			if w.Code != http.StatusInternalServerError {
 				t.Fatalf("want 500, got %d", w.Code)
@@ -756,19 +753,15 @@ func TestAPI_numericParseErrors_stableMessages(t *testing.T) {
 // logged at ERROR level with method and path so operators can identify the
 // failing endpoint. Because the status header is already committed, the only
 // observable signal is the log entry.
-//
-// NOTE: This test mutates the package-level logger via logger.Init.
-// t.Parallel() is intentionally omitted until T54 (injectable logger) lands.
-// See TODO(T54) in writeJSON.
 func TestWriteJSON_encodeErrorLogged(t *testing.T) {
+	t.Parallel()
 	var buf bytes.Buffer
-	logger.Init(slog.LevelError, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
+	s := &Server{Log: slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelError}))}
 
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest(http.MethodGet, "/api/v1/domains", nil)
 	// A channel is not JSON-serializable and will cause Encode to fail.
-	writeJSON(w, r, http.StatusOK, map[string]any{"v": make(chan int)})
+	s.writeJSON(w, r, http.StatusOK, map[string]any{"v": make(chan int)})
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("want status 200 (header already committed), got %d", w.Code)
@@ -844,11 +837,8 @@ func TestReadJSON_failureKindsLogged(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var buf bytes.Buffer
-			logger.Init(slog.LevelWarn, &buf)
-			t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
-
-			ts, _ := newTestAPI(t)
+			t.Parallel()
+			ts, _, logBuf := newTestAPIWithLog(t)
 			res, err := http.Post(ts.URL+"/api/v1/domains", "application/json", strings.NewReader(tt.body))
 			if err != nil {
 				t.Fatal(err)
@@ -862,9 +852,8 @@ func TestReadJSON_failureKindsLogged(t *testing.T) {
 
 			// Scan all log entries first, then assert. Failing on the first
 			// matching entry would mask later entries with the correct kind.
-			logBuf := buf.String()
 			var foundKind string
-			for _, line := range strings.Split(logBuf, "\n") {
+			for _, line := range strings.Split(logBuf.String(), "\n") {
 				line = strings.TrimSpace(line)
 				if line == "" {
 					continue
@@ -880,10 +869,10 @@ func TestReadJSON_failureKindsLogged(t *testing.T) {
 				break // take the first matching log entry
 			}
 			if foundKind == "" {
-				t.Fatalf("no 'request body decode failed' log entry found\nlog: %s", logBuf)
+				t.Fatalf("no 'request body decode failed' log entry found\nlog: %s", logBuf.String())
 			}
 			if foundKind != tt.wantKind {
-				t.Fatalf("kind=%q, want %q\nlog: %s", foundKind, tt.wantKind, logBuf)
+				t.Fatalf("kind=%q, want %q\nlog: %s", foundKind, tt.wantKind, logBuf.String())
 			}
 		})
 	}
@@ -892,11 +881,8 @@ func TestReadJSON_failureKindsLogged(t *testing.T) {
 // TestReadJSON_bodyTooLargeKindLogged asserts that a body exceeding the 1 MiB
 // limit returns 413 and logs kind=body_too_large.
 func TestReadJSON_bodyTooLargeKindLogged(t *testing.T) {
-	var buf bytes.Buffer
-	logger.Init(slog.LevelWarn, &buf)
-	t.Cleanup(func() { logger.Init(slog.LevelInfo, os.Stderr) })
-
-	ts, _ := newTestAPI(t)
+	t.Parallel()
+	ts, _, logBuf := newTestAPIWithLog(t)
 	// Build a body just over 1 MiB; wrap in a JSON object so it parses until
 	// the size limit is hit.
 	oversized := `{"title":"` + strings.Repeat("x", maxRequestBodySize+1) + `"}`
@@ -911,9 +897,8 @@ func TestReadJSON_bodyTooLargeKindLogged(t *testing.T) {
 		t.Fatalf("want 413, got %d", res.StatusCode)
 	}
 
-	logBuf := buf.String()
 	var foundKind string
-	for _, line := range strings.Split(logBuf, "\n") {
+	for _, line := range strings.Split(logBuf.String(), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue
@@ -928,7 +913,7 @@ func TestReadJSON_bodyTooLargeKindLogged(t *testing.T) {
 		}
 	}
 	if foundKind != "body_too_large" {
-		t.Fatalf("want kind=body_too_large in log, got %q\nlog: %s", foundKind, logBuf)
+		t.Fatalf("want kind=body_too_large in log, got %q\nlog: %s", foundKind, logBuf.String())
 	}
 }
 

--- a/go/internal/api/server_request_test.go
+++ b/go/internal/api/server_request_test.go
@@ -116,6 +116,7 @@ func TestWriteInternalErr_generic(t *testing.T) {
 // still returning a generic 500 to the client — making the wrong call site
 // immediately visible in production.
 func TestWriteInternalErr_misuse(t *testing.T) {
+	t.Parallel()
 	sentinels := []struct {
 		name string
 		err  error
@@ -155,6 +156,7 @@ func TestWriteInternalErr_misuse(t *testing.T) {
 
 // newBrokenTestAPIWithRegistry builds a Server backed by a closed DB so any
 func TestAPI_storeErrors(t *testing.T) {
+	t.Parallel()
 	ts := newBrokenTestAPI(t)
 	domID := uuid.NewString()
 	userID := uuid.NewString()
@@ -243,6 +245,7 @@ func TestAPI_storeErrors(t *testing.T) {
 // --- pagination tests ---
 
 func TestAPI_patchEmptyBody_allEntities(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	dom := seedDomain(t, ts, "test-domain")
 	base := ts.URL + "/api/v1/domains/" + dom
@@ -299,6 +302,7 @@ func TestAPI_patchEmptyBody_allEntities(t *testing.T) {
 }
 
 func TestAPI_pagination_invalidOffset(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	tests := []struct {
 		name string
@@ -324,6 +328,7 @@ func TestAPI_pagination_invalidOffset(t *testing.T) {
 }
 
 func TestAPI_pagination_limitClamping(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	mustPostJSON201(t, ts.URL+"/api/v1/domains", `{"title":"d"}`)
 
@@ -345,6 +350,7 @@ func TestAPI_pagination_limitClamping(t *testing.T) {
 }
 
 func TestAPI_pagination_offsetPastEnd(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	mustPostJSON201(t, ts.URL+"/api/v1/domains", `{"title":"d"}`)
 
@@ -369,6 +375,7 @@ func TestAPI_pagination_offsetPastEnd(t *testing.T) {
 }
 
 func TestAPI_pagination_invalidOffset_otherEndpoints(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	dom := seedDomain(t, ts, "test-domain")
 	base := ts.URL + "/api/v1/domains/" + dom
@@ -399,6 +406,7 @@ func TestAPI_pagination_invalidOffset_otherEndpoints(t *testing.T) {
 }
 
 func TestAPI_scopedList_pagination(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	dom := seedDomain(t, ts, "test-domain")
 	base := ts.URL + "/api/v1/domains/" + dom
@@ -457,6 +465,7 @@ func TestAPI_scopedList_pagination(t *testing.T) {
 }
 
 func TestAPI_parseListOpts(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name           string
 		qs             string
@@ -513,6 +522,7 @@ func TestAPI_parseListOpts(t *testing.T) {
 }
 
 func TestAPI_parseSortOrder(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name      string
 		qs        string
@@ -556,6 +566,7 @@ func TestAPI_parseSortOrder(t *testing.T) {
 }
 
 func TestAPI_readJSON_tooLargeBody(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	bigBody := `{"title":"` + strings.Repeat("x", 2*1024*1024) + `"}`
 	res, err := http.Post(ts.URL+"/api/v1/domains", "application/json", strings.NewReader(bigBody))
@@ -575,6 +586,7 @@ func TestAPI_readJSON_tooLargeBody(t *testing.T) {
 // wrapped by an outer fmt.Errorf("%w", err). This is the regression that T48
 // fixed.
 func TestPublicInvalidInputMsg_typedExtraction(t *testing.T) {
+	t.Parallel()
 	cases := []struct {
 		name string
 		err  error
@@ -601,6 +613,7 @@ func TestPublicInvalidInputMsg_typedExtraction(t *testing.T) {
 // rejection path returns a stable sentinel error and never embeds the raw
 // strconv message or the user input.
 func TestParseUint64Validated(t *testing.T) {
+	t.Parallel()
 	const max = maxAccessMask // 1<<63 - 1
 	type tc struct {
 		name    string
@@ -666,6 +679,7 @@ func TestParseUint64Validated(t *testing.T) {
 // numeric input on every handler that parses bit / access_mask. Status code
 // is asserted before the body is read.
 func TestAPI_numericParseErrors_stableMessages(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	dom := seedDomain(t, ts, "test-domain")
 	base := ts.URL + "/api/v1/domains/" + dom
@@ -792,6 +806,7 @@ func TestWriteJSON_encodeErrorLogged(t *testing.T) {
 // TestReadJSON_trailingDataRejected asserts that sending two JSON objects in a
 // single request body returns 400 with a stable, client-safe message.
 func TestReadJSON_trailingDataRejected(t *testing.T) {
+	t.Parallel()
 	ts, _ := newTestAPI(t)
 	// Second JSON object after the first — trailing data.
 	body := `{"title":"first"}{"title":"second"}`
@@ -817,6 +832,7 @@ func TestReadJSON_trailingDataRejected(t *testing.T) {
 // TestReadJSON_failureKindsLogged asserts that readJSON logs the correct
 // structured kind label for each class of decode failure.
 func TestReadJSON_failureKindsLogged(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name       string
 		body       string

--- a/go/internal/api/server_resources.go
+++ b/go/internal/api/server_resources.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -14,39 +13,39 @@ import (
 func (s *Server) resourceCreate(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	var b titleBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	res := &store.Resource{ID: uuid.NewString(), DomainID: domainID, Title: b.Title}
 	if err := s.Store.ResourceCreate(r.Context(), res); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "resource_create", slog.String("domain_id", domainID), slog.String("resource_id", res.ID))
-	writeJSON(w, r, http.StatusCreated, res)
+	s.auditLog(r.Context(), "resource_create", slog.String("domain_id", domainID), slog.String("resource_id", res.ID))
+	s.writeJSON(w, r, http.StatusCreated, res)
 }
 
 func (s *Server) resourceList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.ResourceSortFields)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
 	list, total, err := s.Store.ResourceList(r.Context(), domainID, opts)
 	if err != nil {
-		writeInternalErr(w, r, err)
+		s.writeInternalErr(w, r, err)
 		return
 	}
 	if list == nil {
 		list = []store.Resource{}
 	}
-	writeList(w, r, list, total, opts)
+	s.writeList(w, r, list, total, opts)
 }
 
 func (s *Server) resourceGet(w http.ResponseWriter, r *http.Request) {
@@ -54,39 +53,39 @@ func (s *Server) resourceGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "resourceID")
 	res, err := s.Store.ResourceGet(r.Context(), domainID, id)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, r, http.StatusOK, res)
+	s.writeJSON(w, r, http.StatusOK, res)
 }
 
 func (s *Server) resourcePatch(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "resourceID")
 	var b patchTitleBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	if b.Title == nil {
-		writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
 		return
 	}
 	res, err := s.Store.ResourcePatch(r.Context(), domainID, id, b.Title)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "resource_patch", slog.String("domain_id", domainID), slog.String("resource_id", id))
-	writeJSON(w, r, http.StatusOK, res)
+	s.auditLog(r.Context(), "resource_patch", slog.String("domain_id", domainID), slog.String("resource_id", id))
+	s.writeJSON(w, r, http.StatusOK, res)
 }
 
 func (s *Server) resourceDelete(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "resourceID")
 	if err := s.Store.ResourceDelete(r.Context(), domainID, id); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "resource_delete", slog.String("domain_id", domainID), slog.String("resource_id", id))
+	s.auditLog(r.Context(), "resource_delete", slog.String("domain_id", domainID), slog.String("resource_id", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/api/server_users.go
+++ b/go/internal/api/server_users.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dtorabi/access-manager/internal/logger"
 	"github.com/dtorabi/access-manager/internal/store"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
@@ -14,39 +13,39 @@ import (
 func (s *Server) userCreate(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	var b titleBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	u := &store.User{ID: uuid.NewString(), DomainID: domainID, Title: b.Title}
 	if err := s.Store.UserCreate(r.Context(), u); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "user_create", slog.String("domain_id", domainID), slog.String("user_id", u.ID))
-	writeJSON(w, r, http.StatusCreated, u)
+	s.auditLog(r.Context(), "user_create", slog.String("domain_id", domainID), slog.String("user_id", u.ID))
+	s.writeJSON(w, r, http.StatusCreated, u)
 }
 
 func (s *Server) userList(w http.ResponseWriter, r *http.Request) {
 	opts, err := parseListOpts(r)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	opts.Sort, opts.Order, err = parseSortOrder(r.URL.Query(), store.UserSortFields)
 	if err != nil {
-		writeErr(w, r, http.StatusBadRequest, err)
+		s.writeErr(w, r, http.StatusBadRequest, err)
 		return
 	}
 	domainID := chi.URLParam(r, "domainID")
 	list, total, err := s.Store.UserList(r.Context(), domainID, opts)
 	if err != nil {
-		writeInternalErr(w, r, err)
+		s.writeInternalErr(w, r, err)
 		return
 	}
 	if list == nil {
 		list = []store.User{}
 	}
-	writeList(w, r, list, total, opts)
+	s.writeList(w, r, list, total, opts)
 }
 
 func (s *Server) userGet(w http.ResponseWriter, r *http.Request) {
@@ -54,39 +53,39 @@ func (s *Server) userGet(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "userID")
 	u, err := s.Store.UserGet(r.Context(), domainID, id)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	writeJSON(w, r, http.StatusOK, u)
+	s.writeJSON(w, r, http.StatusOK, u)
 }
 
 func (s *Server) userPatch(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "userID")
 	var b patchTitleBody
-	if !readJSON(w, r, &b) {
+	if !s.readJSON(w, r, &b) {
 		return
 	}
 	if b.Title == nil {
-		writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
+		s.writeErr(w, r, http.StatusBadRequest, errors.New("title is required for patch"))
 		return
 	}
 	u, err := s.Store.UserPatch(r.Context(), domainID, id, b.Title)
 	if err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "user_patch", slog.String("domain_id", domainID), slog.String("user_id", id))
-	writeJSON(w, r, http.StatusOK, u)
+	s.auditLog(r.Context(), "user_patch", slog.String("domain_id", domainID), slog.String("user_id", id))
+	s.writeJSON(w, r, http.StatusOK, u)
 }
 
 func (s *Server) userDelete(w http.ResponseWriter, r *http.Request) {
 	domainID := chi.URLParam(r, "domainID")
 	id := chi.URLParam(r, "userID")
 	if err := s.Store.UserDelete(r.Context(), domainID, id); err != nil {
-		writeStoreErr(w, r, err)
+		s.writeStoreErr(w, r, err)
 		return
 	}
-	logger.Audit(r.Context(), "user_delete", slog.String("domain_id", domainID), slog.String("user_id", id))
+	s.auditLog(r.Context(), "user_delete", slog.String("domain_id", domainID), slog.String("user_id", id))
 	w.WriteHeader(http.StatusNoContent)
 }

--- a/go/internal/api/setup_test.go
+++ b/go/internal/api/setup_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/dtorabi/access-manager/internal/store"
@@ -50,23 +51,46 @@ func newTestAPI(t *testing.T) (*httptest.Server, store.Store) {
 	return ts, st
 }
 
+// syncBuffer is a bytes.Buffer safe for concurrent use by multiple goroutines.
+// slog.NewJSONHandler writes from the HTTP server goroutine while tests read
+// via String() from the test goroutine; the mutex prevents data races under
+// -race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (n int, err error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // newTestAPIWithLog returns an HTTP test server, the underlying store, and a
-// bytes.Buffer that captures all log output from the Server. The handler writes
+// syncBuffer that captures all log output from the Server. The handler writes
 // JSON log entries at DEBUG level so all log levels are visible to the test.
-func newTestAPIWithLog(t *testing.T) (*httptest.Server, store.Store, *bytes.Buffer) {
+// syncBuffer is safe for concurrent access by the server goroutine (writer)
+// and the test goroutine (reader).
+func newTestAPIWithLog(t *testing.T) (*httptest.Server, store.Store, *syncBuffer) {
 	t.Helper()
 	st, cleanup := newTestStore(t)
-	var buf bytes.Buffer
+	buf := &syncBuffer{}
 	srv := &Server{
 		Store: st,
-		Log:   slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		Log:   slog.New(slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
 	}
 	ts := httptest.NewServer(srv.Router(nil, nil))
 	t.Cleanup(func() {
 		ts.Close()
 		cleanup()
 	})
-	return ts, st, &buf
+	return ts, st, buf
 }
 
 // mustPostJSON201 is a convenience wrapper for mustPostJSON with http.StatusCreated.

--- a/go/internal/api/setup_test.go
+++ b/go/internal/api/setup_test.go
@@ -1,7 +1,10 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -29,16 +32,41 @@ func newTestStore(t *testing.T) (store.Store, func()) {
 }
 
 // newTestAPI returns an HTTP test server backed by a real SQLite store and migrations.
+// The Server uses a discard logger so tests never mutate the package-level logger
+// and are safe to run in parallel. For tests that assert on log output use
+// newTestAPIWithLog instead.
 func newTestAPI(t *testing.T) (*httptest.Server, store.Store) {
 	t.Helper()
 	st, cleanup := newTestStore(t)
-	srv := &Server{Store: st}
+	srv := &Server{
+		Store: st,
+		Log:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
 	ts := httptest.NewServer(srv.Router(nil, nil))
 	t.Cleanup(func() {
 		ts.Close()
 		cleanup()
 	})
 	return ts, st
+}
+
+// newTestAPIWithLog returns an HTTP test server, the underlying store, and a
+// bytes.Buffer that captures all log output from the Server. The handler writes
+// JSON log entries at DEBUG level so all log levels are visible to the test.
+func newTestAPIWithLog(t *testing.T) (*httptest.Server, store.Store, *bytes.Buffer) {
+	t.Helper()
+	st, cleanup := newTestStore(t)
+	var buf bytes.Buffer
+	srv := &Server{
+		Store: st,
+		Log:   slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+	ts := httptest.NewServer(srv.Router(nil, nil))
+	t.Cleanup(func() {
+		ts.Close()
+		cleanup()
+	})
+	return ts, st, &buf
 }
 
 // mustPostJSON201 is a convenience wrapper for mustPostJSON with http.StatusCreated.
@@ -78,10 +106,11 @@ func auditLogEntriesWithAction(t *testing.T, buf, action string) []map[string]an
 	return out
 }
 
-// NOTE: Tests that call logger.Init mutate the package-level logger pointer.
-// No test in server_request_test.go uses t.Parallel() because of this.
-// Do NOT add t.Parallel() without first switching to a logger-injectable
-// Server field or an atomic pointer. Tracked on #47 (T36 follow-ups).
+// NOTE: Each test gets its own logger through Server.Log (set in newTestAPI /
+// newTestAPIWithLog / newBrokenTestAPIWithRegistry). The global logger is never
+// mutated in this package. t.Parallel() is safe to add to any test that does
+// not share state by other means (e.g. integration_test.go is sequential by
+// design; see its own comment).
 
 // newBrokenTestAPIWithRegistry builds a Server backed by a closed DB so any
 // store call returns an error. If reg is non-nil it is wired through Router
@@ -98,7 +127,10 @@ func newBrokenTestAPIWithRegistry(t *testing.T, reg *prometheus.Registry) *httpt
 	}
 	st := sqlstore.New(db)
 	_ = db.Close()
-	srv := &Server{Store: st}
+	srv := &Server{
+		Store: st,
+		Log:   slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	}
 	var router http.Handler
 	if reg != nil {
 		router = srv.Router(reg, reg)

--- a/go/internal/logger/logger.go
+++ b/go/internal/logger/logger.go
@@ -19,7 +19,11 @@ func Init(level slog.Level, w io.Writer) {
 	l = slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
 }
 
-// Get returns the package-level logger.
+// Get returns the package-level logger. The returned pointer is valid only after
+// Init has been called and must not be used concurrently with Init. In
+// production, Init is called once at startup before any request handlers run,
+// so subsequent Get() calls are safe. Tests must not call Init after the server
+// starts (use Server.Log for per-test log capture instead).
 func Get() *slog.Logger {
 	return l
 }

--- a/go/internal/logger/logger.go
+++ b/go/internal/logger/logger.go
@@ -38,12 +38,3 @@ func Warn(msg string, attrs ...slog.Attr) {
 func Error(msg string, attrs ...slog.Attr) {
 	l.LogAttrs(context.Background(), slog.LevelError, msg, attrs...)
 }
-
-// Audit emits a structured audit event at INFO level with audit=true.
-// Use for security-relevant mutations (grants, revokes, entity changes).
-func Audit(ctx context.Context, action string, attrs ...slog.Attr) {
-	all := make([]slog.Attr, 0, len(attrs)+2)
-	all = append(all, slog.Bool("audit", true), slog.String("action", action))
-	all = append(all, attrs...)
-	l.LogAttrs(ctx, slog.LevelInfo, "audit", all...)
-}

--- a/go/internal/logger/logger.go
+++ b/go/internal/logger/logger.go
@@ -19,6 +19,11 @@ func Init(level slog.Level, w io.Writer) {
 	l = slog.New(slog.NewJSONHandler(w, &slog.HandlerOptions{Level: level}))
 }
 
+// Get returns the package-level logger.
+func Get() *slog.Logger {
+	return l
+}
+
 // Info logs at INFO level.
 func Info(msg string, attrs ...slog.Attr) {
 	l.LogAttrs(context.Background(), slog.LevelInfo, msg, attrs...)

--- a/go/internal/logger/logger_test.go
+++ b/go/internal/logger/logger_test.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"log/slog"
 	"testing"
@@ -59,34 +58,6 @@ func TestError(t *testing.T) {
 	}
 	if m["error"] != "fail" {
 		t.Fatalf("want error=fail, got %v", m["error"])
-	}
-}
-
-func TestAudit(t *testing.T) {
-	var buf bytes.Buffer
-	Init(slog.LevelInfo, &buf)
-
-	Audit(context.Background(), "grant_user_permission",
-		slog.String("domain_id", "d1"),
-		slog.String("user_id", "u1"),
-		slog.String("permission_id", "p1"),
-	)
-
-	var m map[string]any
-	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
-		t.Fatalf("invalid JSON: %v — raw: %s", err, buf.String())
-	}
-	if m["msg"] != "audit" {
-		t.Fatalf("want msg=audit, got %v", m["msg"])
-	}
-	if m["audit"] != true {
-		t.Fatalf("want audit=true, got %v", m["audit"])
-	}
-	if m["action"] != "grant_user_permission" {
-		t.Fatalf("want action=grant_user_permission, got %v", m["action"])
-	}
-	if m["domain_id"] != "d1" {
-		t.Fatalf("want domain_id=d1, got %v", m["domain_id"])
 	}
 }
 

--- a/plan/phase-6/T54-injectable-logger.md
+++ b/plan/phase-6/T54-injectable-logger.md
@@ -1,4 +1,4 @@
-# T54 — Injectable logger for parallel-safe API tests and structured per-request logging
+# T54 — Injectable Server logger for parallel-safe API tests
 
 ## Ticket
 
@@ -71,14 +71,65 @@ Make the `Server` use an injectable `*slog.Logger` instead of the global from
 
 ## Steps
 
-1. Add `Log *slog.Logger` field to `Server`; add `serverLogger() *slog.Logger`
-   accessor that returns `s.Log` when non-nil and falls back to the package-level
-   logger.
-2. Replace all `logger.Error(...)` / `logger.Warn(...)` calls in `server.go`
-   handlers with `serverLogger()` (or `logWith(r)`).
-3. Update `newTestAPI(t)` to inject a per-test logger.
-4. Iteratively add `t.Parallel()` to API unit tests and run race detector.
-5. Verify `make test -race` passes.
+### Phase 1 — Core infrastructure (commit 1)
+1. Add `Get() *slog.Logger` to `internal/logger/logger.go` to expose the
+   package-level pointer for the Server fallback without coupling `api` to the
+   global directly.
+2. Add to `server.go`:
+   - `Log *slog.Logger` field on `Server` (nil = fall back to `logger.Get()`)
+   - `serverLogger() *slog.Logger` — returns `s.Log` when non-nil, else `logger.Get()`
+   - `logWith(r *http.Request) *slog.Logger` — returns `serverLogger()` enriched
+     with `method` and `path` attributes (deliverable; available for T55)
+   - `auditLog(ctx context.Context, action string, attrs ...slog.Attr)` — mirrors
+     `logger.Audit` but routes through `s.serverLogger()`
+
+### Phase 2 — Convert server_request.go helpers to Server methods (commit 2)
+3. Convert 8 package-level functions to `(s *Server)` methods; replace every
+   `logger.Error/Warn` call with `s.serverLogger().LogAttrs(...)`:
+   `writeJSON`, `writeErr`, `writeStoreErr`, `writeInternalErr`,
+   `logRequestErr`, `logReadJSONErr`, `writeList`, `readJSON`.
+   Remove the `// TODO(T54)` comment from `writeJSON`.
+
+### Phase 3 — Update handler files (commit 3)
+4. In all 7 handler files add `s.` prefix to the now-method calls and replace
+   every `logger.Audit(r.Context(), action, attrs...)` with
+   `s.auditLog(r.Context(), action, attrs...)` (26 call sites across
+   `server_domains.go`, `server_users.go`, `server_groups.go`,
+   `server_resources.go`, `server_permissions.go`, `server_access_types.go`,
+   `server_authz.go`).
+
+### Phase 4 — Update test helpers (commit 4)
+5. `newTestAPI` signature stays `(*httptest.Server, store.Store)` — avoids
+   touching 60+ call sites. Internally set `srv.Log` to a discard logger so
+   the global is never touched, making all tests race-safe immediately.
+6. Add `newTestAPIWithLog(t) (*httptest.Server, store.Store, *bytes.Buffer)`
+   backed by a `slog.LevelDebug` handler over a `bytes.Buffer` — used by the
+   handful of tests that assert on log output.
+7. Update `newBrokenTestAPIWithRegistry` to inject the discard logger as well.
+8. Update the "Do NOT add t.Parallel()" NOTE comment to explain the new
+   per-test injection strategy.
+
+### Phase 5 — Migrate tests off logger.Init (commit 5)
+9. Tests that call request helpers directly (no HTTP server):
+   `TestWriteStoreErr_allCases`, `TestWriteStoreErr_noSQLLeak`,
+   `TestWriteInternalErr_generic`, `TestWriteInternalErr_misuse`,
+   `TestWriteJSON_encodeErrorLogged`.
+   Pattern: `logger.Init(level, &buf)` + package call →
+   `s := &Server{Log: slog.New(...)}; s.writeStoreErr(...)`.
+10. Tests that used `newTestAPI + logger.Init`, switch to `newTestAPIWithLog(t)`:
+    `TestAPI_auditLog_domainCreate`, `TestAPI_auditLog_groupCreate_parentFields`,
+    `TestReadJSON_decodeErrors_kindLogged`, `TestReadJSON_bodyTooLargeKindLogged`.
+    Drop all `logger.Init(...)` / `t.Cleanup(logger.Init...)` lines and the
+    `internal/logger` import where no longer used.
+
+### Phase 6 — Enable t.Parallel() (commit 6)
+11. Add `t.Parallel()` to: `TestWriteJSON_encodeErrorLogged`,
+    `TestAPI_auditLog_domainCreate`, `TestAPI_auditLog_groupCreate_parentFields`,
+    `TestReadJSON_decodeErrors_kindLogged`, `TestReadJSON_bodyTooLargeKindLogged`,
+    and the T52 test in `server_authz_test.go` that carried a "t.Parallel()
+    intentionally omitted until T54" note.
+    Do NOT add `t.Parallel()` to `integration_test.go` (sequential by design).
+12. Update all remaining "Do NOT add t.Parallel()" comments in test files.
 
 ## Acceptance criteria
 

--- a/plan/phase-6/T54-injectable-logger.md
+++ b/plan/phase-6/T54-injectable-logger.md
@@ -49,19 +49,19 @@ Make the `Server` use an injectable `*slog.Logger` instead of the global from
 
 ## Deliverables
 
-- Add an optional `Log *slog.Logger` field to `Server`. When nil, fall back to
-  the package-level `logger` global (backward-compatible with existing callers
-  including `cmd/server`).
-- Expose a `logWith(r *http.Request) *slog.Logger` helper on `Server` that
-  returns the per-server logger (or the global) enriched with request context
-  attributes; replace current `logger.Error(...)` / `logger.Warn(...)` call
-  sites in handlers with this helper.
-- Update `newTestAPI(t)` and `newBrokenTestAPI(t)` to inject a
-  `*slog.Logger` backed by a per-test `slog.NewJSONHandler(&buf, ...)` so
-  each test gets an isolated log buffer.
-- Explicitly annotate CML-T52-9-origin tests with `t.Parallel()` once
-  injection is in place and verify the race detector passes (`go test -race`).
-- Update the API test-file comment explaining the logger isolation strategy.
+- Add optional `Log *slog.Logger` field to `Server`; fall back to `logger.Get()` when nil.
+- Add `serverLogger() *slog.Logger` accessor and `auditLog(ctx, action, attrs...)` on `Server`.
+- Convert 8 package-level helpers in `server_request.go` to `(s *Server)` methods; route all
+  `logger.Error/Warn` calls through `s.serverLogger().LogAttrs(...)`.
+- Update all 7 handler files to use `s.` methods and `s.auditLog(...)`.
+- `newTestAPI` injects a discard logger (signature unchanged, 60+ call sites unaffected).
+- Add `newTestAPIWithLog` (returns `*syncBuffer`) for tests that assert on log content;
+  `syncBuffer` is goroutine-safe for concurrent server writes and test reads.
+- Update `newBrokenTestAPIWithRegistry` to inject a discard logger.
+- Add `t.Parallel()` to all tests whose only blocker was the global logger; verify
+  `go test -race ./internal/api/...` passes.
+- Add `Get() *slog.Logger` to `internal/logger` for the Server fallback.
+- Remove `logger.Audit` (dead code after migration).
 
 ## Out of scope
 
@@ -78,10 +78,10 @@ Make the `Server` use an injectable `*slog.Logger` instead of the global from
 2. Add to `server.go`:
    - `Log *slog.Logger` field on `Server` (nil = fall back to `logger.Get()`)
    - `serverLogger() *slog.Logger` — returns `s.Log` when non-nil, else `logger.Get()`
-   - `logWith(r *http.Request) *slog.Logger` — returns `serverLogger()` enriched
-     with `method` and `path` attributes (deliverable; available for T55)
    - `auditLog(ctx context.Context, action string, attrs ...slog.Attr)` — mirrors
-     `logger.Audit` but routes through `s.serverLogger()`
+     the removed `logger.Audit` but routes through `s.serverLogger()`
+   - Note: `logWith(r *http.Request) *slog.Logger` was planned but deferred to
+     T55 (see TODO comment in `server.go`) because it had no callers in this PR.
 
 ### Phase 2 — Convert server_request.go helpers to Server methods (commit 2)
 3. Convert 8 package-level functions to `(s *Server)` methods; replace every
@@ -123,12 +123,11 @@ Make the `Server` use an injectable `*slog.Logger` instead of the global from
     `internal/logger` import where no longer used.
 
 ### Phase 6 — Enable t.Parallel() (commit 6)
-11. Add `t.Parallel()` to: `TestWriteJSON_encodeErrorLogged`,
-    `TestAPI_auditLog_domainCreate`, `TestAPI_auditLog_groupCreate_parentFields`,
-    `TestReadJSON_decodeErrors_kindLogged`, `TestReadJSON_bodyTooLargeKindLogged`,
-    and the T52 test in `server_authz_test.go` that carried a "t.Parallel()
-    intentionally omitted until T54" note.
-    Do NOT add `t.Parallel()` to `integration_test.go` (sequential by design).
+11. `TestWriteJSON_encodeErrorLogged` (the T52 encode-failure test) was moved from
+    `server_authz_test.go` to `server_request_test.go` and given `t.Parallel()`.
+    `server_authz_test.go` retains only a pointer comment directing readers to
+    `server_request_test.go`. The remaining formerly-blocked tests were given
+    `t.Parallel()` as part of the cleanup pass.
 12. Update all remaining "Do NOT add t.Parallel()" comments in test files.
 
 ## Acceptance criteria


### PR DESCRIPTION
## Summary
Replaces global `logger.Init` mutations in `internal/api` tests with a
per-Server injectable `*slog.Logger`. Production behaviour is unchanged:
`cmd/server` continues to call `logger.Init` once at startup; handlers fall
back to the package-level logger when `Server.Log` is nil.

Key changes:
- `internal/logger`: expose `Get()` for Server fallback
- `Server.Log *slog.Logger` + `serverLogger()` / `auditLog()`
- 8 package-level request helpers → `(s *Server)` methods
- 26 `logger.Audit(...)` calls in handlers → `s.auditLog(...)`
- `newTestAPI` injects discard logger (signature unchanged, 60+ call sites unaffected)
- New `newTestAPIWithLog` for log-asserting tests; existing `newBrokenTestAPIWithRegistry` also updated
- All formerly-blocked tests now run with `t.Parallel()`
- `go test -race ./internal/api/...` passes with no data races

## Ticket
Fixes #76

## Checklist
- [x] `make test` passes
- [x] `make lint` passes
- [x] No secrets or real .env values in diff
- [x] Docs updated if behaviour changed (plan file updated)